### PR TITLE
nano-PR : fixed compile definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,13 +116,6 @@ endif(CGOGN_BUILD_TESTS)
 #### Endianness detection
 include (TestBigEndian)
 test_big_endian(CGOGN_TEST_BIG_ENDIAN)
-add_definitions("-DCGOGN_LITTLE_ENDIAN=1234")
-add_definitions("-DCGOGN_BIG_ENDIAN=4321")
-if(${CGOGN_TEST_BIG_ENDIAN})
-	add_definitions("-DCGOGN_ENDIANNESS=CGOGN_BIG_ENDIAN")
-else()
-	add_definitions("-DCGOGN_ENDIANNESS=CGOGN_LITTLE_ENDIAN")
-endif()
 
 #### Link time optimisation
 if (CGOGN_ENABLE_LTO AND ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") AND (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))

--- a/cgogn/core/CMakeLists.txt
+++ b/cgogn/core/CMakeLists.txt
@@ -128,6 +128,15 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 	$<INSTALL_INTERFACE:include>
 )
 
+
+target_compile_options(${PROJECT_NAME} PUBLIC "-DCGOGN_LITTLE_ENDIAN=1234")
+target_compile_options(${PROJECT_NAME} PUBLIC "-DCGOGN_BIG_ENDIAN=4321")
+if(CGOGN_TEST_BIG_ENDIAN)
+	target_compile_options(${PROJECT_NAME} PUBLIC "-DCGOGN_ENDIANNESS=CGOGN_BIG_ENDIAN")
+else()
+	target_compile_options(${PROJECT_NAME} PUBLIC "-DCGOGN_ENDIANNESS=CGOGN_LITTLE_ENDIAN")
+endif()
+
 install(FILES "dll.h" DESTINATION "include/cgogn/core/")
 install(DIRECTORY basic cmap container utils
 	DESTINATION "include/cgogn/core/"

--- a/cgogn/io/mesh_io_gen.h
+++ b/cgogn/io/mesh_io_gen.h
@@ -112,7 +112,7 @@ public:
 		}
 
 		this->export_file_impl(map,*output, options);
-		map.remove_attribute(indices_);
+		this->clean_added_attributes(map);
 	}
 
 	virtual ~MeshExport() {}
@@ -120,6 +120,11 @@ protected:
 	inline std::vector<ChunkArrayGen*> const & vertex_attributes() const
 	{
 		return vertex_attributes_;
+	}
+
+	virtual void clean_added_attributes(Map& map)
+	{
+		map.remove_attribute(indices_);
 	}
 
 	ChunkArrayGen const * position_attribute() const

--- a/cgogn/io/surface_export.h
+++ b/cgogn/io/surface_export.h
@@ -67,6 +67,11 @@ protected:
 	{
 		return face_attributes_;
 	}
+
+	void clean_added_attributes(Map& map) override
+	{
+		Inherit::clean_added_attributes(map);
+	}
 private:
 
 	virtual void prepare_for_export(Map& map, const ExportOptions& options) override

--- a/cgogn/io/volume_export.h
+++ b/cgogn/io/volume_export.h
@@ -213,6 +213,12 @@ public:
 		}, *(this->cell_cache_));
 	}
 
+	void clean_added_attributes(Map& map) override
+	{
+		Inherit::clean_added_attributes(map);
+		map.remove_attribute(vertices_of_volumes_);
+	}
+
 	inline uint32 nb_tetras() const
 	{
 		return nb_tetras_;

--- a/cgogn/io/vtk_io.h
+++ b/cgogn/io/vtk_io.h
@@ -1237,6 +1237,7 @@ protected:
 				if (to_lower(std::string(cell_data->Attribute("Name"))) == "connectivity" && (cell_data != cell_nodes.back()))
 				{
 					std::swap(cell_data, cell_nodes.back());
+					break;
 				}
 			}
 

--- a/cgogn/io/vtk_io.h
+++ b/cgogn/io/vtk_io.h
@@ -819,8 +819,8 @@ private:
 						const char* elem =  static_cast<const char*>(att->element_ptr(map.embedding(w)));
 						for(uint32 i = 0u; i < elem_size; ++i)
 							buffer_char.push_back(elem[i]);
-						write_binary_xml_data(output,&buffer_char[0], buffer_char.size(), option.compress_);
 					}, *(this->cell_cache_));
+					write_binary_xml_data(output,&buffer_char[0], buffer_char.size(), option.compress_);
 					output << std::endl;
 				} else {
 					map.foreach_cell([&](Volume w)


### PR DESCRIPTION
this is necessary when doing IO with schnapps (or other cmake projects using cgogn).
