### PR TITLE
remove attribute with name, some cleaning in the mesh import

### DIFF
--- a/cgogn/core/basic/cell_marker.h
+++ b/cgogn/core/basic/cell_marker.h
@@ -155,6 +155,13 @@ public:
 		marked_cells_->push_back(this->map_.embedding(c));
 	}
 
+	inline void unmark(Cell<ORBIT> c)
+	{
+		cgogn_message_assert(this->mark_attribute_ != nullptr, "CellMarkerStore has null mark attribute");
+		Inherit::unmark(c);
+		marked_cells_->erase(std::remove(marked_cells_->begin(), marked_cells_->end(), this->map_.embedding(c)), marked_cells_->end());
+	}
+
 	inline void unmark_all()
 	{
 		cgogn_message_assert(this->mark_attribute_ != nullptr, "CellMarkerStore has null mark attribute");

--- a/cgogn/core/basic/dart.h
+++ b/cgogn/core/basic/dart.h
@@ -39,7 +39,7 @@ namespace cgogn
 {
 
 // MSVC doesn't support  std::numeric_limits<uint32>::max() when declaring static const variables
-static const uint32 INVALID_INDEX = UINT_MAX;
+static const uint32 INVALID_INDEX = UINT32_MAX;
 
 /**
  * \brief Dart.

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -64,6 +64,8 @@ public:
 	template <typename T>
 	using ChunkArray = typename Inherit::template ChunkArray<T>;
 	using typename Inherit::ChunkArrayBool;
+	template <typename T_REF>
+	using ChunkArrayContainer = typename Inherit::template ChunkArrayContainer<T_REF>;
 
 	using AttributeGen = cgogn::AttributeGen<MAP_TRAITS>;
 	template <typename T>
@@ -232,6 +234,12 @@ public:
 	 * Attributes management
 	 *******************************************************************************/
 
+	inline bool has_attribute(Orbit orbit, const std::string& att_name)
+	{
+		cgogn_message_assert(orbit < NB_ORBITS, "Unknown orbit parameter");
+		return this->attributes_[orbit].has_array(att_name);
+	}
+
 	/**
 	 * \brief add an attribute
 	 * @param attribute_name the name of the attribute to create
@@ -259,6 +267,18 @@ public:
 
 		const ChunkArray<T>* ca = ah.data();
 		return this->attributes_[ORBIT].remove_chunk_array(ca);
+	}
+
+	/**
+	 * \brief remove_attribute
+	 * @param orbit, the attribute orbit
+	 * @param att_name attribute name
+	 * @return true if remove succeed else false
+	 */
+	inline bool remove_attribute(Orbit orbit, const std::string& att_name)
+	{
+		cgogn_message_assert(orbit < NB_ORBITS, "Unknown orbit parameter");
+		return this->attributes_[orbit].remove_chunk_array(att_name);
 	}
 
 	/**
@@ -457,7 +477,7 @@ public:
 		Attribute<std::vector<CellType>, ORBIT> counter = add_attribute<std::vector<CellType>, ORBIT>("__tmp_dart_per_emb");
 		bool result = true;
 
-		const typename Inherit::template ChunkArrayContainer<uint32>& container = this->attributes_[ORBIT];
+		const ChunkArrayContainer<uint32>& container = this->attributes_[ORBIT];
 
 		// Check that the indexation of cells is correct
 		foreach_cell<FORCE_DART_MARKING>([&] (CellType c)

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -256,6 +256,34 @@ public:
 	}
 
 	/**
+	 * @brief add an attribute, given a ref on an existing attribute
+	 * @param result_attribute, a reference to an attribute that will be overwritten
+	 * @param attribute_name the name of the attribute to create
+	 */
+	template <typename T, Orbit ORBIT>
+	inline void add_attribute(Attribute<T, ORBIT>& attribute_handler, const std::string& attribute_name)
+	{
+		attribute_handler = add_attribute<T,ORBIT>(attribute_name);
+	}
+
+	/**
+	 * @brief init_attribute, init an uninitialized Attribute<T,ORBIT> object (does nothing if the attribute_handler param is already valid)
+	 */
+	template <typename T, Orbit ORBIT>
+	inline void init_attribute(Attribute<T, ORBIT>& attribute_handler, const std::string& attribute_name)
+	{
+		if (attribute_handler.is_valid())
+		{
+			cgogn_log_debug("init_attribute(Attribute<T, ORBIT>&,const std::string&)") << "The attribute \"" << attribute_handler.name() << "\" is already initialized.";
+			return;
+		}
+
+		add_attribute(attribute_handler, attribute_name);
+		if (!attribute_handler.is_valid())
+			get_attribute(attribute_handler, attribute_name);
+	}
+
+	/**
 	 * \brief remove an attribute
 	 * @param ah a handler to the attribute to remove
 	 * @return true if remove succeed else false
@@ -295,6 +323,12 @@ public:
 		return Attribute<T, ORBIT>(this, ca);
 	}
 
+	template <typename T, Orbit ORBIT>
+	inline void get_attribute(Attribute<T, ORBIT>& ah, const std::string& attribute_name)
+	{
+		ah = get_attribute<T,ORBIT>(attribute_name);
+	}
+
 	template <typename T>
 	inline Attribute_T<T> get_attribute(Orbit orbit, const std::string& attribute_name)
 	{
@@ -302,6 +336,12 @@ public:
 
 		ChunkArray<T>* ca = this->attributes_[orbit].template get_chunk_array<T>(attribute_name);
 		return Attribute_T<T>(this, ca, orbit);
+	}
+
+	template <typename T>
+	inline void get_attribute(Attribute_T<T>& ath, Orbit orbit, const std::string& attribute_name)
+	{
+		ath = get_attribute<T>(orbit, attribute_name);
 	}
 
 	/**

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -246,7 +246,7 @@ public:
 	 * @return a handler to the created attribute
 	 */
 	template <typename T, Orbit ORBIT>
-	inline Attribute<T, ORBIT> add_attribute(const std::string& attribute_name = "")
+	inline Attribute<T, ORBIT> add_attribute(const std::string& attribute_name)
 	{
 		static_assert(ORBIT < NB_ORBITS, "Unknown orbit parameter");
 		if (!this->template is_embedded<ORBIT>())

--- a/cgogn/core/container/chunk_array.h
+++ b/cgogn/core/container/chunk_array.h
@@ -37,6 +37,7 @@
 #include <cgogn/core/utils/assert.h>
 #include <cgogn/core/utils/logger.h>
 #include <cgogn/core/utils/endian.h>
+#include <cgogn/core/utils/string.h>
 
 namespace cgogn
 {
@@ -450,6 +451,12 @@ public:
 		}
 	}
 
+	virtual void import_element(uint32 idx, std::istream& in) override
+	{
+		serialization::parse(in, this->operator [](idx));
+	}
+
+
 	virtual const void* element_ptr(uint32 idx) const override
 	{
 		return &(this->operator[](idx));
@@ -457,7 +464,7 @@ public:
 
 	virtual uint32 element_size() const override
 	{
-		return sizeof(this->operator[](0ul));
+		return sizeof(std::declval<T>());
 	}
 };
 
@@ -813,6 +820,18 @@ public:
 	virtual void export_element(uint32 idx, std::ostream& o, bool binary, bool little_endian, std::size_t /*precision*/) const override
 	{
 		serialization::ostream_writer(o, this->operator[](idx),binary, little_endian);
+	}
+
+	virtual void import_element(uint32 idx, std::istream& in) override
+	{
+		std::string val;
+		in >> val;
+		val = to_lower(val);
+		const bool b = (val == "true") || (std::stoi(val) == 1);
+		if (b)
+			set_true(idx);
+		else
+			set_false(idx);
 	}
 
 	virtual const void* element_ptr(uint32) const override

--- a/cgogn/core/container/chunk_array_container.h
+++ b/cgogn/core/container/chunk_array_container.h
@@ -68,7 +68,7 @@ public:
 	/**
 	* constante d'attribut inconnu
 	*/
-	static const uint32 UNKNOWN = UINT_MAX;
+	static const uint32 UNKNOWN = UINT32_MAX;
 
 protected:
 
@@ -185,8 +185,20 @@ public:
 			delete ptr;
 	}
 
-	const std::vector<std::string>& names() const { return names_; }
-	const std::vector<std::string>& type_names() const { return type_names_; }
+	inline const std::vector<std::string>& names() const
+	{
+		return names_;
+	}
+
+	inline const std::vector<std::string>& type_names() const
+	{
+		return type_names_;
+	}
+
+	inline bool has_array(const std::string& array_name) const
+	{
+		return array_index(array_name) != UNKNOWN;
+	}
 
 	/**
 	 * @brief get a chunk array

--- a/cgogn/core/container/chunk_array_gen.h
+++ b/cgogn/core/container/chunk_array_gen.h
@@ -201,6 +201,12 @@ public:
 
 	virtual void export_element(uint32 idx, std::ostream& o, bool binary, bool little_endian, std::size_t precision = 8ul) const = 0;
 	/**
+	 * @brief import_element, read the element "idx" from an ascii istream
+	 * @param idx
+	 * @param i
+	 */
+	virtual void import_element(uint32 idx, std::istream& in) = 0;
+	/**
 	 * @brief element_ptr
 	 * @return a generic pointer to the element of index idx.
 	 * Use with caution. This method can't be used with ChunkArrayBool.

--- a/cgogn/core/utils/serialization.h
+++ b/cgogn/core/utils/serialization.h
@@ -55,6 +55,63 @@ void save(std::ostream& ostream, T const* src, std::size_t quantity)
 	ostream.write(reinterpret_cast<const char*>(src), static_cast<std::streamsize>(quantity*sizeof(T)));
 }
 
+template<typename T>
+inline typename std::enable_if<!type_traits::has_size_method<T>::value, std::size_t>::type size(const T& x);
+template<typename T>
+inline typename std::enable_if<type_traits::has_size_method<T>::value, std::size_t>::type size(const T& x);
+
+template<typename T>
+inline typename std::enable_if<!type_traits::has_size_method<T>::value, std::size_t>::type size(const T& x)
+{
+	return 1;
+}
+
+template<typename T>
+inline typename std::enable_if<type_traits::has_size_method<T>::value, std::size_t>::type size(const T& x)
+{
+	return x.size();
+}
+
+template <typename T>
+inline typename std::enable_if<!type_traits::has_size_method<T>::value || std::is_same<T,std::string>::value, void>::type parse(std::istream& iss, T& x);
+template <typename T>
+inline typename std::enable_if<type_traits::has_size_method<T>::value && type_traits::is_iterable<T>::value && !std::is_same<T,std::string>::value, void>::type parse(std::istream& iss, T& x);
+template <typename T>
+inline typename std::enable_if<type_traits::has_size_method<T>::value && !type_traits::is_iterable<T>::value && !std::is_same<T,std::string>::value && (!type_traits::has_cols_method<T>::value || !type_traits::has_rows_method<T>::value), void>::type parse(std::istream& iss, T& x);
+template <typename T>
+inline typename std::enable_if<type_traits::has_size_method<T>::value && !type_traits::is_iterable<T>::value && !std::is_same<T,std::string>::value &&  type_traits::has_cols_method<T>::value && type_traits::has_rows_method<T>::value, void>::type parse(std::istream& iss, T& x);
+
+
+
+template <typename T>
+inline typename std::enable_if<!type_traits::has_size_method<T>::value || std::is_same<T,std::string>::value, void>::type parse(std::istream& iss, T& x)
+{
+	iss >> x;
+}
+
+template <typename T>
+inline typename std::enable_if<type_traits::has_size_method<T>::value && type_traits::is_iterable<T>::value && !std::is_same<T,std::string>::value, void>::type parse(std::istream& iss, T& x)
+{
+	for (auto& elem : x)
+		parse(iss, elem);
+}
+
+template <typename T>
+inline typename std::enable_if<type_traits::has_size_method<T>::value && !type_traits::is_iterable<T>::value && !std::is_same<T,std::string>::value && (!type_traits::has_cols_method<T>::value || !type_traits::has_rows_method<T>::value), void>::type parse(std::istream& iss, T& x)
+{
+	for (std::size_t i = 0u , end = size(x); i < end; ++i)
+		parse(iss, x[i]);
+}
+
+template <typename T>
+inline typename std::enable_if<type_traits::has_size_method<T>::value && !type_traits::is_iterable<T>::value && !std::is_same<T,std::string>::value &&  type_traits::has_cols_method<T>::value && type_traits::has_rows_method<T>::value, void>::type parse(std::istream& iss, T& x)
+{
+	for (std::size_t r = 0, rend = x.rows(); r < rend ; ++r)
+		for (std::size_t c = 0, cend = x.cols(); c < cend ; ++c)
+			parse(iss,x(r,c));
+}
+
+
 template <typename T, std::size_t Precision = 8ul>
 inline typename std::enable_if<!type_traits::has_size_method<T>::value, void>::type ostream_writer(std::ostream& o, const T& x, bool binary = false, bool little_endian = internal::cgogn_is_little_endian);
 template <typename T, std::size_t Precision = 8ul>

--- a/cgogn/geometry/examples/filtering.cpp
+++ b/cgogn/geometry/examples/filtering.cpp
@@ -142,17 +142,17 @@ void Viewer::import(const std::string& surface_mesh)
 {
 	cgogn::io::import_surface<Vec3>(map_, surface_mesh);
 
-	vertex_position_ = map_.get_attribute<Vec3, Vertex::ORBIT>("position");
+	map_.get_attribute(vertex_position_, "position");
 	if (!vertex_position_.is_valid())
 	{
 		cgogn_log_error("Viewer::import") << "Missing attribute position. Aborting.";
 		std::exit(EXIT_FAILURE);
 	}
 
-	vertex_position2_ = map_.add_attribute<Vec3, Vertex::ORBIT>("position2");
+	map_.add_attribute(vertex_position2_, "position2");
 	map_.copy_attribute(vertex_position2_, vertex_position_);
 
-	vertex_normal_ = map_.add_attribute<Vec3, Vertex::ORBIT>("normal");
+	map_.add_attribute(vertex_normal_, "normal");
 	cgogn::geometry::compute_normal<Vec3>(map_, vertex_position_, vertex_normal_);
 
 	cell_cache_.build<Vertex>();

--- a/cgogn/io/data_io.h
+++ b/cgogn/io/data_io.h
@@ -190,12 +190,14 @@ public:
 				// we need to avoid the specialization of istringstream operator>> for chars
 				using type = typename std::conditional<sizeof(BUFFER_T) == sizeof(char), int, BUFFER_T>::type;
 				type buff;
-				bool no_error = static_cast<bool>(internal::parse(line_stream, buff));
+				serialization::parse(line_stream, buff);
+				bool no_error = static_cast<bool>(line_stream);
 				while (i < n && no_error)
 				{
 					data_[i+old_size] = internal::convert<T>(buff);
 					++i;
-					no_error = static_cast<bool>(internal::parse(line_stream, buff));
+					serialization::parse(line_stream, buff);
+					no_error = static_cast<bool>(line_stream);
 				}
 				if (!no_error && (!line_stream.eof()))
 					break;

--- a/cgogn/io/io_utils.h
+++ b/cgogn/io/io_utils.h
@@ -169,21 +169,6 @@ inline auto convert(const T& x) -> typename std::enable_if<!std::is_arithmetic<T
 }
 
 
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, std::istream&>::type parse(std::istream& iss, T& x)
-{
-	iss >> x;
-	return iss;
-}
-
-template <typename T>
-inline typename std::enable_if<!std::is_arithmetic<T>::value, std::istream&>::type parse(std::istream& iss, T& x)
-{
-	for (std::size_t i = 0u ; i < geometry::vector_traits<T>::SIZE; ++i)
-		iss >> x[i];
-	return iss;
-}
-
 } // namespace internal
 
 

--- a/cgogn/io/lm6_io.h
+++ b/cgogn/io/lm6_io.h
@@ -34,14 +34,13 @@ namespace io
 {
 
 template <typename MAP_TRAITS, typename VEC3>
-class LM6VolumeImport : public VolumeImport<MAP_TRAITS>
+class LM6VolumeImport : public VolumeFileImport<MAP_TRAITS>
 {
-	using Inherit = VolumeImport<MAP_TRAITS>;
+	using Inherit = VolumeFileImport<MAP_TRAITS>;
 	using Self = LM6VolumeImport<MAP_TRAITS,VEC3>;
 	template <typename T>
 	using ChunkArray = typename Inherit::template ChunkArray<T>;
 
-	// MeshImportGen interface
 public:
 	inline LM6VolumeImport() {}
 	CGOGN_NOT_COPYABLE_NOR_MOVABLE(LM6VolumeImport);

--- a/cgogn/io/map_import.h
+++ b/cgogn/io/map_import.h
@@ -51,10 +51,10 @@ namespace io
 {
 
 template <typename MAP_TRAITS, typename VEC3>
-inline std::unique_ptr<SurfaceImport<MAP_TRAITS>> newSurfaceImport(const std::string& filename);
+inline std::unique_ptr<SurfaceFileImport<MAP_TRAITS>> newSurfaceImport(const std::string& filename);
 
 template <typename MAP_TRAITS, typename VEC3>
-inline std::unique_ptr<VolumeImport<MAP_TRAITS>> newVolumeImport(const std::string& filename);
+inline std::unique_ptr<VolumeFileImport<MAP_TRAITS>> newVolumeImport(const std::string& filename);
 
 template <typename VEC3, typename MAP2>
 inline void import_surface(MAP2& cmap2, const std::string& filename);
@@ -88,7 +88,7 @@ inline void import_volume(MAP3& cmap3, const std::string& filename)
 }
 
 template <typename MAP_TRAITS, typename VEC3>
-inline std::unique_ptr<SurfaceImport<MAP_TRAITS>> newSurfaceImport(const std::string& filename)
+inline std::unique_ptr<SurfaceFileImport<MAP_TRAITS>> newSurfaceImport(const std::string& filename)
 {
 	const FileType ft = file_type(filename);
 	switch (ft)
@@ -102,12 +102,12 @@ inline std::unique_ptr<SurfaceImport<MAP_TRAITS>> newSurfaceImport(const std::st
 		case FileType::FileType_STL: return make_unique<StlSurfaceImport<MAP_TRAITS, VEC3>>();
 		default:
 			cgogn_log_warning("newSurfaceImport") << "SurfaceImport does not handle files with extension \"" << extension(filename) << "\".";
-			return std::unique_ptr<SurfaceImport<MAP_TRAITS>> ();
+			return std::unique_ptr<SurfaceFileImport<MAP_TRAITS>> ();
 	}
 }
 
 template <typename MAP_TRAITS, typename VEC3>
-inline std::unique_ptr<VolumeImport<MAP_TRAITS> > newVolumeImport(const std::string& filename)
+inline std::unique_ptr<VolumeFileImport<MAP_TRAITS> > newVolumeImport(const std::string& filename)
 {
 	const FileType ft = file_type(filename);
 	switch (ft)
@@ -121,7 +121,7 @@ inline std::unique_ptr<VolumeImport<MAP_TRAITS> > newVolumeImport(const std::str
 		case FileType::FileType_AIMATSHAPE:	return make_unique<TetVolumeImport<MAP_TRAITS, VEC3>>();
 		default:
 			cgogn_log_warning("VolumeImport") << "VolumeImport does not handle files with extension \"" << extension(filename) << "\".";
-			return std::unique_ptr<VolumeImport<MAP_TRAITS>> ();
+			return std::unique_ptr<VolumeFileImport<MAP_TRAITS>> ();
 	}
 }
 

--- a/cgogn/io/mesh_io_gen.cpp
+++ b/cgogn/io/mesh_io_gen.cpp
@@ -35,11 +35,10 @@ namespace cgogn
 namespace io
 {
 
-MeshImportGen::~MeshImportGen() {}
+FileImport::FileImport() {}
 
-bool MeshImportGen::import_file(const std::string& filename)
+bool FileImport::import_file(const std::string& filename)
 {
-	this->clear();
 	Scoped_C_Locale loc;
 
 	if (!filename.empty())
@@ -48,12 +47,17 @@ bool MeshImportGen::import_file(const std::string& filename)
 		std::ifstream fp(filename.c_str(), std::ios::in);
 		if (!fp.good())
 		{
-			cgogn_log_warning("MeshImportGen::import_file") << "Unable to open file \"" << filename << "\"";
+			cgogn_log_warning("FileImport::import_file") << "Unable to open file \"" << filename << "\"";
 			return false;
 		}
 	}
 
 	return this->import_file_impl(filename);
+}
+
+FileImport::~FileImport()
+{
+
 }
 
 } // namespace io

--- a/cgogn/io/mesh_io_gen.h
+++ b/cgogn/io/mesh_io_gen.h
@@ -37,35 +37,22 @@ namespace cgogn
 namespace io
 {
 
-class CGOGN_IO_API MeshImportGen
+class CGOGN_IO_API FileImport
 {
 public:
-	using Self = MeshImportGen;
-	inline MeshImportGen() {}
-	CGOGN_NOT_COPYABLE_NOR_MOVABLE(MeshImportGen);
+	using Self = FileImport;
 
-
+	FileImport();
+	CGOGN_NOT_COPYABLE_NOR_MOVABLE(FileImport);
+	/**
+	 * @brief import_file, try to open and read a file (during the operation the C locale is used)
+	 * @param filename
+	 * @return true iff the file is successfully read
+	 */
 	bool import_file(const std::string& filename);
-	virtual ~MeshImportGen();
-	virtual void clear() = 0;
-
+	virtual ~FileImport();
 protected:
 	virtual bool import_file_impl(const std::string& filename) = 0;
-
-	/**
-	 * @brief skip_empty_lines
-	 * @param a valid data_stream
-	 * @return the first non-empty encountered line
-	 */
-	inline static std::string skip_empty_lines(std::istream& data_stream)
-	{
-		std::string line;
-		line.reserve(1024ul);
-		while(data_stream.good() && line.empty())
-			std::getline(data_stream,line);
-
-		return line;
-	}
 };
 
 template<typename MAP>

--- a/cgogn/io/mesh_io_gen.h
+++ b/cgogn/io/mesh_io_gen.h
@@ -87,7 +87,7 @@ public:
 		if (!output || !output->good())
 			return;
 
-		indices_ = map.template add_attribute<uint32,Vertex::ORBIT>("indices_vert_export");
+		map.add_attribute(indices_, "indices_vert_export");
 
 		this->prepare_for_export(map, options);
 

--- a/cgogn/io/msh_io.h
+++ b/cgogn/io/msh_io.h
@@ -131,16 +131,13 @@ private:
 };
 
 template <typename MAP_TRAITS, typename VEC3>
-class MshVolumeImport : public MshIO<MAP_TRAITS::CHUNK_SIZE, CMap3<MAP_TRAITS>::PRIM_SIZE, VEC3>, public VolumeImport<MAP_TRAITS>
+class MshVolumeImport : public MshIO<MAP_TRAITS::CHUNK_SIZE, CMap3<MAP_TRAITS>::PRIM_SIZE, VEC3>, public VolumeFileImport<MAP_TRAITS>
 {
 public:
 
 	using Self = MshVolumeImport<MAP_TRAITS, VEC3>;
 	using Inherit_Msh = MshIO<MAP_TRAITS::CHUNK_SIZE, CMap3<MAP_TRAITS>::PRIM_SIZE, VEC3>;
-	using Inherit_Import = VolumeImport<MAP_TRAITS>;
-//	using DataInputGen = typename Inherit_Msh::DataInputGen;
-//	template <typename T>
-//	using DataInput = typename Inherit_Msh::template DataInput<T>;
+	using Inherit_Import = VolumeFileImport<MAP_TRAITS>;
 	using MSH_CELL_TYPES = typename Inherit_Msh::MSH_CELL_TYPES;
 	template <typename T>
 	using ChunkArray = typename Inherit_Import::template ChunkArray<T>;
@@ -153,8 +150,17 @@ public:
 	virtual ~MshVolumeImport() override
 	{}
 
-	// MeshImportGen interface
 protected:
+
+	inline static std::string skip_empty_lines(std::istream& data_stream)
+	{
+		std::string line;
+		line.reserve(1024ul);
+		while(data_stream.good() && line.empty())
+			std::getline(data_stream,line);
+
+		return line;
+	}
 
 	inline bool import_legacy_msh_file(std::istream& data_stream)
 	{

--- a/cgogn/io/nastran_io.h
+++ b/cgogn/io/nastran_io.h
@@ -74,15 +74,14 @@ public:
 };
 
 template <typename MAP_TRAITS, typename VEC3>
-class NastranVolumeImport : public NastranIO<VEC3>, public VolumeImport<MAP_TRAITS>
+class NastranVolumeImport : public NastranIO<VEC3>, public VolumeFileImport<MAP_TRAITS>
 {
 	using Inherit_Nastran = NastranIO<VEC3>;
-	using Inherit_Import = VolumeImport<MAP_TRAITS>;
+	using Inherit_Import = VolumeFileImport<MAP_TRAITS>;
 	using Self = NastranVolumeImport<MAP_TRAITS, VEC3>;
 	template <typename T>
 	using ChunkArray = typename Inherit_Import::template ChunkArray<T>;
 
-	// MeshImportGen interface
 protected:
 
 	virtual bool import_file_impl(const std::string& filename) override

--- a/cgogn/io/obj_io.h
+++ b/cgogn/io/obj_io.h
@@ -40,12 +40,12 @@ namespace io
 {
 
 template <typename MAP_TRAITS, typename VEC3>
-class ObjSurfaceImport : public SurfaceImport<MAP_TRAITS>
+class ObjSurfaceImport : public SurfaceFileImport<MAP_TRAITS>
 {
 public:
 
 	using Self = ObjSurfaceImport<MAP_TRAITS, VEC3>;
-	using Inherit = SurfaceImport<MAP_TRAITS>;
+	using Inherit = SurfaceFileImport<MAP_TRAITS>;
 	using Scalar = typename geometry::vector_traits<VEC3>::Scalar;
 	template <typename T>
 	using ChunkArray = typename Inherit::template ChunkArray<T>;

--- a/cgogn/io/off_io.h
+++ b/cgogn/io/off_io.h
@@ -42,12 +42,12 @@ namespace io
 {
 
 template <typename MAP_TRAITS, typename VEC3>
-class OffSurfaceImport : public SurfaceImport<MAP_TRAITS>
+class OffSurfaceImport : public SurfaceFileImport<MAP_TRAITS>
 {
 public:
 
 	using Self = OffSurfaceImport<MAP_TRAITS, VEC3>;
-	using Inherit = SurfaceImport<MAP_TRAITS>;
+	using Inherit = SurfaceFileImport<MAP_TRAITS>;
 	using Scalar = typename geometry::vector_traits<VEC3>::Scalar;
 	template <typename T>
 	using ChunkArray = typename Inherit::template ChunkArray<T>;

--- a/cgogn/io/off_io.h
+++ b/cgogn/io/off_io.h
@@ -80,7 +80,6 @@ protected:
 		// read number of vertices, edges, faces
 		this->nb_vertices_ = this->read_uint(fp,line);
 		this->nb_faces_ = this->read_uint(fp,line);
-		this->nb_edges_ = this->read_uint(fp,line);
 
 		ChunkArray<VEC3>* position = this->vertex_attributes_.template add_chunk_array<VEC3>("position");
 
@@ -127,7 +126,6 @@ protected:
 
 		this->nb_vertices_= swap_endianness_native_big(*(reinterpret_cast<uint32*>(buffer1)));
 		this->nb_faces_= swap_endianness_native_big(*(reinterpret_cast<uint32*>(buffer1+4)));
-		this->nb_edges_= swap_endianness_native_big(*(reinterpret_cast<uint32*>(buffer1+8)));
 
 		ChunkArray<VEC3>* position = this->vertex_attributes_.template add_chunk_array<VEC3>("position");
 

--- a/cgogn/io/ply_io.h
+++ b/cgogn/io/ply_io.h
@@ -41,12 +41,12 @@ namespace io
 CGOGN_IO_API std::string cgogn_name_of_type_to_ply_data_type(const std::string& cgogn_type);
 
 template <typename MAP_TRAITS, typename VEC3>
-class PlySurfaceImport : public SurfaceImport<MAP_TRAITS>
+class PlySurfaceImport : public SurfaceFileImport<MAP_TRAITS>
 {
 public:
 
 	using Self = PlySurfaceImport<MAP_TRAITS, VEC3>;
-	using Inherit = SurfaceImport<MAP_TRAITS>;
+	using Inherit = SurfaceFileImport<MAP_TRAITS>;
 	using Scalar = typename geometry::vector_traits<VEC3>::Scalar;
 	template <typename T>
 	using ChunkArray = typename Inherit::template ChunkArray<T>;

--- a/cgogn/io/stl_io.h
+++ b/cgogn/io/stl_io.h
@@ -42,12 +42,12 @@ namespace io
 {
 
 template <typename MAP_TRAITS, typename VEC3>
-class StlSurfaceImport : public SurfaceImport<MAP_TRAITS>
+class StlSurfaceImport : public SurfaceFileImport<MAP_TRAITS>
 {
 public:
 
 	using Self = StlSurfaceImport<MAP_TRAITS, VEC3>;
-	using Inherit = SurfaceImport<MAP_TRAITS>;
+	using Inherit = SurfaceFileImport<MAP_TRAITS>;
 	using Scalar = typename geometry::vector_traits<VEC3>::Scalar;
 	template <typename T>
 	using ChunkArray = typename Inherit::template ChunkArray<T>;

--- a/cgogn/io/surface_import.cpp
+++ b/cgogn/io/surface_import.cpp
@@ -32,6 +32,7 @@ namespace io
 {
 
 template class CGOGN_IO_API SurfaceImport<DefaultMapTraits>;
+template class CGOGN_IO_API SurfaceFileImport<DefaultMapTraits>;
 
 } // namespace io
 

--- a/cgogn/io/surface_import.h
+++ b/cgogn/io/surface_import.h
@@ -45,13 +45,11 @@ namespace io
 {
 
 template <typename MAP_TRAITS>
-class SurfaceImport : public MeshImportGen
+class SurfaceImport
 {
 public:
 
 	using Self = SurfaceImport<MAP_TRAITS>;
-	using Inherit = MeshImportGen;
-
 	static const uint32 CHUNK_SIZE = MAP_TRAITS::CHUNK_SIZE;
 
 	template <typename T>
@@ -82,10 +80,10 @@ public:
 
 	CGOGN_NOT_COPYABLE_NOR_MOVABLE(SurfaceImport);
 
-	virtual ~SurfaceImport() override
+	virtual ~SurfaceImport()
 	{}
 
-	virtual void clear() override
+	virtual void clear()
 	{
 		nb_vertices_ = 0;
 		nb_faces_ = 0;
@@ -288,16 +286,28 @@ public:
 		for (uint32 id : v_ids)
 			faces_vertex_indices_.push_back(id);
 	}
+};
 
-protected:
-	virtual bool import_file_impl(const std::string&) override
-	{
-		cgogn_log_warning("SurfaceImport::import_file_impl") << "SurfaceImport::import_file_impl method does nothing and must be overriden.";
-	}
+template <typename MAP_TRAITS>
+class SurfaceFileImport : public SurfaceImport<MAP_TRAITS>, public FileImport
+{
+	using Self = SurfaceFileImport<MAP_TRAITS>;
+	using Inherit1 = SurfaceImport<MAP_TRAITS>;
+	using Inherit2 = FileImport;
+
+	CGOGN_NOT_COPYABLE_NOR_MOVABLE(SurfaceFileImport);
+
+public:
+	inline SurfaceFileImport() : Inherit1(), Inherit2()
+	{}
+
+	virtual ~SurfaceFileImport()
+	{}
 };
 
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_SURFACE_IMPORT_CPP_))
 extern template class CGOGN_IO_API SurfaceImport<DefaultMapTraits>;
+extern template class CGOGN_IO_API SurfaceFileImport<DefaultMapTraits>;
 #endif // defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_SURFACE_IMPORT_CPP_))
 
 } // namespace io

--- a/cgogn/io/surface_import.h
+++ b/cgogn/io/surface_import.h
@@ -112,8 +112,7 @@ public:
 		mbuild.template create_embedding<Vertex::ORBIT>();
 		mbuild.template swap_chunk_array_container<Vertex::ORBIT>(this->vertex_attributes_);
 
-		typename Map::template VertexAttribute<std::vector<Dart>> darts_per_vertex =
-			map.template add_attribute<std::vector<Dart>, Vertex::ORBIT>("darts_per_vertex");
+		auto darts_per_vertex = map.template add_attribute<std::vector<Dart>, Vertex::ORBIT>("darts_per_vertex");
 
 		uint32 faces_vertex_index = 0;
 		std::vector<uint32> vertices_buffer;

--- a/cgogn/io/surface_import.h
+++ b/cgogn/io/surface_import.h
@@ -63,7 +63,6 @@ public:
 protected:
 
 	uint32 nb_vertices_;
-	uint32 nb_edges_;
 	uint32 nb_faces_;
 
 	std::vector<uint32> faces_nb_edges_;
@@ -76,7 +75,6 @@ public:
 
 	inline SurfaceImport() :
 		nb_vertices_(0u)
-	  ,nb_edges_(0u)
 	  ,nb_faces_(0u)
 	  ,faces_nb_edges_()
 	  ,faces_vertex_indices_()
@@ -90,7 +88,6 @@ public:
 	virtual void clear() override
 	{
 		nb_vertices_ = 0;
-		nb_edges_ = 0;
 		nb_faces_ = 0;
 		faces_nb_edges_.clear();
 		faces_vertex_indices_.clear();
@@ -216,6 +213,86 @@ public:
 
 		map.remove_attribute(darts_per_vertex);
 		this->clear();
+	}
+
+	template <typename VEC3>
+	inline ChunkArray<VEC3>* position_attribute()
+	{
+		auto res = this->vertex_attributes_.template add_chunk_array<VEC3>("position");
+		if (res != nullptr)
+			return res;
+		else
+			return this->vertex_attributes_.template get_chunk_array<VEC3>("position");
+	}
+
+	inline uint32 insert_line_vertex_container()
+	{
+		return vertex_attributes_.template insert_lines<1>();
+	}
+
+	inline ChunkArrayContainer& vertex_attributes_container()
+	{
+		return vertex_attributes_;
+	}
+
+	inline ChunkArrayContainer& face_attributes_container()
+	{
+		return face_attributes_;
+	}
+
+	inline void set_nb_vertices(uint32 nbv)
+	{
+		nb_vertices_ = nbv;
+	}
+
+	inline uint32 nb_vertices() const
+	{
+		return nb_vertices_;
+	}
+
+	inline void set_nb_faces(uint32 nbf)
+	{
+		nb_faces_ = nbf;
+		faces_nb_edges_.reserve(nbf);
+		faces_vertex_indices_.reserve(nbf * 4u);
+	}
+
+	inline uint32 nb_faces() const
+	{
+		return nb_faces_;
+	}
+
+	void add_triangle(uint32 p0, uint32 p1, uint32 p2)
+	{
+		++nb_faces_;
+		faces_nb_edges_.push_back(3);
+		faces_vertex_indices_.push_back(p0);
+		faces_vertex_indices_.push_back(p1);
+		faces_vertex_indices_.push_back(p2);
+	}
+
+	void add_quad(uint32 p0, uint32 p1, uint32 p2, uint32 p3)
+	{
+		++nb_faces_;
+		faces_nb_edges_.push_back(4);
+		faces_vertex_indices_.push_back(p0);
+		faces_vertex_indices_.push_back(p1);
+		faces_vertex_indices_.push_back(p2);
+		faces_vertex_indices_.push_back(p3);
+	}
+
+	void add_face(const std::vector<uint32>& v_ids)
+	{
+		nb_faces_ += 1u;
+		faces_nb_edges_.push_back(v_ids.size());
+		for (uint32 id : v_ids)
+			faces_vertex_indices_.push_back(id);
+	}
+
+protected:
+	virtual bool import_file_impl(const std::string&) override
+	{
+		cgogn_log_warning("SurfaceImport::import_file_impl") << "SurfaceImport::import_file_impl method does nothing and must be overriden.";
 	}
 };
 

--- a/cgogn/io/tet_io.h
+++ b/cgogn/io/tet_io.h
@@ -38,9 +38,9 @@ namespace io
 {
 
 template <typename MAP_TRAITS, typename VEC3>
-class TetVolumeImport : public VolumeImport<MAP_TRAITS>
+class TetVolumeImport : public VolumeFileImport<MAP_TRAITS>
 {
-	using Inherit = VolumeImport<MAP_TRAITS>;
+	using Inherit = VolumeFileImport<MAP_TRAITS>;
 	using Self = TetVolumeImport<MAP_TRAITS,VEC3>;
 	template <typename T>
 	using ChunkArray = typename Inherit::template ChunkArray<T>;

--- a/cgogn/io/tetgen_io.h
+++ b/cgogn/io/tetgen_io.h
@@ -39,10 +39,10 @@ namespace io
 {
 
 template <typename MAP_TRAITS, typename VEC3>
-class TetgenVolumeImport : public VolumeImport<MAP_TRAITS>
+class TetgenVolumeImport : public VolumeFileImport<MAP_TRAITS>
 {
 public:
-	using Inherit = VolumeImport<MAP_TRAITS>;
+	using Inherit = VolumeFileImport<MAP_TRAITS>;
 	using Self = TetgenVolumeImport<MAP_TRAITS, VEC3>;
 	template <typename T>
 	using ChunkArray = typename Inherit::template ChunkArray<T>;

--- a/cgogn/io/volume_export.h
+++ b/cgogn/io/volume_export.h
@@ -94,7 +94,7 @@ public:
 		if (!this->position_attribute())
 			return;
 
-		vertices_of_volumes_ = map.template add_attribute<std::vector<int32>, Volume::ORBIT>("vertices_of_volume_volume_export");
+		map.add_attribute(vertices_of_volumes_, "vertices_of_volume_volume_export");
 
 		for (const auto& pair : options.attributes_to_export_)
 		{

--- a/cgogn/io/volume_import.cpp
+++ b/cgogn/io/volume_import.cpp
@@ -32,6 +32,7 @@ namespace io
 {
 
 template class CGOGN_IO_API VolumeImport<DefaultMapTraits>;
+template class CGOGN_IO_API VolumeFileImport<DefaultMapTraits>;
 
 } // namespace io
 

--- a/cgogn/io/volume_import.h
+++ b/cgogn/io/volume_import.h
@@ -217,7 +217,7 @@ public:
 		mbuild.template create_embedding<Vertex::ORBIT>();
 		mbuild.template swap_chunk_array_container<Vertex::ORBIT>(this->vertex_attributes_);
 
-		typename Map::template VertexAttribute<std::vector<Dart>> darts_per_vertex = map.template add_attribute<std::vector<Dart>, Vertex::ORBIT>("darts_per_vertex");
+		auto darts_per_vertex = map.template add_attribute<std::vector<Dart>, Vertex::ORBIT>("darts_per_vertex");
 
 		uint32 index = 0u;
 		typename Map::DartMarkerStore m(map);

--- a/cgogn/io/volume_import.h
+++ b/cgogn/io/volume_import.h
@@ -110,13 +110,11 @@ namespace io
 {
 
 template <typename MAP_TRAITS>
-class VolumeImport : public MeshImportGen
+class VolumeImport
 {
 public:
 
 	using Self = VolumeImport<MAP_TRAITS>;
-	using Inherit = MeshImportGen;
-
 	static const uint32 CHUNK_SIZE = MAP_TRAITS::CHUNK_SIZE;
 
 	template <typename T>
@@ -126,7 +124,7 @@ public:
 	template <typename T, Orbit ORBIT>
 	using Attribute = Attribute<MAP_TRAITS, T, ORBIT>;
 
-	virtual ~VolumeImport() override
+	virtual ~VolumeImport()
 	{}
 
 private:
@@ -523,7 +521,7 @@ public:
 
 protected:
 
-	virtual void clear() override
+	virtual void clear()
 	{
 		set_nb_vertices(0u);
 		set_nb_volumes(0u);
@@ -634,8 +632,26 @@ protected:
 	}
 };
 
+template <typename MAP_TRAITS>
+class VolumeFileImport : public VolumeImport<MAP_TRAITS>, public FileImport
+{
+	using Self = VolumeFileImport<MAP_TRAITS>;
+	using Inherit1 = VolumeImport<MAP_TRAITS>;
+	using Inherit2 = FileImport;
+
+	CGOGN_NOT_COPYABLE_NOR_MOVABLE(VolumeFileImport);
+
+public:
+	inline VolumeFileImport() : Inherit1(), Inherit2()
+	{}
+
+	virtual ~VolumeFileImport()
+	{}
+};
+
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_VOLUME_IMPORT_CPP_))
 extern template class CGOGN_IO_API VolumeImport<DefaultMapTraits>;
+extern template class CGOGN_IO_API VolumeFileImport<DefaultMapTraits>;
 #endif // defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_VOLUME_IMPORT_CPP_))
 
 } // namespace io

--- a/cgogn/io/vtk_io.h
+++ b/cgogn/io/vtk_io.h
@@ -1374,13 +1374,13 @@ protected:
 };
 
 template <typename MAP_TRAITS, typename VEC3>
-class VtkSurfaceImport : public VtkIO<MAP_TRAITS::CHUNK_SIZE, CMap2<MAP_TRAITS>::PRIM_SIZE, VEC3>, public SurfaceImport<MAP_TRAITS>
+class VtkSurfaceImport : public VtkIO<MAP_TRAITS::CHUNK_SIZE, CMap2<MAP_TRAITS>::PRIM_SIZE, VEC3>, public SurfaceFileImport<MAP_TRAITS>
 {
 public:
 
 	using Self = VtkSurfaceImport<MAP_TRAITS, VEC3>;
 	using Inherit_Vtk = VtkIO<MAP_TRAITS::CHUNK_SIZE, CMap2<MAP_TRAITS>::PRIM_SIZE, VEC3>;
-	using Inherit_Import = SurfaceImport<MAP_TRAITS>;
+	using Inherit_Import = SurfaceFileImport<MAP_TRAITS>;
 	using DataInputGen = typename Inherit_Vtk::DataInputGen;
 	template <typename T>
 	using DataInput = typename Inherit_Vtk::template DataInput<T>;
@@ -1511,13 +1511,13 @@ private:
 };
 
 template <typename MAP_TRAITS, typename VEC3>
-class VtkVolumeImport : public VtkIO<MAP_TRAITS::CHUNK_SIZE, CMap3<MAP_TRAITS>::PRIM_SIZE, VEC3>, public VolumeImport<MAP_TRAITS>
+class VtkVolumeImport : public VtkIO<MAP_TRAITS::CHUNK_SIZE, CMap3<MAP_TRAITS>::PRIM_SIZE, VEC3>, public VolumeFileImport<MAP_TRAITS>
 {
 public:
 
 	using Self = VtkVolumeImport<MAP_TRAITS, VEC3>;
 	using Inherit_Vtk = VtkIO<MAP_TRAITS::CHUNK_SIZE, CMap3<MAP_TRAITS>::PRIM_SIZE, VEC3>;
-	using Inherit_Import = VolumeImport<MAP_TRAITS>;
+	using Inherit_Import = VolumeFileImport<MAP_TRAITS>;
 	using DataInputGen = typename Inherit_Vtk::DataInputGen;
 	template <typename T>
 	using DataInput = typename Inherit_Vtk::template DataInput<T>;

--- a/cgogn/rendering/examples/picking_viewer.cpp
+++ b/cgogn/rendering/examples/picking_viewer.cpp
@@ -106,7 +106,7 @@ void Viewer::import(const std::string& surfaceMesh)
 {
 	cgogn::io::import_surface<Vec3>(map_, surfaceMesh);
 
-	vertex_position_ = map_.get_attribute<Vec3, Map2::Vertex::ORBIT>("position");
+	map_.get_attribute(vertex_position_, "position");
 
 	cgogn::geometry::compute_AABB(vertex_position_, bb_);
 

--- a/cgogn/rendering/examples/simple_viewer.cpp
+++ b/cgogn/rendering/examples/simple_viewer.cpp
@@ -123,14 +123,14 @@ void Viewer::import(const std::string& surface_mesh)
 {
 	cgogn::io::import_surface<Vec3>(map_, surface_mesh);
 
-	vertex_position_ = map_.get_attribute<Vec3, Map2::Vertex::ORBIT>("position");
+	map_.get_attribute(vertex_position_, "position");
 	if (!vertex_position_.is_valid())
 	{
 		cgogn_log_error("Viewer::import") << "Missing attribute position. Aborting.";
 		std::exit(EXIT_FAILURE);
 	}
 
-	vertex_normal_ = map_.add_attribute<Vec3, Map2::Vertex::ORBIT>("normal");
+	map_.add_attribute(vertex_normal_, "normal");
 
 // testing merge method
 //	Map2 map2;

--- a/cgogn/rendering/examples/viewer_per_face.cpp
+++ b/cgogn/rendering/examples/viewer_per_face.cpp
@@ -99,8 +99,8 @@ void Viewer::import(const std::string& surfaceMesh)
 {
 	cgogn::io::import_surface<Vec3>(map_, surfaceMesh);
 
-	vertex_position_ = map_.get_attribute<Vec3, Map2::Vertex::ORBIT>("position");
-	face_normal_ = map_.add_attribute<Vec3, Map2::Face::ORBIT>("normal");
+	map_.get_attribute(vertex_position_, "position");
+	map_.add_attribute(face_normal_, "normal");
 
 	cgogn::geometry::compute_normal<Vec3>(map_, vertex_position_, face_normal_);
 	cgogn::geometry::compute_AABB(vertex_position_, bb_);

--- a/cgogn/rendering/examples/viewer_topo.cpp
+++ b/cgogn/rendering/examples/viewer_topo.cpp
@@ -104,7 +104,7 @@ void Viewer::import(const std::string& surface_mesh)
 {
 	cgogn::io::import_surface<Vec3>(map_, surface_mesh);
 
-	vertex_position_ = map_.get_attribute<Vec3, Map2::Vertex::ORBIT>("position");
+	map_.get_attribute(vertex_position_, "position");
 	if (!vertex_position_.is_valid())
 	{
 		cgogn_log_error("Viewer::import") << "Missing attribute position. Aborting.";

--- a/cgogn/rendering/examples/viewer_topo3.cpp
+++ b/cgogn/rendering/examples/viewer_topo3.cpp
@@ -120,7 +120,7 @@ void Viewer::import(const std::string& volumeMesh)
 {
 	cgogn::io::import_volume<Vec3>(map_, volumeMesh);
 
-	vertex_position_ = map_.get_attribute<Vec3, Map3::Vertex::ORBIT>("position");
+	map_.get_attribute(vertex_position_, "position");
 	if (!vertex_position_.is_valid())
 	{
 		cgogn_log_error("Viewer::import") << "Missing attribute position. Aborting.";

--- a/cgogn/rendering/map_render.h
+++ b/cgogn/rendering/map_render.h
@@ -302,6 +302,9 @@ public:
 				break;
 		}
 
+		if (table_indices.empty())
+			return;
+
 		if (!indices_buffers_[prim]->isCreated())
 			indices_buffers_[prim]->create();
 

--- a/cgogn/topology/algos/distance_field.h
+++ b/cgogn/topology/algos/distance_field.h
@@ -66,7 +66,7 @@ public:
 		cache_(cache),
 		intern_edge_weight_(true)
 	{
-		edge_weight_ = map.template add_attribute<Scalar, Edge::ORBIT>("__edge_weight__");
+		map.add_attribute(edge_weight_, "__edge_weight__");
 
 		map.foreach_cell([&](Edge e)
 		{

--- a/cgogn/topology/algos/features.h
+++ b/cgogn/topology/algos/features.h
@@ -63,9 +63,9 @@ public:
 		edge_weight_(weight),
 		distance_field_(map, cache, weight)
 	{
-		distance_to_A_ = map.template add_attribute<Scalar, Vertex::ORBIT>("__feature_A__");
-		distance_to_B_ = map.template add_attribute<Scalar, Vertex::ORBIT>("__feature_B__");
-		paths_ = map.template add_attribute<Vertex, Vertex::ORBIT>("__paths__");
+		map.add_attribute(distance_to_A_, "__feature_A__");
+		map.template add_attribute(distance_to_B_, "__feature_B__");
+		map.add_attribute(paths_, "__paths__");
 	}
 
 	FeaturesFinder(MAP& map,
@@ -76,9 +76,9 @@ public:
 		distance_field_(map, cache)
 	{
 		edge_weight_ = distance_field_.edge_weight();
-		distance_to_A_ = map.template add_attribute<Scalar, Vertex::ORBIT>("__distance_to_A__");
-		distance_to_B_ = map.template add_attribute<Scalar, Vertex::ORBIT>("__distance_to_B__");
-		paths_ = map.template add_attribute<Vertex, Vertex::ORBIT>("__paths__");
+		distance_to_A_ = map.add_attribute(distance_to_A_, "__distance_to_A__");
+		distance_to_B_ = map.add_attribute(distance_to_B_, "__distance_to_B__");
+		paths_ = map.add_attribute(paths_, "__paths__");
 	}
 
 	~FeaturesFinder()

--- a/cgogn/topology/algos/scalar_field.h
+++ b/cgogn/topology/algos/scalar_field.h
@@ -78,7 +78,7 @@ public:
 	{
 		// To allow multiple ScalarField on a same map
 		std::string name = "vertex_type_for_" + scalar_field.name();
-		vertex_type_ = map.template add_attribute<CriticalPoint::Type, Vertex::ORBIT>(name);
+		map.add_attribute(vertex_type_, name);
 	}
 
 	~ScalarField()

--- a/cgogn/topology/types/adjacency_cache.h
+++ b/cgogn/topology/types/adjacency_cache.h
@@ -55,7 +55,7 @@ public:
 
 	void init()
 	{
-		adjacency_ = map_.template add_attribute<VertexArray, Vertex::ORBIT>("__adjacency__");
+		map_.add_attribute(adjacency_, "__adjacency__");
 		map_.foreach_cell([&](Vertex v)
 		{
 			map_.foreach_adjacent_vertex_through_edge(v, [&](Vertex u)


### PR DESCRIPTION
the goal of the changes in the mesh import functions is to ease the creation of a mesh interactively using SurfaceImport or VolumeImport. Examples of use can be found in schnapps or in sofa.
