### PR TITLE
fix crash & compil pb on Windows

### DIFF
--- a/benchmarks/multithreading/bench_multithreading.cpp
+++ b/benchmarks/multithreading/bench_multithreading.cpp
@@ -77,7 +77,7 @@ static void BENCH_Dart_count_multi_threaded(benchmark::State& state)
 		for (unsigned int n : nb_darts_per_thread)
 			nb_darts_2 += n;
 
-		cgogn_assert(nb_darts_2 = map.nb_darts());
+		cgogn_assert(nb_darts_2 == map.nb_darts());
 	}
 }
 

--- a/cgogn/core/basic/cell.h
+++ b/cgogn/core/basic/cell.h
@@ -66,9 +66,9 @@ inline std::string orbit_name(Orbit orbit)
 		case Orbit::PHI2_PHI3: return "cgogn::Orbit::PHI2_PHI3"; break;
 		case Orbit::PHI21: return "cgogn::Orbit::PHI21"; break;
 		case Orbit::PHI21_PHI31: return "cgogn::Orbit::PHI21_PHI31"; break;
-		default: cgogn_assert_not_reached("This orbit does not exist"); break;
+		default: cgogn_assert_not_reached("This orbit does not exist"); return "UNKNOWN"; break;
 	}
-	return "UNKNOWN";
+//	return "UNKNOWN";
 }
 
 /**

--- a/cgogn/core/cmap/cmap1.h
+++ b/cgogn/core/cmap/cmap1.h
@@ -210,12 +210,12 @@ public:
 		{
 			foreach_incident_vertex(f, [this] (Cell<Orbit::DART> c)
 			{
-				this->template set_orbit_embedding(c, this->template add_attribute_element<Orbit::DART>());
+				this->set_orbit_embedding(c, this->template add_attribute_element<Orbit::DART>());
 			});
 		}
 
 		if (this->template is_orbit_embedded<Orbit::PHI1>())
-			this->template set_orbit_embedding(f, this->template add_attribute_element<Orbit::PHI1>());
+			this->set_orbit_embedding(f, this->template add_attribute_element<Orbit::PHI1>());
 
 		return f;
 	}

--- a/cgogn/core/cmap/cmap2.h
+++ b/cgogn/core/cmap/cmap2.h
@@ -239,7 +239,7 @@ public:
 		{
 			foreach_incident_vertex(f, [this] (Cell<Orbit::PHI21> c)
 			{
-				this->template set_orbit_embedding(c, this->template add_attribute_element<Orbit::PHI21>());
+				this->set_orbit_embedding(c, this->template add_attribute_element<Orbit::PHI21>());
 			});
 		}
 
@@ -247,12 +247,12 @@ public:
 		{
 			foreach_incident_edge(f, [this] (Cell<Orbit::PHI2> c)
 			{
-				this->template set_orbit_embedding(c, this->template add_attribute_element<Orbit::PHI2>());
+				this->set_orbit_embedding(c, this->template add_attribute_element<Orbit::PHI2>());
 			});
 		}
 
 		if (this->template is_orbit_embedded<Orbit::PHI1>())
-			this->template set_orbit_embedding(f, this->template add_attribute_element<Orbit::PHI1>());
+			this->set_orbit_embedding(f, this->template add_attribute_element<Orbit::PHI1>());
 
 		if (this->template is_orbit_embedded<Orbit::PHI1_PHI2>())
 			this->template set_orbit_embedding<Orbit::PHI1_PHI2>(d, this->template add_attribute_element<Orbit::PHI1_PHI2>());

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -586,7 +586,7 @@ public:
 		using VecDarts = std::vector<Dart>;
 
 		ThreadPool* thread_pool = cgogn::get_thread_pool();
-		const unsigned int nb_threads_pool = thread_pool->get_nb_threads();
+		const std::size_t nb_threads_pool = thread_pool->get_nb_threads();
 
 		std::array<std::vector<VecDarts*>, 2> dart_buffers;
 		std::array<std::vector<Future>, 2> futures;
@@ -783,7 +783,7 @@ protected:
 		using Future = std::future< typename std::result_of<FUNC(Cell<ORBIT>, unsigned int)>::type >;
 
 		ThreadPool* thread_pool = cgogn::get_thread_pool();
-		const unsigned int nb_threads_pool = thread_pool->get_nb_threads();
+		const std::size_t nb_threads_pool = thread_pool->get_nb_threads();
 
 		std::array<std::vector<VecCell*>, 2> cells_buffers;
 		std::array<std::vector<Future>, 2> futures;
@@ -866,7 +866,7 @@ protected:
 		using Future = std::future< typename std::result_of<FUNC(Cell<ORBIT>, unsigned int)>::type >;
 
 		ThreadPool* thread_pool = cgogn::get_thread_pool();
-		const unsigned int nb_threads_pool = thread_pool->get_nb_threads();
+		const std::size_t nb_threads_pool = thread_pool->get_nb_threads();
 
 		std::array<std::vector<VecCell*>, 2> cells_buffers;
 		std::array<std::vector<Future>, 2> futures;
@@ -944,7 +944,7 @@ protected:
 		using Future = std::future< typename std::result_of<FUNC(Cell<ORBIT>, unsigned int)>::type >;
 
 		ThreadPool* thread_pool = cgogn::get_thread_pool();
-		const unsigned int nb_threads_pool = thread_pool->get_nb_threads();
+		const std::size_t nb_threads_pool = thread_pool->get_nb_threads();
 
 		std::array<std::vector<VecCell*>, 2> cells_buffers;
 		std::array<std::vector<Future>, 2> futures;

--- a/cgogn/core/cmap/map_base_data.h
+++ b/cgogn/core/cmap/map_base_data.h
@@ -201,7 +201,7 @@ protected:
 	*/
 	inline ChunkArray<bool>* get_topology_mark_attribute()
 	{
-		unsigned int thread = this->get_current_thread_index();
+		std::size_t thread = this->get_current_thread_index();
 		if (!this->mark_attributes_topology_[thread].empty())
 		{
 			ChunkArray<bool>* ca = this->mark_attributes_topology_[thread].back();
@@ -222,7 +222,7 @@ protected:
 	*/
 	inline void release_topology_mark_attribute(ChunkArray<bool>* ca)
 	{
-		unsigned int thread = this->get_current_thread_index();
+		std::size_t thread = this->get_current_thread_index();
 		this->mark_attributes_topology_[thread].push_back(ca);
 	}
 
@@ -284,18 +284,18 @@ protected:
 		return old_index;
 	}
 
-	inline unsigned int get_unknown_thread_index(std::thread::id thread_id) const
+	inline std::size_t get_unknown_thread_index(std::thread::id thread_id) const
 	{
 		auto end = thread_ids_.begin();
 		std::advance(end, NB_UNKNOWN_THREADS);
 		auto res_it = std::find(thread_ids_.begin(), end, thread_id);
 		if (res_it != end)
-			return (unsigned int)(std::distance(thread_ids_.begin(), res_it));
+			return std::distance(thread_ids_.begin(), res_it);
 
 		return add_unknown_thread();
 	}
 
-	inline unsigned int get_current_thread_index() const
+	inline std::size_t get_current_thread_index() const
 	{
 		// avoid the unknown threads stored at the beginning of the vector
 		auto real_begin =thread_ids_.begin();
@@ -304,7 +304,7 @@ protected:
 		const auto end = thread_ids_.end();
 		auto it_lower_bound = std::lower_bound(real_begin, end, std::this_thread::get_id());
 		if (it_lower_bound != end)
-			return (unsigned int)(std::distance(thread_ids_.begin(),it_lower_bound));
+			return std::distance(thread_ids_.begin(),it_lower_bound);
 
 		return get_unknown_thread_index(std::this_thread::get_id());
 	}

--- a/cgogn/core/cmap/map_base_data.h
+++ b/cgogn/core/cmap/map_base_data.h
@@ -290,7 +290,7 @@ protected:
 		std::advance(end, NB_UNKNOWN_THREADS);
 		auto res_it = std::find(thread_ids_.begin(), end, thread_id);
 		if (res_it != end)
-			return std::distance(thread_ids_.begin(), res_it);
+			return (unsigned int)(std::distance(thread_ids_.begin(), res_it));
 
 		return add_unknown_thread();
 	}
@@ -304,7 +304,7 @@ protected:
 		const auto end = thread_ids_.end();
 		auto it_lower_bound = std::lower_bound(real_begin, end, std::this_thread::get_id());
 		if (it_lower_bound != end)
-			return std::distance(thread_ids_.begin(),it_lower_bound);
+			return (unsigned int)(std::distance(thread_ids_.begin(),it_lower_bound));
 
 		return get_unknown_thread_index(std::this_thread::get_id());
 	}

--- a/cgogn/core/container/chunk_array_factory.h
+++ b/cgogn/core/container/chunk_array_factory.h
@@ -45,8 +45,9 @@ class ChunkArrayFactory
 public:
 	typedef std::unique_ptr< ChunkArrayGen<CHUNKSIZE> > ChunkArrayGenPtr;
 	typedef std::map<std::string, ChunkArrayGenPtr> NamePtrMap;
+	typedef std::unique_ptr<NamePtrMap> UniqueNamePtrMap;
 
-	static NamePtrMap* map_CA_;
+	static UniqueNamePtrMap map_CA_;
 
 	/**
 	 * @brief register a type
@@ -56,6 +57,10 @@ public:
 	template <typename T>
 	static void register_CA()
 	{
+		// could be moved in register_known_types (dangerous) ??
+		if (!map_CA_)
+			reset();
+
 		std::string&& keyType(name_of_type(T()));
 		if(map_CA_->find(keyType) == map_CA_->end())
 			(*map_CA_)[std::move(keyType)] = make_unique<ChunkArray<CHUNKSIZE, T>>();
@@ -112,12 +117,12 @@ public:
 
 	static void reset()
 	{
-		ChunkArrayFactory<CHUNKSIZE>::map_CA_ = new NamePtrMap();
+		ChunkArrayFactory<CHUNKSIZE>::map_CA_ = make_unique<NamePtrMap>();
 	}
 };
 
 template <unsigned int CHUNKSIZE>
-typename ChunkArrayFactory<CHUNKSIZE>::NamePtrMap* ChunkArrayFactory<CHUNKSIZE>::map_CA_ = nullptr;//typename ChunkArrayFactory<CHUNKSIZE>::NamePtrMap();
+typename ChunkArrayFactory<CHUNKSIZE>::UniqueNamePtrMap ChunkArrayFactory<CHUNKSIZE>::map_CA_ = nullptr;
 
 
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CORE_CONTAINER_CHUNK_ARRAY_FACTORY_CPP_))

--- a/cgogn/core/container/chunk_array_factory.h
+++ b/cgogn/core/container/chunk_array_factory.h
@@ -46,7 +46,7 @@ public:
 	typedef std::unique_ptr< ChunkArrayGen<CHUNKSIZE> > ChunkArrayGenPtr;
 	typedef std::map<std::string, ChunkArrayGenPtr> NamePtrMap;
 
-	static NamePtrMap map_CA_;
+	static NamePtrMap* map_CA_;
 
 	/**
 	 * @brief register a type
@@ -57,8 +57,8 @@ public:
 	static void register_CA()
 	{
 		std::string&& keyType(name_of_type(T()));
-		if(map_CA_.find(keyType) == map_CA_.end())
-			map_CA_[std::move(keyType)] = make_unique<ChunkArray<CHUNKSIZE, T>>();
+		if(map_CA_->find(keyType) == map_CA_->end())
+			(*map_CA_)[std::move(keyType)] = make_unique<ChunkArray<CHUNKSIZE, T>>();
 	}
 
 	static void register_known_types()
@@ -98,9 +98,9 @@ public:
 	static ChunkArrayGen<CHUNKSIZE>* create(const std::string& keyType)
 	{
 		ChunkArrayGen<CHUNKSIZE>* tmp = nullptr;
-		typename NamePtrMap::const_iterator it = map_CA_.find(keyType);
+		typename NamePtrMap::const_iterator it = map_CA_->find(keyType);
 
-		if(it != map_CA_.end())
+		if(it != map_CA_->end())
 		{
 			tmp = (it->second)->clone();
 		}
@@ -112,12 +112,12 @@ public:
 
 	static void reset()
 	{
-		ChunkArrayFactory<CHUNKSIZE>::map_CA_ = NamePtrMap();
+		ChunkArrayFactory<CHUNKSIZE>::map_CA_ = new NamePtrMap();
 	}
 };
 
 template <unsigned int CHUNKSIZE>
-typename ChunkArrayFactory<CHUNKSIZE>::NamePtrMap ChunkArrayFactory<CHUNKSIZE>::map_CA_= typename ChunkArrayFactory<CHUNKSIZE>::NamePtrMap();
+typename ChunkArrayFactory<CHUNKSIZE>::NamePtrMap* ChunkArrayFactory<CHUNKSIZE>::map_CA_ = nullptr;//typename ChunkArrayFactory<CHUNKSIZE>::NamePtrMap();
 
 
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CORE_CONTAINER_CHUNK_ARRAY_FACTORY_CPP_))

--- a/cgogn/core/utils/definitions.h
+++ b/cgogn/core/utils/definitions.h
@@ -37,7 +37,8 @@
 /*
  * Thread local storage. In VS <1900 it works only with POD types.
 */
-#if defined(_MSC_VER) && _MSC_VER < 1900
+//#if defined(_MSC_VER) && _MSC_VER < 1900
+#if defined(_MSC_VER)
 #define CGOGN_TLS __declspec( thread )
 #else
 #define CGOGN_TLS __thread


### PR DESCRIPTION
- Pb de  crash sous Windows de bench_mt. En fait pour la 1iere fois une carte et déclarée en var. globale
  et ça pose des pb au niveau des variables statiques qui ne sont pas des pod (ici une std::map)
- Pb de compil sous VS 2015 (#define VS<1900 pour TLS ??)
- qq template en trop (classique sous VS)
- qq warning en moins 
