### PR TITLE
Attribute orbit

### DIFF
--- a/cgogn/core/cmap/attribute.h
+++ b/cgogn/core/cmap/attribute.h
@@ -138,11 +138,11 @@ public:
 		chunk_array_(ca)
 	{
 		if (map != nullptr)
-			chunk_array_cont_ = get_chunk_array_container_tmpl(map,orbit);
+			chunk_array_cont_ = &map->get_const_attribute_container(orbit);
 		if (chunk_array_ != nullptr)
 		{
 			TChunkArray** tmp = &chunk_array_;
-			typename TChunkArray::Inherit** ref = reinterpret_cast<typename TChunkArray::Inherit**>(tmp);
+			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
 			chunk_array_->add_external_ref(ref);
 		}
 	}
@@ -155,7 +155,7 @@ public:
 		if (chunk_array_ != nullptr)
 		{
 			TChunkArray** tmp = &chunk_array_;
-			typename TChunkArray::Inherit** ref = reinterpret_cast<typename TChunkArray::Inherit**>(tmp);
+			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
 			chunk_array_->add_external_ref(ref);
 		}
 	}
@@ -168,7 +168,7 @@ public:
 		if (chunk_array_ != nullptr)
 		{
 			TChunkArray** tmp = &chunk_array_;
-			typename TChunkArray::Inherit** ref = reinterpret_cast<typename TChunkArray::Inherit**>(tmp);
+			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
 			chunk_array_->add_external_ref(ref);
 		}
 	}
@@ -180,7 +180,7 @@ public:
 		if (is_valid())
 		{
 			TChunkArray** tmp = &chunk_array_;
-			typename TChunkArray::Inherit** ref = reinterpret_cast<typename TChunkArray::Inherit**>(tmp);
+			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
 			chunk_array_->remove_external_ref(ref);
 		}
 
@@ -190,7 +190,7 @@ public:
 		if (chunk_array_ != nullptr)
 		{
 			TChunkArray** tmp = &chunk_array_;
-			typename TChunkArray::Inherit** ref = reinterpret_cast<typename TChunkArray::Inherit**>(tmp);
+			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
 			chunk_array_->add_external_ref(ref);
 		}
 
@@ -204,7 +204,7 @@ public:
 		if (is_valid())
 		{
 			TChunkArray** tmp = &chunk_array_;
-			typename TChunkArray::Inherit** ref = reinterpret_cast<typename TChunkArray::Inherit**>(tmp);
+			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
 			chunk_array_->remove_external_ref(ref);
 		}
 
@@ -214,7 +214,7 @@ public:
 		if (chunk_array_ != nullptr)
 		{
 			TChunkArray** tmp = &chunk_array_;
-			typename TChunkArray::Inherit** ref = reinterpret_cast<typename TChunkArray::Inherit**>(tmp);
+			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
 			chunk_array_->add_external_ref(ref);
 		}
 
@@ -226,7 +226,7 @@ public:
 		if (is_valid())
 		{
 			TChunkArray** tmp = &chunk_array_;
-			typename TChunkArray::Inherit** ref = reinterpret_cast<typename TChunkArray::Inherit**>(tmp);
+			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
 			chunk_array_->remove_external_ref(ref);
 		}
 	}
@@ -401,26 +401,8 @@ public:
 	}
 
 protected:
-	ChunkArrayContainer*	chunk_array_cont_;
-	TChunkArray*			chunk_array_;
-
-private:
-	inline static ChunkArrayContainer* get_chunk_array_container_tmpl(MapData* map, Orbit orb)
-	{
-		switch (orb) {
-			case Orbit::DART : return &(map->template get_attribute_container<Orbit::DART>());
-			case Orbit::PHI1 : return &(map->template get_attribute_container<Orbit::PHI1>());
-			case Orbit::PHI2 : return &(map->template get_attribute_container<Orbit::PHI2>());
-			case Orbit::PHI1_PHI2 : return &(map->template get_attribute_container<Orbit::PHI1_PHI2>());
-			case Orbit::PHI1_PHI3 : return &(map->template get_attribute_container<Orbit::PHI1_PHI3>());
-			case Orbit::PHI2_PHI3 : return &(map->template get_attribute_container<Orbit::PHI2_PHI3>());
-			case Orbit::PHI21 : return &(map->template get_attribute_container<Orbit::PHI21>());
-			case Orbit::PHI21_PHI31 : return &(map->template get_attribute_container<Orbit::PHI21_PHI31>());
-			case Orbit::PHI1_PHI2_PHI3 : return &(map->template get_attribute_container<Orbit::PHI1_PHI2_PHI3>());
-			default:
-				return nullptr;
-		}
-	}
+	ChunkArrayContainer const*	chunk_array_cont_;
+	TChunkArray*				chunk_array_;
 };
 
 /**

--- a/cgogn/core/cmap/attribute.h
+++ b/cgogn/core/cmap/attribute.h
@@ -140,11 +140,7 @@ public:
 		if (map != nullptr)
 			chunk_array_cont_ = &map->get_const_attribute_container(orbit);
 		if (chunk_array_ != nullptr)
-		{
-			TChunkArray** tmp = &chunk_array_;
-			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
-			chunk_array_->add_external_ref(ref);
-		}
+			chunk_array_->add_external_ref(reinterpret_cast<ChunkArrayGen**>(&chunk_array_));
 	}
 
 	Attribute_T(const Self& att) :
@@ -153,11 +149,7 @@ public:
 		chunk_array_(att.chunk_array_)
 	{
 		if (chunk_array_ != nullptr)
-		{
-			TChunkArray** tmp = &chunk_array_;
-			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
-			chunk_array_->add_external_ref(ref);
-		}
+			chunk_array_->add_external_ref(reinterpret_cast<ChunkArrayGen**>(&chunk_array_));
 	}
 
 	inline Attribute_T(Self&& att) CGOGN_NOEXCEPT :
@@ -166,11 +158,7 @@ public:
 		chunk_array_(att.chunk_array_)
 	{
 		if (chunk_array_ != nullptr)
-		{
-			TChunkArray** tmp = &chunk_array_;
-			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
-			chunk_array_->add_external_ref(ref);
-		}
+			chunk_array_->add_external_ref(reinterpret_cast<ChunkArrayGen**>(&chunk_array_));
 	}
 
 	inline Attribute_T& operator=(const Self& att)
@@ -178,21 +166,13 @@ public:
 		Inherit::operator=(att);
 
 		if (is_valid())
-		{
-			TChunkArray** tmp = &chunk_array_;
-			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
-			chunk_array_->remove_external_ref(ref);
-		}
+			chunk_array_->remove_external_ref(reinterpret_cast<ChunkArrayGen**>(&chunk_array_));
 
 		chunk_array_cont_ = att.chunk_array_cont_;
 		chunk_array_ = att.chunk_array_;
 
 		if (chunk_array_ != nullptr)
-		{
-			TChunkArray** tmp = &chunk_array_;
-			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
-			chunk_array_->add_external_ref(ref);
-		}
+			chunk_array_->add_external_ref(reinterpret_cast<ChunkArrayGen**>(&chunk_array_));
 
 		return *this;
 	}
@@ -202,21 +182,13 @@ public:
 		Inherit::operator=(std::move(att));
 
 		if (is_valid())
-		{
-			TChunkArray** tmp = &chunk_array_;
-			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
-			chunk_array_->remove_external_ref(ref);
-		}
+			chunk_array_->remove_external_ref(reinterpret_cast<ChunkArrayGen**>(&chunk_array_));
 
 		chunk_array_cont_ = att.chunk_array_cont_;
 		chunk_array_ = att.chunk_array_;
 
 		if (chunk_array_ != nullptr)
-		{
-			TChunkArray** tmp = &chunk_array_;
-			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
-			chunk_array_->add_external_ref(ref);
-		}
+			chunk_array_->add_external_ref(reinterpret_cast<ChunkArrayGen**>(&chunk_array_));
 
 		return *this;
 	}
@@ -224,11 +196,7 @@ public:
 	virtual ~Attribute_T() override
 	{
 		if (is_valid())
-		{
-			TChunkArray** tmp = &chunk_array_;
-			ChunkArrayGen** ref = reinterpret_cast<ChunkArrayGen**>(tmp);
-			chunk_array_->remove_external_ref(ref);
-		}
+			chunk_array_->remove_external_ref(reinterpret_cast<ChunkArrayGen**>(&chunk_array_));
 	}
 
 	/**

--- a/cgogn/core/cmap/attribute.h
+++ b/cgogn/core/cmap/attribute.h
@@ -106,136 +106,39 @@ public:
 	virtual const std::string&	get_name() const = 0;
 	virtual const std::string&	get_type_name() const = 0;
 	virtual bool				is_valid() const = 0;
-	virtual Orbit				get_orbit() const = 0;
-};
-
-
-/**
- * \brief Generic Attribute class with orbit parameter
- * @TPARAM ORBIT the orbit of the attribute to handlde
- */
-template <typename DATA_TRAITS, Orbit ORBIT>
-class AttributeOrbit : public AttributeGen<DATA_TRAITS>
-{
-public:
-
-	using Inherit = AttributeGen<DATA_TRAITS>;
-	using Self = AttributeOrbit<DATA_TRAITS, ORBIT>;
-	using MapData = typename Inherit::MapData;
-
-	static const uint32 CHUNKSIZE = DATA_TRAITS::CHUNK_SIZE;
-	static const Orbit orbit_value = ORBIT;
-
-	template <typename T>
-	using ChunkArrayContainer = cgogn::ChunkArrayContainer<CHUNKSIZE, T>;
-	template <typename T>
-	using ChunkArray = cgogn::ChunkArray<CHUNKSIZE, T>;
-
-protected:
-
-	ChunkArrayContainer<uint32>* chunk_array_cont_;
-
-public:
-
-	inline AttributeOrbit(MapData* const map) :
-		Inherit(map),
-		chunk_array_cont_(nullptr)
-	{
-		if (map != nullptr)
-			chunk_array_cont_ = &(map->template get_attribute_container<ORBIT>());
-	}
-
-	/**
-	 * \brief copy constructor
-	 * @param attho
-	 */
-	inline AttributeOrbit(const Self& attho) :
-		Inherit(attho),
-		chunk_array_cont_(attho.chunk_array_cont_)
-	{}
-
-	/**
-	 * \brief move constructor
-	 * @param attho
-	 */
-	inline AttributeOrbit(Self&& attho) CGOGN_NOEXCEPT :
-		Inherit(std::move(attho)),
-		chunk_array_cont_(attho.chunk_array_cont_)
-	{}
-
-	/**
-	 * \brief operator =
-	 * @param attho
-	 * @return
-	 */
-	inline AttributeOrbit& operator=(const Self& attho)
-	{
-		Inherit::operator=(attho);
-		chunk_array_cont_ = attho.chunk_array_cont_;
-		return *this;
-	}
-	/**
-	 * \brief move operator =
-	 * @param attho
-	 * @return
-	 */
-	inline AttributeOrbit& operator=(Self&& attho)
-	{
-		Inherit::operator=(std::move(attho));
-		chunk_array_cont_ = attho.chunk_array_cont_;
-		return *this;
-	}
-
-	virtual Orbit get_orbit() const override
-	{
-		return ORBIT;
-	}
-
-	virtual ~AttributeOrbit() override
-	{}
 };
 
 /**
- * \brief Attribute class
+ * @brief The Attribute_T class
  * @TPARAM T the data type of the attribute to handlde
+ * In this class we do not know the orbit of the Attribute.
  */
-template <typename DATA_TRAITS, typename T, Orbit ORBIT>
-class Attribute : public AttributeOrbit<DATA_TRAITS, ORBIT>
+template<typename DATA_TRAITS, typename T>
+class Attribute_T : public AttributeGen<DATA_TRAITS>
 {
 public:
-
-	using Inherit = AttributeOrbit<DATA_TRAITS, ORBIT>;
-	using Self = Attribute<DATA_TRAITS, T, ORBIT>;
+	using Inherit = AttributeGen<DATA_TRAITS>;
+	using Self = Attribute_T<DATA_TRAITS, T>;
 	using value_type = T;
 	using MapData = typename Inherit::MapData;
-	using TChunkArray = typename Inherit::template ChunkArray<T>;
+	static const uint32 CHUNK_SIZE = DATA_TRAITS::CHUNK_SIZE;
+	using TChunkArray = cgogn::ChunkArray<CHUNK_SIZE, T>;
 	using ChunkArrayGen = typename Inherit::ChunkArrayGen;
+	using ChunkArrayContainer = cgogn::ChunkArrayContainer<CHUNK_SIZE, uint32>;
 
-protected:
 
-	TChunkArray* chunk_array_;
-
-public:
-
-	/**
-	 * \brief Default constructor
-	 *
-	 * Construct a non-valid Attribute (i.e. not linked to any attribute)
-	 */
-	Attribute() :
+	inline Attribute_T() :
 		Inherit(nullptr),
+		chunk_array_cont_(nullptr),
 		chunk_array_(nullptr)
 	{}
 
-	/**
-	 * \brief Constructor
-	 * @param m the map the attribute belongs to
-	 * @param ca TChunkArray pointer
-	 */
-	Attribute(MapData* const m, TChunkArray* const ca) :
-		Inherit(m),
+	Attribute_T(MapData* const map, TChunkArray* const ca, Orbit orbit) :
+		Inherit(map),
 		chunk_array_(ca)
 	{
+		if (map != nullptr)
+			chunk_array_cont_ = get_chunk_array_container_tmpl(map,orbit);
 		if (chunk_array_ != nullptr)
 		{
 			TChunkArray** tmp = &chunk_array_;
@@ -244,12 +147,9 @@ public:
 		}
 	}
 
-	/**
-	 * \brief Copy constructor
-	 * @param att
-	 */
-	Attribute(const Self& att) :
+	Attribute_T(const Self& att) :
 		Inherit(att),
+		chunk_array_cont_(att.chunk_array_cont_),
 		chunk_array_(att.chunk_array_)
 	{
 		if (chunk_array_ != nullptr)
@@ -260,12 +160,9 @@ public:
 		}
 	}
 
-	/**
-	 * \brief Move constructor
-	 * @param att
-	 */
-	Attribute(Self&& att) CGOGN_NOEXCEPT :
+	inline Attribute_T(Self&& att) CGOGN_NOEXCEPT :
 		Inherit(std::move(att)),
+		chunk_array_cont_(att.chunk_array_cont_),
 		chunk_array_(att.chunk_array_)
 	{
 		if (chunk_array_ != nullptr)
@@ -276,12 +173,7 @@ public:
 		}
 	}
 
-	/**
-	 * \brief operator =
-	 * @param att
-	 * @return
-	 */
-	Attribute& operator=(const Self& att)
+	inline Attribute_T& operator=(const Self& att)
 	{
 		Inherit::operator=(att);
 
@@ -292,6 +184,7 @@ public:
 			chunk_array_->remove_external_ref(ref);
 		}
 
+		chunk_array_cont_ = att.chunk_array_cont_;
 		chunk_array_ = att.chunk_array_;
 
 		if (chunk_array_ != nullptr)
@@ -304,12 +197,7 @@ public:
 		return *this;
 	}
 
-	/**
-	 * \brief move operator =
-	 * @param att
-	 * @return
-	 */
-	Attribute& operator=(Self&& att)
+	Attribute_T& operator=(Self&& att)
 	{
 		Inherit::operator=(std::move(att));
 
@@ -320,6 +208,7 @@ public:
 			chunk_array_->remove_external_ref(ref);
 		}
 
+		chunk_array_cont_ = att.chunk_array_cont_;
 		chunk_array_ = att.chunk_array_;
 
 		if (chunk_array_ != nullptr)
@@ -332,7 +221,7 @@ public:
 		return *this;
 	}
 
-	virtual ~Attribute() override
+	virtual ~Attribute_T() override
 	{
 		if (is_valid())
 		{
@@ -340,16 +229,6 @@ public:
 			typename TChunkArray::Inherit** ref = reinterpret_cast<typename TChunkArray::Inherit**>(tmp);
 			chunk_array_->remove_external_ref(ref);
 		}
-	}
-
-	virtual const std::string& get_name() const override
-	{
-		return chunk_array_->get_name();
-	}
-
-	virtual bool is_valid() const override
-	{
-		return chunk_array_ != nullptr;
 	}
 
 	/**
@@ -368,38 +247,6 @@ public:
 	inline void set_all_container_values(const T& val)
 	{
 		chunk_array_->set_all_values(val);
-	}
-
-	/**
-	 * \brief operator []
-	 * @param c
-	 * @return
-	 */
-	inline T& operator[](Cell<ORBIT> c)
-	{
-		cgogn_message_assert(is_valid(), "Invalid Attribute");
-		return chunk_array_->operator[](this->map_->get_embedding(c));
-	}
-
-	/**
-	 * \brief operator []
-	 * @param c
-	 * @return
-	 */
-	inline const T& operator[](Cell<ORBIT> c) const
-	{
-		cgogn_message_assert(is_valid(), "Invalid Attribute");
-		return chunk_array_->operator[](this->map_->get_embedding(c));
-	}
-
-	/**
-	 * @brief set_value method to write in boolean Attributes
-	 * @param c
-	 * @param t
-	 */
-	inline void set_value(Cell<ORBIT> c, const T& t)
-	{
-		chunk_array_->set_value(this->map_->get_embedding(c), t);
 	}
 
 	/**
@@ -435,13 +282,28 @@ public:
 	}
 
 
+	virtual const std::string& get_name() const override
+	{
+		return chunk_array_->get_name();
+	}
+
+	virtual bool is_valid() const override
+	{
+		return chunk_array_ != nullptr;
+	}
+
+	virtual const std::string& get_type_name() const override
+	{
+		return chunk_array_->get_type_name();
+	}
+
 	class const_iterator
 	{
 	public:
-		const Attribute<DATA_TRAITS, T, ORBIT>* const ah_ptr_;
+		const Attribute_T<DATA_TRAITS, T>* const ah_ptr_;
 		uint32 index_;
 
-		inline const_iterator(const Attribute<DATA_TRAITS, T, ORBIT>* ah, uint32 i) :
+		inline const_iterator(const Attribute_T<DATA_TRAITS, T>* ah, uint32 i) :
 			ah_ptr_(ah),
 			index_(i)
 		{}
@@ -490,10 +352,10 @@ public:
 	class iterator
 	{
 	public:
-		Attribute<DATA_TRAITS, T, ORBIT>* const ah_ptr_;
+		Attribute_T<DATA_TRAITS, T>* const ah_ptr_;
 		uint32 index_;
 
-		inline iterator(Attribute<DATA_TRAITS, T, ORBIT>* ah, uint32 i) :
+		inline iterator(Attribute_T<DATA_TRAITS, T>* ah, uint32 i) :
 			ah_ptr_(ah),
 			index_(i)
 		{}
@@ -538,9 +400,132 @@ public:
 		return iterator(this, this->chunk_array_cont_->end());
 	}
 
-	virtual const std::string& get_type_name() const override
+protected:
+	ChunkArrayContainer*	chunk_array_cont_;
+	TChunkArray*			chunk_array_;
+
+private:
+	inline static ChunkArrayContainer* get_chunk_array_container_tmpl(MapData* map, Orbit orb)
 	{
-		return chunk_array_->get_type_name();
+		switch (orb) {
+			case Orbit::DART : return &(map->template get_attribute_container<Orbit::DART>());
+			case Orbit::PHI1 : return &(map->template get_attribute_container<Orbit::PHI1>());
+			case Orbit::PHI2 : return &(map->template get_attribute_container<Orbit::PHI2>());
+			case Orbit::PHI1_PHI2 : return &(map->template get_attribute_container<Orbit::PHI1_PHI2>());
+			case Orbit::PHI1_PHI3 : return &(map->template get_attribute_container<Orbit::PHI1_PHI3>());
+			case Orbit::PHI2_PHI3 : return &(map->template get_attribute_container<Orbit::PHI2_PHI3>());
+			case Orbit::PHI21 : return &(map->template get_attribute_container<Orbit::PHI21>());
+			case Orbit::PHI21_PHI31 : return &(map->template get_attribute_container<Orbit::PHI21_PHI31>());
+			case Orbit::PHI1_PHI2_PHI3 : return &(map->template get_attribute_container<Orbit::PHI1_PHI2_PHI3>());
+			default:
+				return nullptr;
+		}
+	}
+};
+
+/**
+ * \brief Attribute class
+ * @TPARAM T the data type of the attribute to handlde
+ */
+template <typename DATA_TRAITS, typename T, Orbit ORBIT>
+class Attribute : public Attribute_T<DATA_TRAITS, T>
+{
+public:
+	using Inherit = Attribute_T<DATA_TRAITS, T>;
+	using Self = Attribute<DATA_TRAITS, T, ORBIT>;
+	using MapData = typename Inherit::MapData;
+	using TChunkArray = typename Inherit::TChunkArray;
+	using Inherit::operator [];
+	/**
+	 * \brief Default constructor
+	 *
+	 * Construct a non-valid Attribute (i.e. not linked to any attribute)
+	 */
+	inline Attribute() :
+		Inherit(nullptr, nullptr, Orbit())
+	{}
+
+	inline Attribute(MapData* const map, TChunkArray* const ca) :
+		Inherit(map, ca, ORBIT)
+	{}
+
+
+	/**
+	 * \brief Copy constructor
+	 * @param att
+	 */
+	inline Attribute(const Self& att) :
+		Inherit(att)
+	{}
+
+	/**
+	 * \brief Move constructor
+	 * @param att
+	 */
+	inline Attribute(Self&& att) CGOGN_NOEXCEPT :
+		Inherit(std::move(att))
+	{}
+
+	/**
+	 * \brief operator =
+	 * @param att
+	 * @return
+	 */
+	inline Attribute& operator=(const Self& att)
+	{
+		Inherit::operator=(att);
+		return *this;
+	}
+
+	/**
+	 * \brief move operator =
+	 * @param att
+	 * @return
+	 */
+	Attribute& operator=(Self&& att)
+	{
+		Inherit::operator=(std::move(att));
+		return *this;
+	}
+
+	virtual ~Attribute() override
+	{}
+
+	/**
+	 * \brief operator []
+	 * @param c
+	 * @return
+	 */
+	inline T& operator[](Cell<ORBIT> c)
+	{
+		cgogn_message_assert(this->is_valid(), "Invalid Attribute");
+		return this->chunk_array_->operator[](this->map_->get_embedding(c));
+	}
+
+	/**
+	 * \brief operator []
+	 * @param c
+	 * @return
+	 */
+	inline const T& operator[](Cell<ORBIT> c) const
+	{
+		cgogn_message_assert(this->is_valid(), "Invalid Attribute");
+		return this->chunk_array_->operator[](this->map_->get_embedding(c));
+	}
+
+	/**
+	 * @brief set_value method to write in boolean Attributes
+	 * @param c
+	 * @param t
+	 */
+	inline void set_value(Cell<ORBIT> c, const T& t)
+	{
+		this->chunk_array_->set_value(this->map_->get_embedding(c), t);
+	}
+
+	inline Orbit get_orbit() const
+	{
+		return ORBIT;
 	}
 };
 

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -277,7 +277,7 @@ public:
 	}
 
 	template <typename T>
-	inline Attribute_T<T> get_attribute(const std::string& attribute_name, Orbit orbit)
+	inline Attribute_T<T> get_attribute(Orbit orbit, const std::string& attribute_name)
 	{
 		cgogn_message_assert(orbit < NB_ORBITS, "Unknown orbit parameter");
 

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -66,6 +66,8 @@ public:
 	using typename Inherit::ChunkArrayBool;
 
 	using AttributeGen = cgogn::AttributeGen<MAP_TRAITS>;
+	template <typename T>
+	using Attribute_T = cgogn::Attribute_T<MAP_TRAITS, T>;
 	template <typename T, Orbit ORBIT>
 	using Attribute = cgogn::Attribute<MAP_TRAITS, T, ORBIT>;
 
@@ -272,6 +274,15 @@ public:
 
 		ChunkArray<T>* ca = this->attributes_[ORBIT].template get_attribute<T>(attribute_name);
 		return Attribute<T, ORBIT>(this, ca);
+	}
+
+	template <typename T>
+	inline Attribute_T<T> get_attribute(const std::string& attribute_name, Orbit orbit)
+	{
+		cgogn_message_assert(orbit < NB_ORBITS, "Unknown orbit parameter");
+
+		ChunkArray<T>* ca = this->attributes_[orbit].template get_attribute<T>(attribute_name);
+		return Attribute_T<T>(this, ca, orbit);
 	}
 
 	/**

--- a/cgogn/core/cmap/map_base_data.h
+++ b/cgogn/core/cmap/map_base_data.h
@@ -188,6 +188,13 @@ public:
 		return attributes_[ORBIT];
 	}
 
+	inline const ChunkArrayContainer<uint32>& get_const_attribute_container(Orbit orbit) const
+	{
+		cgogn_message_assert(orbit < NB_ORBITS, "Unknown orbit parameter");
+		return attributes_[orbit];
+	}
+
+
 	inline const ChunkArrayContainer<uint8>& get_topology_container() const
 	{
 		return topology_;

--- a/cgogn/core/cmap/map_base_data.h
+++ b/cgogn/core/cmap/map_base_data.h
@@ -78,9 +78,13 @@ public:
 	}
 };
 
-// forward declaration of class AttributeOrbit
-template <typename DATA_TRAITS, Orbit ORBIT>
-class AttributeOrbit;
+// forward declaration of class Attribute_T
+template<typename DATA_TRAITS, typename T>
+class Attribute_T;
+
+// forward declaration of class Attribute
+template <typename DATA_TRAITS, typename T, Orbit ORBIT>
+class Attribute;
 
 /**
  * @brief The MapBaseData class
@@ -93,17 +97,17 @@ public:
 	using Inherit = MapGen;
 	using Self = MapBaseData<MAP_TRAITS>;
 
-	static const uint32 CHUNKSIZE = MAP_TRAITS::CHUNK_SIZE;
+	static const uint32 CHUNK_SIZE = MAP_TRAITS::CHUNK_SIZE;
 	static const uint32 NB_UNKNOWN_THREADS = 4u;
-	template <typename DT, Orbit ORBIT> friend class AttributeOrbit;
+	template<typename DT, typename T> friend class Attribute_T;
 	template <typename DT, typename T, Orbit ORBIT> friend class Attribute;
 
 	template <typename T_REF>
-	using ChunkArrayContainer = cgogn::ChunkArrayContainer<CHUNKSIZE, T_REF>;
-	using ChunkArrayGen = cgogn::ChunkArrayGen<CHUNKSIZE>;
+	using ChunkArrayContainer = cgogn::ChunkArrayContainer<CHUNK_SIZE, T_REF>;
+	using ChunkArrayGen = cgogn::ChunkArrayGen<CHUNK_SIZE>;
 	template <typename T>
-	using ChunkArray = cgogn::ChunkArray<CHUNKSIZE, T>;
-	using ChunkArrayBool = cgogn::ChunkArrayBool<CHUNKSIZE>;
+	using ChunkArray = cgogn::ChunkArray<CHUNK_SIZE, T>;
+	using ChunkArrayBool = cgogn::ChunkArrayBool<CHUNK_SIZE>;
 
 protected:
 
@@ -138,7 +142,7 @@ public:
 	{
 		if (init_CA_factory)
 		{
-			ChunkArrayFactory<CHUNKSIZE>::reset();
+			ChunkArrayFactory<CHUNK_SIZE>::reset();
 			init_CA_factory = false;
 		}
 		for (uint32 i = 0; i < NB_ORBITS; ++i)

--- a/cgogn/core/container/chunk_array.h
+++ b/cgogn/core/container/chunk_array.h
@@ -42,16 +42,16 @@ namespace cgogn
 
 /**
  *	@brief chunk array class storage
- *	@tparam CHUNKSIZE size of each chunk (in T, not in bytes!), must be a power of 2 >=32
+ *	@tparam CHUNK_SIZE size of each chunk (in T, not in bytes!), must be a power of 2 >=32
  *	@tparam T type of stored data
  */
-template <uint32 CHUNKSIZE, typename T>
-class ChunkArray : public ChunkArrayGen<CHUNKSIZE>
+template <uint32 CHUNK_SIZE, typename T>
+class ChunkArray : public ChunkArrayGen<CHUNK_SIZE>
 {
 public:
 
-	using Inherit = ChunkArrayGen<CHUNKSIZE>;
-	using Self = ChunkArray<CHUNKSIZE, T>;
+	using Inherit = ChunkArrayGen<CHUNK_SIZE>;
+	using Self = ChunkArray<CHUNK_SIZE, T>;
 	using value_type = T;
 
 protected:
@@ -84,7 +84,7 @@ public:
 	}
 
 	/**
-	 * @brief create a ChunkArray<CHUNKSIZE,T>
+	 * @brief create a ChunkArray<CHUNK_SIZE,T>
 	 * @return generic pointer
 	 */
 	std::unique_ptr<Inherit> clone(const std::string& clone_name) const override
@@ -113,11 +113,11 @@ public:
 //	}
 
 	/**
-	 * @brief add a chunk (T[CHUNKSIZE])
+	 * @brief add a chunk (T[CHUNK_SIZE])
 	 */
 	void add_chunk() override
 	{
-		table_data_.push_back(new T[CHUNKSIZE]());
+		table_data_.push_back(new T[CHUNK_SIZE]());
 	}
 
 	/**
@@ -154,7 +154,7 @@ public:
 	 */
 	uint32 capacity() const override
 	{
-		return uint32(table_data_.size())*CHUNKSIZE;
+		return uint32(table_data_.size())*CHUNK_SIZE;
 	}
 
 	/**
@@ -170,12 +170,12 @@ public:
 	/**
 	 * @brief fill a vector with pointers to all chunks
 	 * @param addr vector to fill
-	 * @param byte_chunk_size filled with CHUNKSIZE*sizeof(T)
+	 * @param byte_chunk_size filled with CHUNK_SIZE*sizeof(T)
 	 * @return addr.size()
 	 */
 	uint32 get_chunks_pointers(std::vector<void*>& addr, uint32& byte_chunk_size) const override
 	{
-		byte_chunk_size = CHUNKSIZE * sizeof(T);
+		byte_chunk_size = CHUNK_SIZE * sizeof(T);
 
 		addr.reserve(table_data_.size());
 		addr.clear();
@@ -192,7 +192,7 @@ public:
 	 */
 	void init_element(uint32 id) override
 	{
-		table_data_[id / CHUNKSIZE][id % CHUNKSIZE] = T();
+		table_data_[id / CHUNK_SIZE][id % CHUNK_SIZE] = T();
 	}
 
 	/**
@@ -202,7 +202,7 @@ public:
 	 */
 	void copy_element(uint32 dst, uint32 src) override
 	{
-		table_data_[dst / CHUNKSIZE][dst % CHUNKSIZE] = table_data_[src / CHUNKSIZE][src % CHUNKSIZE];
+		table_data_[dst / CHUNK_SIZE][dst % CHUNK_SIZE] = table_data_[src / CHUNK_SIZE][src % CHUNK_SIZE];
 	}
 
 	/**
@@ -214,7 +214,7 @@ public:
 	void copy_external_element(uint32 dst, Inherit* cag_src, uint32 src) override
 	{
 		Self* ca = static_cast<Self*>(cag_src);
-		table_data_[dst / CHUNKSIZE][dst % CHUNKSIZE] = ca->table_data_[src / CHUNKSIZE][src % CHUNKSIZE];
+		table_data_[dst / CHUNK_SIZE][dst % CHUNK_SIZE] = ca->table_data_[src / CHUNK_SIZE][src % CHUNK_SIZE];
 	}
 
 	/**
@@ -224,7 +224,7 @@ public:
 	 */
 	void move_element(uint32 dst, uint32 src) override
 	{
-		table_data_[dst / CHUNKSIZE][dst % CHUNKSIZE] = std::move(table_data_[src / CHUNKSIZE][src % CHUNKSIZE]);
+		table_data_[dst / CHUNK_SIZE][dst % CHUNK_SIZE] = std::move(table_data_[src / CHUNK_SIZE][src % CHUNK_SIZE]);
 	}
 
 	/**
@@ -236,10 +236,10 @@ public:
 	{
 // small workaround to avoid difficulties with std::swap when _GLIBCXX_DEBUG is defined.
 #ifndef _GLIBCXX_DEBUG
-		std::swap(table_data_[idx1 / CHUNKSIZE][idx1 % CHUNKSIZE], table_data_[idx2 / CHUNKSIZE][idx2 % CHUNKSIZE] );
+		std::swap(table_data_[idx1 / CHUNK_SIZE][idx1 % CHUNK_SIZE], table_data_[idx2 / CHUNK_SIZE][idx2 % CHUNK_SIZE] );
 #else
-		T& a = table_data_[idx1 / CHUNKSIZE][idx1 % CHUNKSIZE];
-		T& b = table_data_[idx2 / CHUNKSIZE][idx2 % CHUNKSIZE];
+		T& a = table_data_[idx1 / CHUNK_SIZE][idx1 % CHUNK_SIZE];
+		T& b = table_data_[idx2 / CHUNK_SIZE][idx2 % CHUNK_SIZE];
 		T tmp(std::move(a));
 		a = std::move(b);
 		b = std::move(tmp);
@@ -251,10 +251,10 @@ public:
 //		uint32 nbs[3];
 //		nbs[0] = (uint32)(table_data_.size());
 //		nbs[1] = nb_lines;
-//		nbs[2] = CHUNKSIZE*sizeof(T);
+//		nbs[2] = CHUNK_SIZE*sizeof(T);
 
-//		assert(nb_lines/CHUNKSIZE <= table_data_.size());
-//		// TODO: if (nb_lines == 0) nb_lines = CHUNKSIZE*table_data_.size(); ??
+//		assert(nb_lines/CHUNK_SIZE <= table_data_.size());
+//		// TODO: if (nb_lines == 0) nb_lines = CHUNK_SIZE*table_data_.size(); ??
 
 //		fs.write(reinterpret_cast<const char*>(nbs),3*sizeof(uint32));
 
@@ -266,11 +266,11 @@ public:
 //		// save data chunks except last
 //		for(uint32 i=0; i<nbca; ++i)
 //		{
-//			fs.write(reinterpret_cast<const char*>(table_data_[i]),CHUNKSIZE*sizeof(T));
+//			fs.write(reinterpret_cast<const char*>(table_data_[i]),CHUNK_SIZE*sizeof(T));
 //		}
 
 //		// save last
-//		unsigned nbl = nb_lines - nbca*CHUNKSIZE;
+//		unsigned nbl = nb_lines - nbca*CHUNK_SIZE;
 //		fs.write(reinterpret_cast<const char*>(table_data_[nbca]),std::streamsize(nbl*sizeof(T)));
 //	}
 
@@ -279,9 +279,9 @@ public:
 //		uint32 nbs[3];
 //		fs.read(reinterpret_cast<char*>(nbs), 3*sizeof(uint32));
 
-//		if (nbs[2] != CHUNKSIZE*sizeof(T))
+//		if (nbs[2] != CHUNK_SIZE*sizeof(T))
 //		{
-//			std::cerr << "Error loading ChunkArray wrong CHUNKSIZE"<< std::endl;
+//			std::cerr << "Error loading ChunkArray wrong CHUNK_SIZE"<< std::endl;
 //			return false;
 //		}
 
@@ -294,10 +294,10 @@ public:
 //		// load data chunks except last
 //		uint32 nbca = nbs[0]-1;
 //		for(uint32 i = 0; i < nbca; ++i)
-//			fs.read(reinterpret_cast<char*>(table_data_[i]),CHUNKSIZE*sizeof(T));
+//			fs.read(reinterpret_cast<char*>(table_data_[i]),CHUNK_SIZE*sizeof(T));
 
 //		// load last chunk
-//		uint32 nbl = nbs[1] - CHUNKSIZE*nbca;
+//		uint32 nbl = nbs[1] - CHUNK_SIZE*nbca;
 //		fs.read(reinterpret_cast<char*>(table_data_[nbca]),std::streamsize(nbl*sizeof(T)));
 
 //		return true;
@@ -306,7 +306,7 @@ public:
 	void save(std::ostream& fs, uint32 nb_lines) const override
 	{
 		cgogn_assert(fs.good());
-		cgogn_assert(nb_lines / CHUNKSIZE <= get_nb_chunks());
+		cgogn_assert(nb_lines / CHUNK_SIZE <= get_nb_chunks());
 
 		// no data -> finished
 		if (nb_lines == 0)
@@ -319,18 +319,18 @@ public:
 
 		uint32 nbc = get_nb_chunks() - 1u;
 		// nb of lines of last chunk
-		const unsigned nb = nb_lines - nbc*CHUNKSIZE;
+		const unsigned nb = nb_lines - nbc*CHUNK_SIZE;
 
 		// compute number of bytes to save
 		std::size_t chunk_bytes = 0;
 		if (serialization::known_size(table_data_[0]))
 		{
-			chunk_bytes += nbc * serialization::data_length(table_data_[0], CHUNKSIZE);
+			chunk_bytes += nbc * serialization::data_length(table_data_[0], CHUNK_SIZE);
 		}
 		else
 		{
 			for(uint32 i = 0u; i < nbc; ++i)
-				chunk_bytes += serialization::data_length(table_data_[i], CHUNKSIZE);
+				chunk_bytes += serialization::data_length(table_data_[i], CHUNK_SIZE);
 		}
 		chunk_bytes +=serialization::data_length(table_data_[nbc], nb);
 		// save it
@@ -343,7 +343,7 @@ public:
 		// save data chunks except last
 		for(uint32 i = 0u; i < nbc; ++i)
 		{
-			serialization::save(fs, table_data_[i], CHUNKSIZE);
+			serialization::save(fs, table_data_[i], CHUNK_SIZE);
 		}
 
 		// save last incomplete chunk
@@ -366,8 +366,8 @@ public:
 			return true;
 
 		// compute number of chunks
-		uint32 nbc = nb_lines / CHUNKSIZE;
-		if (nb_lines % CHUNKSIZE != 0)
+		uint32 nbc = nb_lines / CHUNK_SIZE;
+		if (nb_lines % CHUNK_SIZE != 0)
 			nbc++;
 
 		this->set_nb_chunks(nbc);
@@ -375,10 +375,10 @@ public:
 		// load data chunks except last
 		nbc--;
 		for(uint32 i = 0u; i < nbc; ++i)
-			serialization::load(fs, table_data_[i], CHUNKSIZE);
+			serialization::load(fs, table_data_[i], CHUNK_SIZE);
 
 		// load last incomplete chunk
-		const uint32 nb = nb_lines - nbc*CHUNKSIZE;
+		const uint32 nb = nb_lines - nbc*CHUNK_SIZE;
 		serialization::load(fs, table_data_[nbc], nb);
 		cgogn_assert(fs.good());
 
@@ -392,8 +392,8 @@ public:
 	 */
 	inline T& operator[](uint32 i)
 	{
-		cgogn_assert(i / CHUNKSIZE < table_data_.size());
-		return table_data_[i / CHUNKSIZE][i % CHUNKSIZE];
+		cgogn_assert(i / CHUNK_SIZE < table_data_.size());
+		return table_data_[i / CHUNK_SIZE][i % CHUNK_SIZE];
 	}
 
 	/**
@@ -403,8 +403,8 @@ public:
 	 */
 	inline const T& operator[](uint32 i) const
 	{
-		cgogn_assert(i / CHUNKSIZE < table_data_.size());
-		return table_data_[i / CHUNKSIZE][i % CHUNKSIZE];
+		cgogn_assert(i / CHUNK_SIZE < table_data_.size());
+		return table_data_[i / CHUNK_SIZE][i % CHUNK_SIZE];
 	}
 
 	/**
@@ -414,15 +414,15 @@ public:
 	 */
 	inline void set_value(uint32 i, const T& v)
 	{
-		cgogn_assert(i / CHUNKSIZE < table_data_.size());
-		table_data_[i / CHUNKSIZE][i % CHUNKSIZE] = v;
+		cgogn_assert(i / CHUNK_SIZE < table_data_.size());
+		table_data_[i / CHUNK_SIZE][i % CHUNK_SIZE] = v;
 	}
 
 	inline void set_all_values(const T& v)
 	{
 		for(T* chunk : table_data_)
 		{
-			for(uint32 i = 0; i < CHUNKSIZE; ++i)
+			for(uint32 i = 0; i < CHUNK_SIZE; ++i)
 				*chunk++ = v;
 		}
 	}
@@ -447,19 +447,19 @@ public:
 /**
  * @brief separate version of ChunkArray specialized for bool data. One bit per bool.
  */
-template <uint32 CHUNKSIZE>
-class ChunkArrayBool : public ChunkArrayGen<CHUNKSIZE>
+template <uint32 CHUNK_SIZE>
+class ChunkArrayBool : public ChunkArrayGen<CHUNK_SIZE>
 {
 public:
 
-	using Inherit = ChunkArrayGen<CHUNKSIZE>;
+	using Inherit = ChunkArrayGen<CHUNK_SIZE>;
 	using Self = ChunkArrayBool;
 	using value_type = uint32;
 
 protected:
 
 	// ensure we can use CHUNK_SIZE value < 32
-	const int BOOLS_PER_INT = (CHUNKSIZE<32u) ? CHUNKSIZE : 32u;
+	const int BOOLS_PER_INT = (CHUNK_SIZE<32u) ? CHUNK_SIZE : 32u;
 
 	// vector of block pointers
 	std::vector<uint32*> table_data_;
@@ -486,7 +486,7 @@ public:
 	}
 
 	/**
-	 * @brief create a ChunkArray<CHUNKSIZE,T>
+	 * @brief create a ChunkArray<CHUNK_SIZE,T>
 	 * @return generic pointer
 	 */
 	std::unique_ptr<Inherit> clone(const std::string& clone_name) const override
@@ -515,12 +515,12 @@ public:
 //	}
 
 	/**
-	 * @brief add a chunk (T[CHUNKSIZE/32])
+	 * @brief add a chunk (T[CHUNK_SIZE/32])
 	 */
 	void add_chunk() override
 	{
 		// adding the empty parentheses for default-initialization
-		table_data_.push_back(new uint32[CHUNKSIZE/BOOLS_PER_INT]());
+		table_data_.push_back(new uint32[CHUNK_SIZE/BOOLS_PER_INT]());
 	}
 
 	/**
@@ -557,7 +557,7 @@ public:
 	 */
 	uint32 capacity() const override
 	{
-		return uint32(table_data_.size())*CHUNKSIZE/BOOLS_PER_INT;
+		return uint32(table_data_.size())*CHUNK_SIZE/BOOLS_PER_INT;
 	}
 
 	/**
@@ -573,12 +573,12 @@ public:
 	/**
 	 * @brief fill a vector with pointers to all chunks
 	 * @param addr vector to fill
-	 * @param byte_block_size filled with CHUNKSIZE*sizeof(T)
+	 * @param byte_block_size filled with CHUNK_SIZE*sizeof(T)
 	 * @return addr.size()
 	 */
 	inline uint32 get_chunks_pointers(std::vector<void*>& addr, uint32& byte_block_size) const override
 	{
-		byte_block_size = CHUNKSIZE / 8u;
+		byte_block_size = CHUNK_SIZE / 8u;
 
 		addr.reserve(table_data_.size());
 		addr.clear();
@@ -647,8 +647,8 @@ public:
 		if (nb_lines % BOOLS_PER_INT)
 			nb_lines = ((nb_lines / BOOLS_PER_INT) + 1u) * BOOLS_PER_INT;
 
-		cgogn_assert(nb_lines / CHUNKSIZE <= table_data_.size());
-		// TODO: if (nb_lines==0) nb_lines = CHUNKSIZE*table_data_.size(); ??
+		cgogn_assert(nb_lines / CHUNK_SIZE <= table_data_.size());
+		// TODO: if (nb_lines==0) nb_lines = CHUNK_SIZE*table_data_.size(); ??
 
 		// save number of bytes
 		std::size_t chunk_bytes = nb_lines / 8u;
@@ -660,10 +660,10 @@ public:
 		const uint32 nbc = get_nb_chunks() - 1u;
 		// save data chunks except last
 		for(uint32 i = 0u; i < nbc; ++i)
-			fs.write(reinterpret_cast<const char*>(table_data_[i]), CHUNKSIZE / 8u); // /8 because bool = 1 bit & octet = 8 bit
+			fs.write(reinterpret_cast<const char*>(table_data_[i]), CHUNK_SIZE / 8u); // /8 because bool = 1 bit & octet = 8 bit
 
 		// save last
-		const uint32 nb = nb_lines - nbc*CHUNKSIZE;
+		const uint32 nb = nb_lines - nbc*CHUNK_SIZE;
 		fs.write(reinterpret_cast<const char*>(table_data_[nbc]), nb / 8u);
 	}
 
@@ -682,8 +682,8 @@ public:
 			return true;
 
 		// compute number of chunks
-		uint32 nbc = nb_lines / CHUNKSIZE;
-		if (nb_lines % CHUNKSIZE != 0u)
+		uint32 nbc = nb_lines / CHUNK_SIZE;
+		if (nb_lines % CHUNK_SIZE != 0u)
 			nbc++;
 
 		this->set_nb_chunks(nbc);
@@ -691,10 +691,10 @@ public:
 		// load data chunks except last
 		nbc--;
 		for(uint32 i = 0u; i < nbc; ++i)
-			fs.read(reinterpret_cast<char*>(table_data_[i]), CHUNKSIZE / 8u);// /8 because bool = 1 bit & octet = 8 bit
+			fs.read(reinterpret_cast<char*>(table_data_[i]), CHUNK_SIZE / 8u);// /8 because bool = 1 bit & octet = 8 bit
 
 		// load last chunk
-		uint32 nb = nb_lines - nbc*CHUNKSIZE;
+		uint32 nb = nb_lines - nbc*CHUNK_SIZE;
 		fs.read(reinterpret_cast<char*>(table_data_[nbc]), nb / 8u);
 
 		return true;
@@ -707,9 +707,9 @@ public:
 	 */
 	inline bool operator[](uint32 i) const
 	{
-		const uint32 jj = i / CHUNKSIZE;
+		const uint32 jj = i / CHUNK_SIZE;
 		cgogn_assert(jj < table_data_.size());
-		const uint32 j = i % CHUNKSIZE;
+		const uint32 j = i % CHUNK_SIZE;
 		const uint32 x = j / BOOLS_PER_INT;
 		const uint32 y = j % BOOLS_PER_INT;
 
@@ -720,9 +720,9 @@ public:
 
 	inline void set_false(uint32 i)
 	{
-		const uint32 jj = i / CHUNKSIZE;
+		const uint32 jj = i / CHUNK_SIZE;
 		cgogn_assert(jj < table_data_.size());
-		const uint32 j = i % CHUNKSIZE;
+		const uint32 j = i % CHUNK_SIZE;
 		const uint32 x = j / BOOLS_PER_INT;
 		const uint32 y = j % BOOLS_PER_INT;
 		const uint32 mask = 1u << y;
@@ -731,9 +731,9 @@ public:
 
 	inline void set_true(uint32 i)
 	{
-		const uint32 jj = i / CHUNKSIZE;
+		const uint32 jj = i / CHUNK_SIZE;
 		cgogn_assert(jj < table_data_.size());
-		const uint32 j = i % CHUNKSIZE;
+		const uint32 j = i % CHUNK_SIZE;
 		const uint32 x = j / BOOLS_PER_INT;
 		const uint32 y = j % BOOLS_PER_INT;
 		const uint32 mask = 1u << y;
@@ -742,9 +742,9 @@ public:
 
 	inline void set_value(uint32 i, bool b)
 	{
-		const uint32 jj = i / CHUNKSIZE;
+		const uint32 jj = i / CHUNK_SIZE;
 		cgogn_assert(jj < table_data_.size());
-		const uint32 j = i % CHUNKSIZE;
+		const uint32 j = i % CHUNK_SIZE;
 		const uint32 x = j / BOOLS_PER_INT;
 		const uint32 y = j % BOOLS_PER_INT;
 		const uint32 mask = 1u << y;
@@ -763,9 +763,9 @@ public:
 	 */
 	inline void set_false_byte(uint32 i)
 	{
-		const uint32 jj = i / CHUNKSIZE;
+		const uint32 jj = i / CHUNK_SIZE;
 		cgogn_assert(jj < table_data_.size());
-		const uint32 j = (i % CHUNKSIZE) / BOOLS_PER_INT;
+		const uint32 j = (i % CHUNK_SIZE) / BOOLS_PER_INT;
 		table_data_[jj][j] = 0u;
 	}
 
@@ -774,7 +774,7 @@ public:
 		for (uint32 * const ptr : table_data_)
 		{
 //#pragma omp for
-			for (int32 j = 0; j < int32(CHUNKSIZE / BOOLS_PER_INT); ++j)
+			for (int32 j = 0; j < int32(CHUNK_SIZE / BOOLS_PER_INT); ++j)
 				ptr[j] = 0u;
 		}
 	}
@@ -783,7 +783,7 @@ public:
 //	{
 //		for (auto ptr : table_data_)
 //		{
-//			for (uint32 j = 0u; j < CHUNKSIZE/BOOLS_PER_INT; ++j)
+//			for (uint32 j = 0u; j < CHUNK_SIZE/BOOLS_PER_INT; ++j)
 //				*ptr++ = 0xffffffff;
 //		}
 //	}

--- a/cgogn/core/container/chunk_array_container.h
+++ b/cgogn/core/container/chunk_array_container.h
@@ -47,23 +47,23 @@ namespace cgogn
 
 /**
  * @brief class that manage the storage of several ChunkArray
- * @tparam CHUNKSIZE chunk size for ChunkArray
+ * @tparam CHUNK_SIZE chunk size for ChunkArray
  */
-template <uint32 CHUNKSIZE, typename T_REF>
+template <uint32 CHUNK_SIZE, typename T_REF>
 class ChunkArrayContainer
 {
 public:
 
-	using Self = ChunkArrayContainer<CHUNKSIZE, T_REF>;
+	using Self = ChunkArrayContainer<CHUNK_SIZE, T_REF>;
 	using ref_type = T_REF;
 
-	using ChunkArrayGen = cgogn::ChunkArrayGen<CHUNKSIZE>;
+	using ChunkArrayGen = cgogn::ChunkArrayGen<CHUNK_SIZE>;
 	template <class T>
-	using ChunkArray = cgogn::ChunkArray<CHUNKSIZE, T>;
-	using ChunkArrayBool = cgogn::ChunkArrayBool<CHUNKSIZE>;
+	using ChunkArray = cgogn::ChunkArray<CHUNK_SIZE, T>;
+	using ChunkArrayBool = cgogn::ChunkArrayBool<CHUNK_SIZE>;
 	template <class T>
-	using ChunkStack = cgogn::ChunkStack<CHUNKSIZE, T>;
-	using ChunkArrayFactory = cgogn::ChunkArrayFactory<CHUNKSIZE>;
+	using ChunkStack = cgogn::ChunkStack<CHUNK_SIZE, T>;
+	using ChunkArrayFactory = cgogn::ChunkArrayFactory<CHUNK_SIZE>;
 
 	/**
 	* constante d'attribut inconnu
@@ -591,9 +591,9 @@ public:
 		}while (!holes_stack_.empty());
 
 		// free unused memory blocks
-		const uint32 old_nb_blocks = this->nb_max_lines_/CHUNKSIZE + 1u;
+		const uint32 old_nb_blocks = this->nb_max_lines_/CHUNK_SIZE + 1u;
 		nb_max_lines_ = nb_used_lines_;
-		const uint32 new_nb_blocks = nb_max_lines_/CHUNKSIZE + 1u;
+		const uint32 new_nb_blocks = nb_max_lines_/CHUNK_SIZE + 1u;
 
 		if (old_nb_blocks == new_nb_blocks)
 			return map_old_new;
@@ -703,7 +703,7 @@ public:
 	template <uint32 PRIMSIZE>
 	uint32 insert_lines()
 	{
-		static_assert(PRIMSIZE < CHUNKSIZE, "Cannot insert lines in a container if PRIMSIZE < CHUNKSIZE");
+		static_assert(PRIMSIZE < CHUNK_SIZE, "Cannot insert lines in a container if PRIMSIZE < CHUNK_SIZE");
 
 		uint32 index;
 
@@ -718,9 +718,9 @@ public:
 				refs_.add_chunk();
 			}
 
-			if ((nb_max_lines_ + PRIMSIZE) % CHUNKSIZE < PRIMSIZE) // prim does not fit on current chunk? -> add chunk
+			if ((nb_max_lines_ + PRIMSIZE) % CHUNK_SIZE < PRIMSIZE) // prim does not fit on current chunk? -> add chunk
 			{
-				// nb_max_lines_ = refs_.get_nb_chunks() * CHUNKSIZE; // next index will be at start of new chunk
+				// nb_max_lines_ = refs_.get_nb_chunks() * CHUNK_SIZE; // next index will be at start of new chunk
 
 				for (auto arr : table_arrays_)
 					arr->add_chunk();

--- a/cgogn/core/container/chunk_array_factory.h
+++ b/cgogn/core/container/chunk_array_factory.h
@@ -37,16 +37,16 @@
 namespace cgogn
 {
 
-template <uint32 CHUNKSIZE>
+template <uint32 CHUNK_SIZE>
 class ChunkArrayFactory
 {
-	static_assert(CHUNKSIZE >= 1u, "ChunkSize must be at least 1");
-	static_assert(!(CHUNKSIZE & (CHUNKSIZE - 1)), "CHUNKSIZE must be a power of 2");
+	static_assert(CHUNK_SIZE >= 1u, "ChunkSize must be at least 1");
+	static_assert(!(CHUNK_SIZE & (CHUNK_SIZE - 1)), "CHUNK_SIZE must be a power of 2");
 
 public:
 
-	using Self = ChunkArrayFactory<CHUNKSIZE>;
-	using ChunkArrayGenPtr = std::unique_ptr< ChunkArrayGen<CHUNKSIZE> >;
+	using Self = ChunkArrayFactory<CHUNK_SIZE>;
+	using ChunkArrayGenPtr = std::unique_ptr< ChunkArrayGen<CHUNK_SIZE> >;
 	using NamePtrMap = std::map<std::string, ChunkArrayGenPtr>;
 	using UniqueNamePtrMap = std::unique_ptr<NamePtrMap>;
 
@@ -68,7 +68,7 @@ public:
 
 		std::string&& keyType(name_of_type(T()));
 		if(map_CA_->find(keyType) == map_CA_->end())
-			(*map_CA_)[std::move(keyType)] = make_unique<ChunkArray<CHUNKSIZE, T>>();
+			(*map_CA_)[std::move(keyType)] = make_unique<ChunkArray<CHUNK_SIZE, T>>();
 	}
 
 	static void register_known_types()
@@ -118,7 +118,7 @@ public:
 
 	static void reset()
 	{
-		ChunkArrayFactory<CHUNKSIZE>::map_CA_ = make_unique<NamePtrMap>();
+		ChunkArrayFactory<CHUNK_SIZE>::map_CA_ = make_unique<NamePtrMap>();
 	}
 
 private:
@@ -126,8 +126,8 @@ private:
 	inline ChunkArrayFactory() {}
 };
 
-template <uint32 CHUNKSIZE>
-typename ChunkArrayFactory<CHUNKSIZE>::UniqueNamePtrMap ChunkArrayFactory<CHUNKSIZE>::map_CA_ = nullptr;
+template <uint32 CHUNK_SIZE>
+typename ChunkArrayFactory<CHUNK_SIZE>::UniqueNamePtrMap ChunkArrayFactory<CHUNK_SIZE>::map_CA_ = nullptr;
 
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_CORE_CONTAINER_CHUNK_ARRAY_FACTORY_CPP_))
 extern template class CGOGN_CORE_API ChunkArrayFactory<DEFAULT_CHUNK_SIZE>;

--- a/cgogn/core/container/chunk_array_gen.h
+++ b/cgogn/core/container/chunk_array_gen.h
@@ -40,12 +40,12 @@ static const uint32 DEFAULT_CHUNK_SIZE = 4096;
 /**
  * @brief Virtual version of ChunkArray
  */
-template <uint32 CHUNKSIZE>
+template <uint32 CHUNK_SIZE>
 class ChunkArrayGen
 {
 public:
 
-	using Self = ChunkArrayGen<CHUNKSIZE>;
+	using Self = ChunkArrayGen<CHUNK_SIZE>;
 
 	inline ChunkArrayGen(const std::string& name, const std::string& type_name) :
 		name_(name),
@@ -112,7 +112,7 @@ public:
 //	virtual bool is_boolean_array() const = 0;
 
 	/**
-	 * @brief add a chunk (T[CHUNKSIZE])
+	 * @brief add a chunk (T[CHUNK_SIZE])
 	 */
 	virtual void add_chunk() = 0;
 
@@ -142,7 +142,7 @@ public:
 	/**
 	 * @brief fill a vector with pointers to all chunks
 	 * @param addr vector to fill
-	 * @param byte_block_size filled with CHUNKSIZE*sizeof(T)
+	 * @param byte_block_size filled with CHUNK_SIZE*sizeof(T)
 	 * @return addr.size()
 	 */
 	virtual uint32 get_chunks_pointers(std::vector<void*>& addr, uint32& byte_block_size) const = 0;

--- a/cgogn/core/container/chunk_stack.h
+++ b/cgogn/core/container/chunk_stack.h
@@ -33,15 +33,15 @@ namespace cgogn
 
 /**
  * @brief Heap implemented in a chunk array
- * @tparam CHUNKSIZE chunk size of array
+ * @tparam CHUNK_SIZE chunk size of array
  * @tparam T type stored in heap
  */
-template <uint32 CHUNKSIZE, typename T>
-class ChunkStack : public ChunkArray<CHUNKSIZE, T>
+template <uint32 CHUNK_SIZE, typename T>
+class ChunkStack : public ChunkArray<CHUNK_SIZE, T>
 {
 public:
-	using Inherit = ChunkArray<CHUNKSIZE, T>;
-	using Self = ChunkStack<CHUNKSIZE, T>;
+	using Inherit = ChunkArray<CHUNK_SIZE, T>;
+	using Self = ChunkStack<CHUNK_SIZE, T>;
 	using value_type = T;
 
 protected:
@@ -72,8 +72,8 @@ public:
 	void push(const T& val)
 	{
 		stack_size_++;
-		uint32 offset = stack_size_ % CHUNKSIZE;
-		uint32 blkId  = stack_size_ / CHUNKSIZE;
+		uint32 offset = stack_size_ % CHUNK_SIZE;
+		uint32 blkId  = stack_size_ / CHUNK_SIZE;
 
 		if (blkId >= this->table_data_.size())
 			this->add_chunk();
@@ -113,8 +113,8 @@ public:
 	 */
 	inline T head() const
 	{
-		const uint32 offset = stack_size_ % CHUNKSIZE;
-		const uint32 blkId  = stack_size_ / CHUNKSIZE;
+		const uint32 offset = stack_size_ % CHUNK_SIZE;
+		const uint32 blkId  = stack_size_ / CHUNK_SIZE;
 
 		return this->table_data_[blkId][offset];
 	}
@@ -124,7 +124,7 @@ public:
 	 */
 	void compact()
 	{
-		const uint32 keep = (stack_size_+CHUNKSIZE-1u) / CHUNKSIZE;
+		const uint32 keep = (stack_size_+CHUNK_SIZE-1u) / CHUNK_SIZE;
 		while (this->table_data_.size() > keep)
 		{
 			delete[] this->table_data_.back();
@@ -141,7 +141,7 @@ public:
 		Inherit::clear();
 	}
 
-	bool swap(ChunkArrayGen<CHUNKSIZE>* cag) override
+	bool swap(ChunkArrayGen<CHUNK_SIZE>* cag) override
 	{
 		if (Inherit::swap(cag))
 		{

--- a/cgogn/rendering/shaders/vbo.h
+++ b/cgogn/rendering/shaders/vbo.h
@@ -170,9 +170,9 @@ void update_vbo(const ATTR& attr, VBO* vbo)
 	uint32 nb_chunks = ca->get_chunks_pointers(chunk_addr, byte_chunk_size);
 	const uint32 vec_dim = geometry::nb_components_traits<typename ATTR::value_type>::value;
 
-	vbo->allocate(nb_chunks * ATTR::CHUNKSIZE, vec_dim);
+	vbo->allocate(nb_chunks * ATTR::CHUNK_SIZE, vec_dim);
 
-	const uint32 vbo_blk_bytes =  ATTR::CHUNKSIZE * vec_dim * sizeof(float32);
+	const uint32 vbo_blk_bytes =  ATTR::CHUNK_SIZE * vec_dim * sizeof(float32);
 
 	if (std::is_same<typename geometry::vector_traits<typename ATTR::value_type>::Scalar, float32>::value)
 	{
@@ -185,16 +185,16 @@ void update_vbo(const ATTR& attr, VBO* vbo)
 	else if (std::is_same<typename geometry::vector_traits<typename ATTR::value_type>::Scalar, float64>::value)
 	{
 		// copy (after conversion to float)
-		float32* float_buffer = new float32[ATTR::CHUNKSIZE * vec_dim];
+		float32* float_buffer = new float32[ATTR::CHUNK_SIZE * vec_dim];
 		for (uint32 i = 0; i < nb_chunks; ++i)
 		{
 			// transform double into float
 			float32* fit = float_buffer;
 			float64* src = reinterpret_cast<float64*>(chunk_addr[i]);
-			for (uint32 j = 0; j < ATTR::CHUNKSIZE * vec_dim; ++j)
+			for (uint32 j = 0; j < ATTR::CHUNK_SIZE * vec_dim; ++j)
 				*fit++ = *src++;
 			vbo->bind();
-			vbo->copy_data(i* ATTR::CHUNKSIZE * vec_dim * sizeof(float32), ATTR::CHUNKSIZE * vec_dim * sizeof(float32),float_buffer);
+			vbo->copy_data(i* ATTR::CHUNK_SIZE * vec_dim * sizeof(float32), ATTR::CHUNK_SIZE * vec_dim * sizeof(float32),float_buffer);
 			vbo->release();
 		}
 		delete[] float_buffer;
@@ -243,7 +243,7 @@ void update_vbo(const ATTR& attr, VBO* vbo, const FUNC& convert)
 	else if (check_func_return_type(FUNC,Vec4f) )
 		vec_dim = 4;
 
-	vbo->allocate(nb_chunks * ATTR::CHUNKSIZE, vec_dim);
+	vbo->allocate(nb_chunks * ATTR::CHUNK_SIZE, vec_dim);
 
 	// copy (after conversion)
 	using OutputConvert = typename function_traits<FUNC>::result_type;
@@ -251,7 +251,7 @@ void update_vbo(const ATTR& attr, VBO* vbo, const FUNC& convert)
 	for (uint32 i = 0; i < nb_chunks; ++i)
 	{
 		InputConvert* typed_chunk = static_cast<InputConvert*>(chunk_addr[i]);
-		for (uint32 j = 0; j < ATTR::CHUNKSIZE; ++j)
+		for (uint32 j = 0; j < ATTR::CHUNK_SIZE; ++j)
 			*dst++ = convert(typed_chunk[j]);
 	}
 
@@ -313,7 +313,7 @@ void update_vbo(const ATTR& attr, const ATTR2& attr2, VBO* vbo, const FUNC& conv
 		vec_dim = 4;
 
 	// allocate vbo
-	vbo->allocate(nb_chunks * ATTR::CHUNKSIZE, vec_dim);
+	vbo->allocate(nb_chunks * ATTR::CHUNK_SIZE, vec_dim);
 
 	// copy (after conversion)
 	// out type conversion
@@ -323,7 +323,7 @@ void update_vbo(const ATTR& attr, const ATTR2& attr2, VBO* vbo, const FUNC& conv
 	{
 		InputConvert* typed_chunk = static_cast<InputConvert*>(chunk_addr[i]);
 		InputConvert2* typed_chunk2 = static_cast<InputConvert2*>(chunk_addr2[i]);
-		for (uint32 j = 0; j < ATTR::CHUNKSIZE; ++j)
+		for (uint32 j = 0; j < ATTR::CHUNK_SIZE; ++j)
 			*dst++ = convert(typed_chunk[j],typed_chunk2[j]);
 	}
 


### PR DESCRIPTION
Une nouvelle classe permettant de travailler avec un attribut sans avoir à connaître son orbite.
Remplace la classe AttributeOrbit dont l'intérêt restait à démontrer.
