### PR TITLE
fixing threading issues

### DIFF
--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -35,6 +35,7 @@
 #include <core/basic/cell_marker.h>
 
 #include <core/utils/thread_barrier.h>
+#include <core/utils/make_unique.h>
 
 namespace cgogn
 {
@@ -528,19 +529,6 @@ public:
 		static_assert(check_func_ith_parameter_type(FUNC, 0, Dart), "Wrong function first parameter type");
 		static_assert(check_func_ith_parameter_type(FUNC, 1, unsigned int), "Wrong function second parameter type");
 
-		std::vector<unsigned int> thread_indices(nb_threads);
-		std::vector<std::thread::id*> thread_id_pointers(nb_threads);
-
-		// get new thread local indices on this map
-		// and get pointers to the corresponding thread_id locations
-		// so that the threads will be able to store their id once created
-		for (unsigned int i = 0; i < nb_threads; ++i)
-		{
-			unsigned int index = this->get_new_thread_index();
-			thread_indices[i] = index;
-			thread_id_pointers[i] = this->get_thread_id_pointer(index);
-		}
-
 		// these vectors will contain elements to be processed by the threads
 		// the first ones are passed to the threads
 		// the second ones are filled by this thread then swapped with the first ones
@@ -558,15 +546,10 @@ public:
 		Barrier sync1(nb_threads + 1);
 		Barrier sync2(nb_threads + 1);
 
-		auto thread_deleter = [] (std::thread* th) { th->join(); delete th; };
-		auto tfs_deleter = [this] (ThreadFunction<Dart, FUNC>* tf)
-		{
-			this->remove_thread(tf->get_thread_index());
-			delete tf;
-		};
+		auto thread_deleter = [this] (std::thread* th) { const std::thread::id id = th->get_id(); th->join(); delete th; this->remove_thread(id) ;};
 
 		using thread_ptr = std::unique_ptr<std::thread, decltype(thread_deleter)>;
-		using tfs_ptr = std::unique_ptr<ThreadFunction<Dart, FUNC>, decltype(tfs_deleter)>;
+		using tfs_ptr = std::unique_ptr<ThreadFunction<Dart, FUNC>>;
 
 		std::vector<thread_ptr> threads;
 		std::vector<tfs_ptr> tfs;
@@ -574,8 +557,9 @@ public:
 		tfs.reserve(nb_threads);
 		for (unsigned int i = 0; i < nb_threads; ++i)
 		{
-			tfs.emplace_back(tfs_ptr(new ThreadFunction<Dart, FUNC>(f, vd1[i], sync1, sync2, finished, i, thread_indices[i], thread_id_pointers[i]), tfs_deleter));
+			tfs.emplace_back(make_unique<ThreadFunction<Dart, FUNC>>(f, vd1[i], sync1, sync2, finished, i));
 			threads.emplace_back(thread_ptr(new std::thread(std::ref( *(tfs[i]) )), thread_deleter));
+			this->add_thread(threads.back()->get_id());
 		}
 
 		Dart it = Dart(this->topology_.begin());
@@ -741,19 +725,6 @@ protected:
 	template <Orbit ORBIT, typename FUNC>
 	inline void parallel_foreach_cell_dart_marking(const FUNC& f, unsigned int nb_threads)
 	{
-		std::vector<unsigned int> thread_indices(nb_threads);
-		std::vector<std::thread::id*> thread_id_pointers(nb_threads);
-
-		// get new thread local indices on this map
-		// and get pointers to the corresponding thread_id locations
-		// so that the threads will be able to store their id once created
-		for (unsigned int i = 0; i < nb_threads; ++i)
-		{
-			unsigned int index = this->get_new_thread_index();
-			thread_indices[i] = index;
-			thread_id_pointers[i] = this->get_thread_id_pointer(index);
-		}
-
 		// these vectors will contain elements to be processed by the threads
 		// the first ones are passed to the threads
 		// the second ones are filled by this thread while the other are processed
@@ -771,15 +742,10 @@ protected:
 		Barrier sync1(nb_threads + 1);
 		Barrier sync2(nb_threads + 1);
 
-		auto thread_deleter = [] (std::thread* th) { th->join(); delete th; };
-		auto tfs_deleter = [this] (ThreadFunction<Cell<ORBIT>, FUNC>* tf)
-		{
-			this->remove_thread(tf->get_thread_index());
-			delete tf;
-		};
+		auto thread_deleter = [this] (std::thread* th) { const std::thread::id id = th->get_id(); th->join(); delete th; this->remove_thread(id) ;};
 
 		using thread_ptr = std::unique_ptr<std::thread, decltype(thread_deleter)>;
-		using tfs_ptr = std::unique_ptr<ThreadFunction<Cell<ORBIT>, FUNC>, decltype(tfs_deleter)>;
+		using tfs_ptr = std::unique_ptr<ThreadFunction<Cell<ORBIT>, FUNC>>;
 
 		std::vector<thread_ptr> threads;
 		std::vector<tfs_ptr> tfs;
@@ -787,8 +753,9 @@ protected:
 		tfs.reserve(nb_threads);
 		for (unsigned int i = 0u; i < nb_threads; ++i)
 		{
-			tfs.emplace_back(tfs_ptr(new ThreadFunction<Cell<ORBIT>, FUNC>(f, vd1[i], sync1, sync2, finished, i, thread_indices[i], thread_id_pointers[i]), tfs_deleter));
+			tfs.emplace_back(make_unique<ThreadFunction<Cell<ORBIT>, FUNC>>(f, vd1[i], sync1, sync2, finished, i));
 			threads.emplace_back(thread_ptr(new std::thread(std::ref( *(tfs[i]) )), thread_deleter));
+			this->add_thread(threads.back()->get_id());
 		}
 
 		DartMarker dm(*to_concrete());
@@ -842,19 +809,6 @@ protected:
 	template <Orbit ORBIT, typename FUNC>
 	inline void parallel_foreach_cell_cell_marking(const FUNC& f, unsigned int nb_threads)
 	{
-		std::vector<unsigned int> thread_indices(nb_threads);
-		std::vector<std::thread::id*> thread_id_pointers(nb_threads);
-
-		// get new thread local indices on this map
-		// and get pointers to the corresponding thread_id locations
-		// so that the threads will be able to store their id once created
-		for (unsigned int i = 0; i < nb_threads; ++i)
-		{
-			unsigned int index = this->get_new_thread_index();
-			thread_indices[i] = index;
-			thread_id_pointers[i] = this->get_thread_id_pointer(index);
-		}
-
 		// these vectors will contain elements to be processed by the threads
 		// the first ones are passed to the threads
 		// the second ones are filled by this thread while the other are processed
@@ -872,15 +826,10 @@ protected:
 		Barrier sync1(nb_threads + 1);
 		Barrier sync2(nb_threads + 1);
 
-		auto thread_deleter = [] (std::thread* th) { th->join(); delete th; };
-		auto tfs_deleter = [this] (ThreadFunction<Cell<ORBIT>, FUNC>* tf)
-		{
-			this->remove_thread(tf->get_thread_index());
-			delete tf;
-		};
+		auto thread_deleter = [this] (std::thread* th) { const std::thread::id id = th->get_id(); th->join(); delete th; this->remove_thread(id) ;};
 
 		using thread_ptr = std::unique_ptr<std::thread, decltype(thread_deleter)>;
-		using tfs_ptr = std::unique_ptr<ThreadFunction<Cell<ORBIT>, FUNC>, decltype(tfs_deleter)>;
+		using tfs_ptr = std::unique_ptr<ThreadFunction<Cell<ORBIT>, FUNC>>;
 
 		std::vector<thread_ptr> threads;
 		std::vector<tfs_ptr> tfs;
@@ -888,8 +837,9 @@ protected:
 		tfs.reserve(nb_threads);
 		for (unsigned int i = 0; i < nb_threads; ++i)
 		{
-			tfs.emplace_back(tfs_ptr(new ThreadFunction<Cell<ORBIT>, FUNC>(f, vd1[i], sync1, sync2, finished, i, thread_indices[i], thread_id_pointers[i]), tfs_deleter));
+			tfs.emplace_back(make_unique<ThreadFunction<Cell<ORBIT>, FUNC>>(f, vd1[i], sync1, sync2, finished, i));
 			threads.emplace_back(thread_ptr(new std::thread(std::ref( *(tfs[i]) )), thread_deleter));
+			this->add_thread(threads.back()->get_id());
 		}
 
 		CellMarker<ORBIT> cm(*to_concrete());
@@ -938,19 +888,6 @@ protected:
 	template <Orbit ORBIT, typename FUNC>
 	inline void parallel_foreach_cell_topo_cache(const FUNC& f, unsigned int nb_threads)
 	{
-		std::vector<unsigned int> thread_indices(nb_threads);
-		std::vector<std::thread::id*> thread_id_pointers(nb_threads);
-
-		// get new thread local indices on this map
-		// and get pointers to the corresponding thread_id locations
-		// so that the threads will be able to store their id once created
-		for (unsigned int i = 0; i < nb_threads; ++i)
-		{
-			unsigned int index = this->get_new_thread_index();
-			thread_indices[i] = index;
-			thread_id_pointers[i] = this->get_thread_id_pointer(index);
-		}
-
 		// these vectors will contain elements to be processed by the threads
 		// the first ones are passed to the threads
 		// the second ones are filled by this thread while the other are processed
@@ -968,15 +905,10 @@ protected:
 		Barrier sync1(nb_threads + 1);
 		Barrier sync2(nb_threads + 1);
 
-		auto thread_deleter = [] (std::thread* th) { th->join(); delete th; };
-		auto tfs_deleter = [this] (ThreadFunction<Cell<ORBIT>, FUNC>* tf)
-		{
-			this->remove_thread(tf->get_thread_index());
-			delete tf;
-		};
+		auto thread_deleter = [this] (std::thread* th) { const std::thread::id id = th->get_id(); th->join(); delete th; this->remove_thread(id) ;};
 
 		using thread_ptr = std::unique_ptr<std::thread, decltype(thread_deleter)>;
-		using tfs_ptr = std::unique_ptr<ThreadFunction<Cell<ORBIT>, FUNC>, decltype(tfs_deleter)>;
+		using tfs_ptr = std::unique_ptr<ThreadFunction<Cell<ORBIT>, FUNC>>;
 
 		std::vector<thread_ptr> threads;
 		std::vector<tfs_ptr> tfs;
@@ -984,8 +916,9 @@ protected:
 		tfs.reserve(nb_threads);
 		for (unsigned int i = 0; i < nb_threads; ++i)
 		{
-			tfs.emplace_back(tfs_ptr(new ThreadFunction<Cell<ORBIT>, FUNC>(f, vd1[i], sync1, sync2, finished, i, thread_indices[i], thread_id_pointers[i]), tfs_deleter));
+			tfs.emplace_back(make_unique<ThreadFunction<Cell<ORBIT>, FUNC>>(f, vd1[i], sync1, sync2, finished, i));
 			threads.emplace_back(thread_ptr(new std::thread(std::ref( *(tfs[i]) )), thread_deleter));
+			this->add_thread(threads.back()->get_id());
 		}
 
 		unsigned int it = this->attributes_[ORBIT].begin();

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -549,7 +549,8 @@ public:
 		auto thread_deleter = [this] (std::thread* th) { const std::thread::id id = th->get_id(); th->join(); delete th; this->remove_thread(id) ;};
 
 		using thread_ptr = std::unique_ptr<std::thread, decltype(thread_deleter)>;
-		using tfs_ptr = std::unique_ptr<ThreadFunction<Dart, FUNC>>;
+		using ThreadFunc = ThreadFunction<Dart, FUNC>;
+		using tfs_ptr = std::unique_ptr<ThreadFunc>;
 
 		std::vector<thread_ptr> threads;
 		std::vector<tfs_ptr> tfs;
@@ -557,7 +558,7 @@ public:
 		tfs.reserve(nb_threads);
 		for (unsigned int i = 0; i < nb_threads; ++i)
 		{
-			tfs.emplace_back(make_unique<ThreadFunction<Dart, FUNC>>(f, vd1[i], sync1, sync2, finished, i));
+			tfs.emplace_back(tfs_ptr(new ThreadFunc(f, vd1[i], sync1, sync2, finished, i)));
 			threads.emplace_back(thread_ptr(new std::thread(std::ref( *(tfs[i]) )), thread_deleter));
 			this->add_thread(threads.back()->get_id());
 		}
@@ -745,7 +746,8 @@ protected:
 		auto thread_deleter = [this] (std::thread* th) { const std::thread::id id = th->get_id(); th->join(); delete th; this->remove_thread(id) ;};
 
 		using thread_ptr = std::unique_ptr<std::thread, decltype(thread_deleter)>;
-		using tfs_ptr = std::unique_ptr<ThreadFunction<Cell<ORBIT>, FUNC>>;
+		using ThreadFunc = ThreadFunction<Cell<ORBIT>, FUNC>;
+		using tfs_ptr = std::unique_ptr<ThreadFunc>;
 
 		std::vector<thread_ptr> threads;
 		std::vector<tfs_ptr> tfs;
@@ -753,7 +755,7 @@ protected:
 		tfs.reserve(nb_threads);
 		for (unsigned int i = 0u; i < nb_threads; ++i)
 		{
-			tfs.emplace_back(make_unique<ThreadFunction<Cell<ORBIT>, FUNC>>(f, vd1[i], sync1, sync2, finished, i));
+			tfs.emplace_back(tfs_ptr(new ThreadFunc(f, vd1[i], sync1, sync2, finished, i)));
 			threads.emplace_back(thread_ptr(new std::thread(std::ref( *(tfs[i]) )), thread_deleter));
 			this->add_thread(threads.back()->get_id());
 		}
@@ -829,7 +831,8 @@ protected:
 		auto thread_deleter = [this] (std::thread* th) { const std::thread::id id = th->get_id(); th->join(); delete th; this->remove_thread(id) ;};
 
 		using thread_ptr = std::unique_ptr<std::thread, decltype(thread_deleter)>;
-		using tfs_ptr = std::unique_ptr<ThreadFunction<Cell<ORBIT>, FUNC>>;
+		using ThreadFunc = ThreadFunction<Cell<ORBIT>, FUNC>;
+		using tfs_ptr = std::unique_ptr<ThreadFunc>;
 
 		std::vector<thread_ptr> threads;
 		std::vector<tfs_ptr> tfs;
@@ -837,7 +840,7 @@ protected:
 		tfs.reserve(nb_threads);
 		for (unsigned int i = 0; i < nb_threads; ++i)
 		{
-			tfs.emplace_back(make_unique<ThreadFunction<Cell<ORBIT>, FUNC>>(f, vd1[i], sync1, sync2, finished, i));
+			tfs.emplace_back(tfs_ptr(new ThreadFunc(f, vd1[i], sync1, sync2, finished, i)));
 			threads.emplace_back(thread_ptr(new std::thread(std::ref( *(tfs[i]) )), thread_deleter));
 			this->add_thread(threads.back()->get_id());
 		}
@@ -908,7 +911,8 @@ protected:
 		auto thread_deleter = [this] (std::thread* th) { const std::thread::id id = th->get_id(); th->join(); delete th; this->remove_thread(id) ;};
 
 		using thread_ptr = std::unique_ptr<std::thread, decltype(thread_deleter)>;
-		using tfs_ptr = std::unique_ptr<ThreadFunction<Cell<ORBIT>, FUNC>>;
+		using ThreadFunc = ThreadFunction<Cell<ORBIT>, FUNC>;
+		using tfs_ptr = std::unique_ptr<ThreadFunc>;
 
 		std::vector<thread_ptr> threads;
 		std::vector<tfs_ptr> tfs;
@@ -916,7 +920,7 @@ protected:
 		tfs.reserve(nb_threads);
 		for (unsigned int i = 0; i < nb_threads; ++i)
 		{
-			tfs.emplace_back(make_unique<ThreadFunction<Cell<ORBIT>, FUNC>>(f, vd1[i], sync1, sync2, finished, i));
+			tfs.emplace_back(tfs_ptr(new ThreadFunc(f, vd1[i], sync1, sync2, finished, i)));
 			threads.emplace_back(thread_ptr(new std::thread(std::ref( *(tfs[i]) )), thread_deleter));
 			this->add_thread(threads.back()->get_id());
 		}

--- a/cgogn/core/cmap/map_base_data.cpp
+++ b/cgogn/core/cmap/map_base_data.cpp
@@ -35,7 +35,10 @@ bool MapGen::init_CA_factory = true;
 MapGen::MapGen()
 {
 	if (instances_ == nullptr)
+	{
+		cgogn::thread_start();
 		instances_ = new std::vector<MapGen*>;
+	}
 
 	cgogn_message_assert(std::find(instances_->begin(), instances_->end(), this) == instances_->end(), "This map is already present in the instances vector");
 
@@ -52,6 +55,7 @@ MapGen::~MapGen()
 
 	if (instances_->empty())
 	{
+		cgogn::thread_stop();
 		delete instances_;
 		instances_ = nullptr;
 	}

--- a/cgogn/core/cmap/map_base_data.h
+++ b/cgogn/core/cmap/map_base_data.h
@@ -265,33 +265,26 @@ protected:
 
 	inline unsigned int get_current_thread_index() const
 	{
-		std::thread::id id = std::this_thread::get_id();
-		unsigned int i = 0;
-		while (id != thread_ids_[i])
+		cgogn_message_assert(std::binary_search(thread_ids_.begin(), thread_ids_.end(), std::this_thread::get_id()),"Unable to find currend thread ID.");
+		return std::distance(thread_ids_.begin(), std::lower_bound(thread_ids_.begin(), thread_ids_.end(), std::this_thread::get_id()));
+	}
+
+	inline void remove_thread(std::thread::id thread_id)
+	{
+		cgogn_message_assert(std::binary_search(thread_ids_.begin(), thread_ids_.end(), thread_id),"Unable to find the thread.");
+		auto it = std::lower_bound(thread_ids_.begin(), thread_ids_.end(),thread_id);
+		cgogn_message_assert((*it)  == thread_id,"Unable to find the thread.");
+		thread_ids_.erase(it);
+	}
+
+	inline void add_thread(std::thread::id thread_id)
+	{
+		auto it = std::lower_bound(thread_ids_.begin(), thread_ids_.end(),thread_id);
+		if ((it == thread_ids_.end()) || (*it  != thread_id))
 		{
-			i++;
-			cgogn_assert(i < thread_ids_.size());
+			thread_ids_.insert(it,thread_id);
 		}
-		return i;
-	}
 
-	inline unsigned int get_new_thread_index()
-	{
-		cgogn_assert(thread_ids_.size() < NB_THREADS);
-//		thread_ids_.resize(thread_ids_.size() + 1);
-		thread_ids_.push_back(std::thread::id());
-		return thread_ids_.size() - 1;
-	}
-
-	inline std::thread::id* get_thread_id_pointer(unsigned int thread_index)
-	{
-		return &(thread_ids_[thread_index]);
-	}
-
-	inline void remove_thread(unsigned int thread_index)
-	{
-		thread_ids_[thread_index] = thread_ids_.back();
-		thread_ids_.pop_back();
 	}
 };
 

--- a/cgogn/core/examples/map/map.cpp
+++ b/cgogn/core/examples/map/map.cpp
@@ -135,7 +135,6 @@ int test1(MAP& map)
 
 int main()
 {
-	cgogn::thread_start();
 	Map1 map1;
 	Map2 map2;
 //	Map3 map3;
@@ -143,6 +142,5 @@ int main()
 	test1(map2);
 //	test1(map3);
 
-	cgogn::thread_stop();
 	return 0;
 }

--- a/cgogn/core/utils/thread.h
+++ b/cgogn/core/utils/thread.h
@@ -73,8 +73,6 @@ private:
 	Barrier& sync2_;
 	bool& finished_;
 	unsigned int thread_order_;
-	unsigned int thread_index_;
-	std::thread::id* thread_id_pointer_;
 
 public:
 
@@ -84,31 +82,18 @@ public:
 		Barrier& sync1,
 		Barrier& sync2,
 		bool& finished,
-		unsigned int thread_order,
-		unsigned int thread_index,
-		std::thread::id* thread_id_pointer
+		unsigned int thread_order
 	) :
 		f_(f),
 		elements_(elements),
 		sync1_(sync1),
 		sync2_(sync2),
 		finished_(finished),
-		thread_order_(thread_order),
-		thread_index_(thread_index),
-		thread_id_pointer_(thread_id_pointer)
+		thread_order_(thread_order)
 	{}
-
-	unsigned int get_thread_index() const
-	{
-		return thread_index_;
-	}
 
 	void operator()()
 	{
-		thread_start();
-
-		*thread_id_pointer_ = std::this_thread::get_id();
-
 		while (true)
 		{
 			sync2_.wait(); // wait for vectors to be filled
@@ -118,8 +103,6 @@ public:
 				f_(e, thread_order_);
 			sync1_.wait(); // wait every thread has finished
 		}
-
-		thread_stop();
 	}
 };
 

--- a/cgogn/io/examples/cmap2_import.cpp
+++ b/cgogn/io/examples/cmap2_import.cpp
@@ -36,7 +36,6 @@ int main(int argc, char** argv)
 		surfaceMesh = std::string(argv[1]);
 	}
 
-	cgogn::thread_start();
 	Map2 map;
 
 	for (int k = 0 ; k < 2 ; ++k)
@@ -130,6 +129,5 @@ int main(int argc, char** argv)
 		std::cout << "elapsed time: " << elapsed_seconds.count() << "s\n";
 	}
 
-	cgogn::thread_stop();
 	return 0;
 }

--- a/cgogn/io/examples/cmap3_import.cpp
+++ b/cgogn/io/examples/cmap3_import.cpp
@@ -31,7 +31,6 @@ int main(int argc, char** argv)
 		volumeMesh = std::string(argv[1]);
 	}
 
-	cgogn::thread_start();
 	Map3 map;
 	for (int k = 0 ; k < 2 ; ++k)
 	{
@@ -89,6 +88,6 @@ int main(int argc, char** argv)
 		std::cout << "elapsed time: " << elapsed_seconds.count() << "s\n";
 
 	}
-	cgogn::thread_stop();
+
 	return 0;
 }

--- a/cgogn/rendering/examples/CMakeLists.txt
+++ b/cgogn/rendering/examples/CMakeLists.txt
@@ -13,7 +13,7 @@ add_definitions("-DCGOGN_TEST_MESHES_PATH=${CGOGN_TEST_MESHES_PATH}")
 
 
 add_executable(simple_viewer simple_viewer.cpp)
-target_link_libraries(simple_viewer cgogn_core cgogn_rendering QOGLViewer)
+target_link_libraries(simple_viewer cgogn_core cgogn_io cgogn_rendering QOGLViewer)
 
 
 

--- a/cgogn/rendering/examples/simple_viewer.cpp
+++ b/cgogn/rendering/examples/simple_viewer.cpp
@@ -86,8 +86,6 @@ public:
 
 void Viewer::import(const std::string& surfaceMesh)
 {
-	cgogn::thread_start();
-
 	cgogn::io::import_surface<Vec3>(map, surfaceMesh);
 
 	vertex_position_ = map.get_attribute<Vec3, Map2::VERTEX>("position");


### PR DESCRIPTION
Il y avait un probleme lors de la suppression de threads s'ils n'étaient pas supprimés par ID décroissante (parce que dans le cas contraire les IDs de plusieurs threads changent d'indice et du coup on tente parfois d'acceder a des elements en dehors du tableau).
