### PR TITLE
Fixed compilation under MSVC 2013.

### DIFF
--- a/cgogn/core/map/cmap2.h
+++ b/cgogn/core/map/cmap2.h
@@ -69,6 +69,9 @@ public:
 	template<typename T>
 	using VolumeAttributeHandler = AttributeHandler<T, Self::VOLUME>;
 
+	using DartMarker = cgogn::DartMarker<Self>;
+	using DartMarkerStore = cgogn::DartMarkerStore<Self>;
+
 protected:
 
 	ChunkArray<Dart>* phi2_;
@@ -263,7 +266,7 @@ public:
 
 		bool need_bijective_check = false;
 		unsigned int nb_boundary_edges = 0;
-		DartMarker<Self> dm(*this);
+		DartMarker dm(*this);
 
 		for (Dart d : *this)
 		{
@@ -285,7 +288,7 @@ public:
 						if (good_dart == phi2(good_dart))
 						{
 							phi2_sew(d, good_dart);
-							dm.template mark_orbit<EDGE>(d);
+							dm.mark_orbit<EDGE>(d);
 						}
 						else
 						{
@@ -300,7 +303,7 @@ public:
 
 				if (good_dart.index == Dart::INVALID_INDEX)
 				{
-					dm.template mark_orbit<EDGE>(d);
+					dm.mark_orbit<EDGE>(d);
 					++nb_boundary_edges;
 				}
 			}
@@ -350,7 +353,7 @@ public:
 	template <typename FUNC>
 	void foreach_dart_of_volume(Dart d, const FUNC& f) const
 	{
-		DartMarkerStore<Self> marker(*this); // get a marker
+		DartMarkerStore marker(*this); // get a marker
 
 		std::vector<Dart>* visited_faces = cgogn::get_dart_buffers()->get_buffer();
 

--- a/cgogn/core/map/cmap2.h
+++ b/cgogn/core/map/cmap2.h
@@ -69,9 +69,6 @@ public:
 	template<typename T>
 	using VolumeAttributeHandler = AttributeHandler<T, Self::VOLUME>;
 
-	using DartMarker = cgogn::DartMarker<Self>;
-	using DartMarkerStore = cgogn::DartMarkerStore<Self>;
-
 protected:
 
 	ChunkArray<Dart>* phi2_;
@@ -237,7 +234,7 @@ public:
 		{
 			unsigned short nbe = si.faces_nb_edges_[i];
 			edges_buffer.clear();
-			unsigned int prev = -1;
+			unsigned int prev = std::numeric_limits<unsigned int>::max();
 			for (unsigned int j = 0; j < nbe; ++j)
 			{
 				unsigned int idx = si.faces_vertex_indices_[faces_vertex_index++];

--- a/cgogn/utils/CMakeLists.txt
+++ b/cgogn/utils/CMakeLists.txt
@@ -30,7 +30,9 @@ endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES DEBUG_POSTFIX "_d")
 
 # Eigen generated warnings
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+if(NOT MSVC)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC
 	$<BUILD_INTERFACE:${EIGEN3_INCLUDE_DIR}>

--- a/cgogn/utils/name_types.h
+++ b/cgogn/utils/name_types.h
@@ -39,7 +39,7 @@ namespace cgogn
  * @brief function that give a name to a type.
  */
 template <typename T>
-CGOGN_UTILS_API std::string name_of_type(const T& )
+std::string name_of_type(const T& )
 { return T::cgogn_name_of_type(); }
 
 template <typename T>  
@@ -97,11 +97,11 @@ template <>
 CGOGN_UTILS_API std::string name_of_type(const Eigen::Vector3d& );
 
 template <typename T>  
-CGOGN_UTILS_API std::string name_of_type(const std::list<T>& ) 
+std::string name_of_type(const std::list<T>& )
 { return std::string("std::list<") + name_of_type(T()) + std::string(">"); }
 
 template <typename T>  
-CGOGN_UTILS_API std::string name_of_type(const std::vector<T>& ) 
+std::string name_of_type(const std::vector<T>& )
 { return std::string("std::vector<") + name_of_type(T()) + std::string(">"); }
 
 /**

--- a/cgogn/utils/name_types.h
+++ b/cgogn/utils/name_types.h
@@ -43,10 +43,10 @@ std::string name_of_type(const T& )
 { return T::cgogn_name_of_type(); }
 
 template <typename T>  
-CGOGN_UTILS_API std::string name_of_type(const std::list<T>& );
+std::string name_of_type(const std::list<T>& );
 
 template <typename T>  
-CGOGN_UTILS_API std::string name_of_type(const std::vector<T>& );
+std::string name_of_type(const std::vector<T>& );
 
 template <>
 CGOGN_UTILS_API std::string name_of_type(const bool& );


### PR DESCRIPTION
Added DartMarker(Store) aliases.
Remove some unnecessary "template" keyword.
Removed the "-Wno-deprecated-declarations" flag when using MSVC.
Removed CGOGN_UTILS_API from no specialized template methods.

Signed-off-by: Etienne Schmitt etienne.schmitt@inria.fr
