### PR TITLE
add same_cell function + fix foreach_cell_until_topo_cache

### DIFF
--- a/cgogn/core/cmap/cmap1.h
+++ b/cgogn/core/cmap/cmap1.h
@@ -275,10 +275,44 @@ protected:
 	{
 		static_assert(ORBIT == Orbit::DART || ORBIT == Orbit::PHI1,
 					  "Orbit not supported in a CMap1");
+
 		switch (ORBIT)
 		{
 			case Orbit::DART: foreach_dart_of_DART(c, f); break;
 			case Orbit::PHI1: foreach_dart_of_PHI1(c, f); break;
+			case Orbit::PHI2:
+			case Orbit::PHI1_PHI2:
+			case Orbit::PHI1_PHI3:
+			case Orbit::PHI2_PHI3:
+			case Orbit::PHI21:
+			case Orbit::PHI21_PHI31:
+			default: cgogn_assert_not_reached("Cells of this dimension are not handled"); break;
+		}
+	}
+
+	template <typename FUNC>
+	inline void foreach_dart_of_PHI1_until(Dart d, const FUNC& f) const
+	{
+		Dart it = d;
+		do
+		{
+			if (!f(it))
+				break;
+			it = phi1(it);
+		} while (it != d);
+	}
+
+	template <Orbit ORBIT, typename FUNC>
+	inline void foreach_dart_of_orbit_until(Cell<ORBIT> c, const FUNC& f) const
+	{
+		static_assert(ORBIT == Orbit::DART || ORBIT == Orbit::PHI1,
+					  "Orbit not supported in a CMap1");
+		static_assert(check_func_return_type(FUNC, bool), "Wrong function return type");
+
+		switch (ORBIT)
+		{
+			case Orbit::DART: foreach_dart_of_DART(c, f); break;
+			case Orbit::PHI1: foreach_dart_of_PHI1_until(c, f); break;
 			case Orbit::PHI2:
 			case Orbit::PHI1_PHI2:
 			case Orbit::PHI1_PHI3:

--- a/cgogn/core/cmap/cmap2.h
+++ b/cgogn/core/cmap/cmap2.h
@@ -313,6 +313,7 @@ protected:
 		static_assert(ORBIT == Orbit::DART || ORBIT == Orbit::PHI1 ||
 					  ORBIT == Orbit::PHI2 || ORBIT == Orbit::PHI1_PHI2 || ORBIT == Orbit::PHI21,
 					  "Orbit not supported in a CMap2");
+
 		switch (ORBIT)
 		{
 			case Orbit::DART: this->foreach_dart_of_DART(c, f); break;
@@ -320,6 +321,82 @@ protected:
 			case Orbit::PHI2: foreach_dart_of_PHI2(c, f); break;
 			case Orbit::PHI1_PHI2: foreach_dart_of_PHI1_PHI2(c, f); break;
 			case Orbit::PHI21: foreach_dart_of_PHI21(c, f); break;
+			case Orbit::PHI2_PHI3:
+			case Orbit::PHI1_PHI3:
+			case Orbit::PHI21_PHI31:
+			default: cgogn_assert_not_reached("Cells of this dimension are not handled"); break;
+		}
+	}
+
+	template <typename FUNC>
+	inline void foreach_dart_of_PHI2_until(Dart d, const FUNC& f) const
+	{
+		if (f(d))
+			f(phi2(d));
+	}
+
+	template <typename FUNC>
+	inline void foreach_dart_of_PHI21_until(Dart d, const FUNC& f) const
+	{
+		Dart it = d;
+		do
+		{
+			if (!f(it))
+				break;
+			it = phi2(this->phi_1(it));
+		} while (it != d);
+	}
+
+	template <typename FUNC>
+	void foreach_dart_of_PHI1_PHI2_until(Dart d, const FUNC& f) const
+	{
+		DartMarkerStore marker(*this);
+
+		std::vector<Dart>* visited_faces = cgogn::get_dart_buffers()->get_buffer();
+		visited_faces->push_back(d); // Start with the face of d
+
+		// For every face added to the list
+		for(unsigned int i = 0; i < visited_faces->size(); ++i)
+		{
+			if (!marker.is_marked((*visited_faces)[i]))	// Face has not been visited yet
+			{
+				// mark visited darts (current face)
+				// and add non visited adjacent faces to the list of face
+				Dart e = (*visited_faces)[i] ;
+				do
+				{
+					if (!f(e)) // apply the function to the darts of the face
+					{
+						cgogn::get_dart_buffers()->release_buffer(visited_faces);
+						return;
+					}
+					marker.mark(e);				// Mark
+					Dart adj = phi2(e);			// Get adjacent face
+					if (!marker.is_marked(adj))
+						visited_faces->push_back(adj);	// Add it
+					e = this->phi1(e);
+				} while (e != (*visited_faces)[i]);
+			}
+		}
+
+		cgogn::get_dart_buffers()->release_buffer(visited_faces);
+	}
+
+	template <Orbit ORBIT, typename FUNC>
+	inline void foreach_dart_of_orbit_until(Cell<ORBIT> c, const FUNC& f) const
+	{
+		static_assert(ORBIT == Orbit::DART || ORBIT == Orbit::PHI1 ||
+					  ORBIT == Orbit::PHI2 || ORBIT == Orbit::PHI1_PHI2 || ORBIT == Orbit::PHI21,
+					  "Orbit not supported in a CMap2");
+		static_assert(check_func_return_type(FUNC, bool), "Wrong function return type");
+
+		switch (ORBIT)
+		{
+			case Orbit::DART: this->foreach_dart_of_DART(c, f); break;
+			case Orbit::PHI1: this->foreach_dart_of_PHI1_until(c, f); break;
+			case Orbit::PHI2: foreach_dart_of_PHI2_until(c, f); break;
+			case Orbit::PHI1_PHI2: foreach_dart_of_PHI1_PHI2_until(c, f); break;
+			case Orbit::PHI21: foreach_dart_of_PHI21_until(c, f); break;
 			case Orbit::PHI2_PHI3:
 			case Orbit::PHI1_PHI3:
 			case Orbit::PHI21_PHI31:

--- a/cgogn/core/cmap/cmap3.h
+++ b/cgogn/core/cmap/cmap3.h
@@ -251,6 +251,89 @@ protected:
 		}
 	}
 
+	template <typename FUNC>
+	inline void foreach_dart_of_PHI21_PHI31_until(Dart d, const FUNC& f) const
+	{
+		DartMarkerStore marker(*this);
+		const std::vector<Dart>* marked_darts = marker.get_marked_darts();
+
+		marker.mark(d);
+		for(unsigned int i = 0; i < marked_darts->size(); ++i)
+		{
+			if (!f((*marked_darts)[i]))
+				break;
+
+			Dart d2 = this->phi2((*marked_darts)[i]);
+			Dart d21 = this->phi1(d2); // turn in volume
+			Dart d23 = phi3(d2); // change volume
+			if(!marker.is_marked(d21))
+				marker.mark(d21);
+			if(!marker.is_marked(d23))
+				marker.mark(d23);
+		}
+	}
+
+	template <typename FUNC>
+	inline void foreach_dart_of_PHI2_PHI3_until(Dart d, const FUNC& f) const
+	{
+		Dart it = d;
+		do
+		{
+			if (!f(it))
+				break;
+			it = this->phi2(it);
+			if (!f(it))
+				break;
+			it = phi3(it);
+		} while (it != d);
+	}
+
+	template <typename FUNC>
+	inline void foreach_dart_of_PHI23_until(Dart d, const FUNC& f) const
+	{
+		Dart it = d;
+		do
+		{
+			if (!f(it))
+				break;
+			it = phi3(this->phi2(it));
+		} while (it != d);
+	}
+
+	template <typename FUNC>
+	inline void foreach_dart_of_PHI1_PHI3_until(Dart d, const FUNC& f) const
+	{
+		this->foreach_dart_of_PHI1_until(d, [&] (Dart fd) -> bool
+		{
+			if (f(fd))
+				return f(phi3(fd));
+			return false;
+		});
+	}
+
+	template <Orbit ORBIT, typename FUNC>
+	inline void foreach_dart_of_orbit_until(Cell<ORBIT> c, const FUNC& f) const
+	{
+		static_assert(ORBIT == Orbit::DART || ORBIT == Orbit::PHI1 ||
+					  ORBIT == Orbit::PHI2 || ORBIT == Orbit::PHI1_PHI2 || ORBIT == Orbit::PHI21 ||
+					  ORBIT == Orbit::PHI1_PHI3 || ORBIT == Orbit::PHI2_PHI3 || ORBIT == Orbit::PHI21_PHI31,
+					  "Orbit not supported in a CMap3");
+		static_assert(check_func_return_type(FUNC, bool), "Wrong function return type");
+
+		switch (ORBIT)
+		{
+			case Orbit::DART: this->foreach_dart_of_DART(c, f); break;
+			case Orbit::PHI1: this->foreach_dart_of_PHI1_until(c, f); break;
+			case Orbit::PHI2: this->foreach_dart_of_PHI2_until(c, f); break;
+			case Orbit::PHI1_PHI2: this->foreach_dart_of_PHI1_PHI2_until(c, f); break;
+			case Orbit::PHI1_PHI3: foreach_dart_of_PHI1_PHI3_until(c, f); break;
+			case Orbit::PHI2_PHI3: foreach_dart_of_PHI2_PHI3_until(c, f); break;
+			case Orbit::PHI21: this->foreach_dart_of_PHI21_until(c, f); break;
+			case Orbit::PHI21_PHI31: foreach_dart_of_PHI21_PHI31_until(c, f); break;
+			default: cgogn_assert_not_reached("Cells of this dimension are not handled"); break;
+		}
+	}
+
 public:
 
 	/*******************************************************************************

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -358,6 +358,29 @@ public:
 	}
 
 	/*******************************************************************************
+	 * Topological information
+	 *******************************************************************************/
+
+	/**
+	 * \brief return true if c1 and c2 represent the same cell, i.e. contain darts of the same orbit
+	 * @tparam ORBIT considered orbit
+	 * @param c1 first cell to compare
+	 * @param c2 second cell to compare
+	 */
+	template <Orbit ORBIT>
+	bool same_cell(Cell<ORBIT> c1, Cell<ORBIT> c2)
+	{
+		ConcreteMap* cmap = to_concrete();
+		bool result = false;
+		cmap->template foreach_dart_of_orbit<ORBIT>(c1, [&] (Dart d)
+		{
+			if (d == c2.dart)
+				result = true;
+		});
+		return result;
+	}
+
+	/*******************************************************************************
 	 * Traversals
 	 *******************************************************************************/
 
@@ -479,7 +502,6 @@ public:
 		}
 	}
 
-
 	/**
 	 * \brief apply a function on each orbit of the map and stops when the function returns false
 	 * @tparam ORBIT orbit to traverse
@@ -501,11 +523,11 @@ public:
 				foreach_cell_until_cell_marking<ORBIT>(f);
 				break;
 			case FORCE_TOPO_CACHE :
-				foreach_cell_topo_cache<ORBIT>(f);
+				foreach_cell_until_topo_cache<ORBIT>(f);
 				break;
 			case AUTO :
 				if (is_topo_cache_enabled<ORBIT>())
-					foreach_cell_topo_cache<ORBIT>(f);
+					foreach_cell_until_topo_cache<ORBIT>(f);
 				else if (this->template is_orbit_embedded<ORBIT>())
 					foreach_cell_until_cell_marking<ORBIT>(f);
 				else

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -372,10 +372,14 @@ public:
 	{
 		ConcreteMap* cmap = to_concrete();
 		bool result = false;
-		cmap->template foreach_dart_of_orbit<ORBIT>(c1, [&] (Dart d)
+		cmap->template foreach_dart_of_orbit_until<ORBIT>(c1, [&] (Dart d) -> bool
 		{
 			if (d == c2.dart)
+			{
 				result = true;
+				return false;
+			}
+			return true;
 		});
 		return result;
 	}


### PR DESCRIPTION
Pour le moment, same_cell(c1, c2) a pour complexité le nombre de brins de c1.
On pourrait arrêter la recherche une fois le brin de c2 trouvé dans l'orbite de c1, mais cela suppose d'avoir des fonctions foreach_dart_of_orbit_until que l'on n'a pas pour le moment..
