### PR TITLE
Fixed Msvc compilation issue

### DIFF
--- a/cgogn/core/cmap/cmap2.h
+++ b/cgogn/core/cmap/cmap2.h
@@ -30,7 +30,7 @@ namespace cgogn
 {
 
 // forward declaration of CMap2Builder_T
-template <typename MAP_TRAITS> class CMap2Builder_T;
+template <typename Map2> class CMap2Builder_T;
 
 template <typename MAP_TRAITS, typename MAP_TYPE>
 class CMap2_T : public CMap1_T<MAP_TRAITS, MAP_TYPE>
@@ -45,10 +45,10 @@ public:
 	using Inherit = CMap1_T<MAP_TRAITS, MAP_TYPE>;
 	using Self = CMap2_T<MAP_TRAITS, MAP_TYPE>;
 
-	using Builder = CMap2Builder_T<MapTraits>;
+	using Builder = CMap2Builder_T<Self>;
 
 	friend class MapBase<MAP_TRAITS, MAP_TYPE>;
-	friend class CMap2Builder_T<MapTraits>;
+	friend class CMap2Builder_T<Self>;
 	friend class DartMarker_T<Self>;
 	friend class cgogn::DartMarkerStore<Self>;
 

--- a/cgogn/core/cmap/cmap2_builder.cpp
+++ b/cgogn/core/cmap/cmap2_builder.cpp
@@ -28,6 +28,6 @@
 namespace cgogn
 {
 
-	template class CGOGN_CORE_API cgogn::CMap2Builder_T<DefaultMapTraits>;
+	template class CGOGN_CORE_API cgogn::CMap2Builder_T<cgogn::CMap2<cgogn::DefaultMapTraits>>;
 
 } // namespace cgogn

--- a/cgogn/core/cmap/cmap2_builder.h
+++ b/cgogn/core/cmap/cmap2_builder.h
@@ -32,6 +32,7 @@ namespace cgogn
 template <typename MAP2>
 class CMap2Builder_T
 {
+	static_assert(MAP2::DIMENSION == 2,"CMap2Builder_T works only with 2D Maps.");
 public:
 
 	using Self = CMap2Builder_T<MAP2>;

--- a/cgogn/core/cmap/cmap2_builder.h
+++ b/cgogn/core/cmap/cmap2_builder.h
@@ -29,23 +29,23 @@
 namespace cgogn
 {
 
-template <typename MAP_TRAITS>
+template <typename MAP2>
 class CMap2Builder_T
 {
 public:
 
-	using Self = CMap2Builder_T<MAP_TRAITS>;
-	using CMap2 = cgogn::CMap2<MAP_TRAITS>;
-	using CDart = typename CMap2::CDart;
-	using Vertex = typename CMap2::Vertex;
-	using Edge = typename CMap2::Edge;
-	using Face = typename CMap2::Face;
-	using Volume = typename CMap2::Volume;
+	using Self = CMap2Builder_T<MAP2>;
+	using Map2 = MAP2;
+	using CDart = typename Map2::CDart;
+	using Vertex = typename Map2::Vertex;
+	using Edge = typename Map2::Edge;
+	using Face = typename Map2::Face;
+	using Volume = typename Map2::Volume;
 
 	template <typename T>
-	using ChunkArrayContainer = typename CMap2::template ChunkArrayContainer<T>;
+	using ChunkArrayContainer = typename Map2::template ChunkArrayContainer<T>;
 
-	inline CMap2Builder_T(CMap2& map) : map_(map)
+	inline CMap2Builder_T(Map2& map) : map_(map)
 	{}
 
 	CGOGN_NOT_COPYABLE_NOR_MOVABLE(CMap2Builder_T);
@@ -88,7 +88,7 @@ public:
 
 	inline Dart add_face_topo_parent(uint32 nb_edges)
 	{
-		return map_.CMap2::Inherit::add_face_topo(nb_edges);
+		return map_.Map2::Inherit::add_face_topo(nb_edges);
 	}
 
 	inline Dart close_hole_topo(Dart d)
@@ -186,13 +186,13 @@ public:
 
 private:
 
-	CMap2& map_;
+	Map2& map_;
 };
 
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_CORE_MAP_MAP2_BUILDER_CPP_))
-extern template class CGOGN_CORE_API cgogn::CMap2Builder_T<DefaultMapTraits>;
+extern template class CGOGN_CORE_API cgogn::CMap2Builder_T<CMap2<DefaultMapTraits>>;
 #endif // defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_CORE_MAP_MAP2_BUILDER_CPP_))
-using CMap2Builder = cgogn::CMap2Builder_T<DefaultMapTraits>;
+using CMap2Builder = cgogn::CMap2Builder_T<cgogn::CMap2<cgogn::DefaultMapTraits>>;
 
 } // namespace cgogn
 

--- a/cgogn/core/cmap/cmap3.h
+++ b/cgogn/core/cmap/cmap3.h
@@ -48,7 +48,7 @@ public:
 	using Builder = CMap3Builder_T<Self>;
 
 	friend class MapBase<MAP_TRAITS, MAP_TYPE>;
-	friend class Builder;
+	friend class CMap3Builder_T<Self>;
 	friend class DartMarker_T<Self>;
 	friend class cgogn::DartMarkerStore<Self>;
 

--- a/cgogn/core/cmap/cmap3.h
+++ b/cgogn/core/cmap/cmap3.h
@@ -30,7 +30,7 @@ namespace cgogn
 {
 
 // forward declaration of CMap3Builder_T
-template <typename MAP_TRAITS> class CMap3Builder_T;
+template <typename Map3> class CMap3Builder_T;
 
 template <typename MAP_TRAITS, typename MAP_TYPE>
 class CMap3_T : public CMap2_T<MAP_TRAITS, MAP_TYPE>
@@ -45,11 +45,10 @@ public:
 	using MapType = MAP_TYPE;
 	using Inherit = CMap2_T<MAP_TRAITS, MAP_TYPE>;
 	using Self = CMap3_T<MAP_TRAITS, MAP_TYPE>;
-
-	using Builder = CMap3Builder_T<MapTraits>;
+	using Builder = CMap3Builder_T<Self>;
 
 	friend class MapBase<MAP_TRAITS, MAP_TYPE>;
-	friend class CMap3Builder_T<MapTraits>;
+	friend class Builder;
 	friend class DartMarker_T<Self>;
 	friend class cgogn::DartMarkerStore<Self>;
 

--- a/cgogn/core/cmap/cmap3_builder.cpp
+++ b/cgogn/core/cmap/cmap3_builder.cpp
@@ -28,6 +28,6 @@
 namespace cgogn
 {
 
-	template class CGOGN_CORE_API cgogn::CMap3Builder_T<DefaultMapTraits>;
+	template class CGOGN_CORE_API cgogn::CMap3Builder_T<cgogn::CMap3<cgogn::DefaultMapTraits>>;
 
 } // namespace cgogn

--- a/cgogn/core/cmap/cmap3_builder.h
+++ b/cgogn/core/cmap/cmap3_builder.h
@@ -32,6 +32,7 @@ namespace cgogn
 template <typename MAP3>
 class CMap3Builder_T
 {
+	static_assert(MAP3::DIMENSION == 3,"CMap3Builder_T works only with 3D Maps.");
 public:
 	using Self = CMap3Builder_T<MAP3>;
 	using Map3 = MAP3;

--- a/cgogn/core/cmap/cmap3_builder.h
+++ b/cgogn/core/cmap/cmap3_builder.h
@@ -29,27 +29,26 @@
 namespace cgogn
 {
 
-template <typename MAP_TRAITS>
+template <typename MAP3>
 class CMap3Builder_T
 {
 public:
+	using Self = CMap3Builder_T<MAP3>;
+	using Map3 = MAP3;
+	using CDart = typename Map3::CDart;
+	using Vertex = typename Map3::Vertex;
+	using Vertex2 = typename Map3::Vertex2;
+	using Edge = typename Map3::Edge;
+	using Edge2 = typename Map3::Edge2;
+	using Face = typename Map3::Face;
+	using Face2 = typename Map3::Face2;
+	using Volume = typename Map3::Volume;
 
-	using Self = CMap3Builder_T<MAP_TRAITS>;
-	using CMap3 = cgogn::CMap3<MAP_TRAITS>;
-	using CDart = typename CMap3::CDart;
-	using Vertex = typename CMap3::Vertex;
-	using Vertex2 = typename CMap3::Vertex2;
-	using Edge = typename CMap3::Edge;
-	using Edge2 = typename CMap3::Edge2;
-	using Face = typename CMap3::Face;
-	using Face2 = typename CMap3::Face2;
-	using Volume = typename CMap3::Volume;
-
-	using DartMarkerStore = typename CMap3::DartMarkerStore;
+	using DartMarkerStore = typename Map3::DartMarkerStore;
 	template <typename T>
-	using ChunkArrayContainer = typename CMap3::template ChunkArrayContainer<T>;
+	using ChunkArrayContainer = typename Map3::template ChunkArrayContainer<T>;
 
-	inline CMap3Builder_T(CMap3& map) : map_(map)
+	inline CMap3Builder_T(Map3& map) : map_(map)
 	{}
 
 	CGOGN_NOT_COPYABLE_NOR_MOVABLE(CMap3Builder_T);
@@ -174,7 +173,7 @@ public:
 			Dart it = visitedFaces[i];
 			Dart f = it;
 
-			const Dart b = map_.CMap3::Inherit::Inherit::add_face_topo(map_.codegree(Face(f)));
+			const Dart b = map_.Map3::Inherit::Inherit::add_face_topo(map_.codegree(Face(f)));
 			boundary_marker.mark_orbit(Face2(b));
 			++count;
 
@@ -266,14 +265,14 @@ public:
 
 private:
 
-	CMap3& map_;
+	Map3& map_;
 };
 
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_CORE_CMAP_CMAP3_BUILDER_CPP_))
-extern template class CGOGN_CORE_API cgogn::CMap3Builder_T<DefaultMapTraits>;
+extern template class CGOGN_CORE_API cgogn::CMap3Builder_T<cgogn::CMap3<cgogn::DefaultMapTraits>>;
 #endif // defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_CORE_CMAP_CMAP3_BUILDER_CPP_))
 
-using CMap3Builder = cgogn::CMap3Builder_T<DefaultMapTraits>;
+using CMap3Builder = cgogn::CMap3Builder_T<cgogn::CMap3<cgogn::DefaultMapTraits>>;
 
 } // namespace cgogn
 

--- a/cgogn/core/tests/cmap/cmap2_test.cpp
+++ b/cgogn/core/tests/cmap/cmap2_test.cpp
@@ -49,7 +49,7 @@ public:
 	};
 
 	using testCMap2 = CMap2<MiniMapTraits>;
-	using MapBuilder = CMap2Builder_T<MiniMapTraits>;
+	using MapBuilder = testCMap2::Builder;
 	using CDart = testCMap2::CDart;
 	using Vertex = testCMap2::Vertex;
 	using Edge = testCMap2::Edge;

--- a/cgogn/core/tests/cmap/cmap2_topo_test.cpp
+++ b/cgogn/core/tests/cmap/cmap2_topo_test.cpp
@@ -44,7 +44,7 @@ class CMap2TopoTest : public CMap2<DefaultMapTraits>, public ::testing::Test
 public:
 
 	using Inherit = CMap2<DefaultMapTraits>;
-	using MapBuilder = CMap2Builder_T<DefaultMapTraits>;
+	using MapBuilder = Inherit::Builder;
 	using CDart = CMap2TopoTest::CDart;
 	using Vertex = CMap2TopoTest::Vertex;
 	using Edge   = CMap2TopoTest::Edge;

--- a/cgogn/core/tests/cmap/cmap2quad_test.cpp
+++ b/cgogn/core/tests/cmap/cmap2quad_test.cpp
@@ -23,7 +23,7 @@
 
 #include <gtest/gtest.h>
 
-#include <cgogn/core/cmap/cmap2_quad_builder.h>
+#include <cgogn/core/cmap/cmap2_quad.h>
 
 namespace cgogn
 {
@@ -50,7 +50,7 @@ public:
 	};
 
 	using testCMap2Quad = CMap2Quad<MiniMapTraits>;
-	using MapBuilder = CMap2QuadBuilder_T<MiniMapTraits>;
+	using MapBuilder = testCMap2Quad::Builder;
 	using CDart = testCMap2Quad::CDart;
 	using Vertex = testCMap2Quad::Vertex;
 	using Edge = testCMap2Quad::Edge;

--- a/cgogn/core/tests/cmap/cmap2tri_test.cpp
+++ b/cgogn/core/tests/cmap/cmap2tri_test.cpp
@@ -23,7 +23,7 @@
 
 #include <gtest/gtest.h>
 
-#include <cgogn/core/cmap/cmap2_tri_builder.h>
+#include <cgogn/core/cmap/cmap2_tri.h>
 
 namespace cgogn
 {
@@ -50,7 +50,7 @@ public:
 	};
 
 	using testCMap2Tri = CMap2Tri<MiniMapTraits>;
-	using MapBuilder = CMap2TriBuilder_T<MiniMapTraits>;
+	using MapBuilder = testCMap2Tri::Builder;
 	using CDart = testCMap2Tri::CDart;
 	using Vertex = testCMap2Tri::Vertex;
 	using Edge = testCMap2Tri::Edge;

--- a/cgogn/core/tests/cmap/cmap3_test.cpp
+++ b/cgogn/core/tests/cmap/cmap3_test.cpp
@@ -49,7 +49,7 @@ public:
 	};
 
 	using testCMap3 = CMap3<MiniMapTraits>;
-	using MapBuilder = CMap3Builder_T<testCMap3>;
+	using MapBuilder = testCMap3::Builder;
 	using CDart = testCMap3::CDart;
 	using Vertex2 = testCMap3::Vertex2;
 	using Vertex = testCMap3::Vertex;
@@ -506,7 +506,7 @@ TEST_F(CMap3Test, merge_map2)
 	// create a map2
 	CMap2<MiniMapTraits> map2;
 
-	CMap2Builder_T<MiniMapTraits> mbuild2(map2);
+	CMap2<MiniMapTraits>::Builder mbuild2(map2);
 
 	Dart f1 = mbuild2.add_face_topo_parent(4u);
 	Dart f2 = mbuild2.add_face_topo_parent(3u);

--- a/cgogn/core/tests/cmap/cmap3_test.cpp
+++ b/cgogn/core/tests/cmap/cmap3_test.cpp
@@ -49,7 +49,7 @@ public:
 	};
 
 	using testCMap3 = CMap3<MiniMapTraits>;
-	using MapBuilder = CMap3Builder_T<MiniMapTraits>;
+	using MapBuilder = CMap3Builder_T<testCMap3>;
 	using CDart = testCMap3::CDart;
 	using Vertex2 = testCMap3::Vertex2;
 	using Vertex = testCMap3::Vertex;

--- a/cgogn/core/tests/cmap/cmap3_topo_test.cpp
+++ b/cgogn/core/tests/cmap/cmap3_topo_test.cpp
@@ -44,7 +44,7 @@ class CMap3TopoTest : public CMap3<DefaultMapTraits>, public ::testing::Test
 public:
 
 	using Inherit = CMap3<DefaultMapTraits>;
-	using MapBuilder = CMap3Builder_T<DefaultMapTraits>;
+	using MapBuilder = CMap3Builder_T<CMap3<DefaultMapTraits>>;
 	using Vertex2 = CMap3TopoTest::Vertex2;
 	using Vertex = CMap3TopoTest::Vertex;
 	using Edge2 = CMap3TopoTest::Edge2;

--- a/cgogn/core/utils/definitions.h
+++ b/cgogn/core/utils/definitions.h
@@ -149,4 +149,13 @@
 	CLASSNAME& operator=(const CLASSNAME&) = delete;\
 	CLASSNAME& operator=(CLASSNAME&&) = delete
 
+namespace cgogn
+{
+// this function can be used to avoid warnings when not using function parameters
+template<class... T>
+inline void unused_parameters(T&&...)
+{}
+
+} // namespace cgogn
+
 #endif // CGOGN_CORE_UTILS_DEFINITIONS_H_

--- a/cgogn/geometry/algos/curvature.h
+++ b/cgogn/geometry/algos/curvature.h
@@ -57,6 +57,7 @@ void curvature(
 	using Edge2 = Cell<Orbit::PHI2>;
 	using Face = typename MAP::Face;
 
+	unused_parameters(edge_area);
 	// collect the normal cycle tensor
 	geometry::Collector_WithinSphere<VEC3, MAP> neighborhood(map, radius, position);
 	neighborhood.collect(v);

--- a/cgogn/geometry/algos/selection.h
+++ b/cgogn/geometry/algos/selection.h
@@ -109,6 +109,9 @@ public:
 	inline Collector(const MAP& m) : map_(m)
 	{}
 
+	Collector& operator=(const Collector&) = delete;
+	Collector& operator=(Collector&&) = delete;
+
 	virtual void collect(const Vertex center) = 0;
 	virtual void collect(const Dart v_center) override
 	{
@@ -148,6 +151,9 @@ public:
 
 	Collector_OneRing(const MAP& map) : Inherit(map)
 	{}
+
+	Collector_OneRing& operator=(const Collector_OneRing&) = delete;
+	Collector_OneRing& operator=(Collector_OneRing&&) = delete;
 
 	void collect(const Vertex center) override
 	{
@@ -198,6 +204,9 @@ public:
 		radius_(radius),
 		position_(position)
 	{}
+
+	Collector_WithinSphere& operator=(const Collector_WithinSphere&) = delete;
+	Collector_WithinSphere& operator=(Collector_WithinSphere&&) = delete;
 
 	void collect(const Vertex center) override
 	{

--- a/cgogn/io/lm6_io.h
+++ b/cgogn/io/lm6_io.h
@@ -90,7 +90,7 @@ protected:
 		{
 			GmfGotoKwd(mesh_index, GmfTetrahedra);
 			std::array<int, 4> ids;
-			for (int i = 0 ; i < number_of_tetras; ++i)
+			for (uint32 i = 0; i < number_of_tetras; ++i)
 			{
 				(void) GmfGetLin(mesh_index, GmfTetrahedra, &ids[0],&ids[1], &ids[2], &ids[3], &ref);
 				for (auto& id : ids)
@@ -104,7 +104,7 @@ protected:
 		{
 			GmfGotoKwd(mesh_index, GmfHexahedra);
 			std::array<int, 8> ids;
-			for (int i = 0 ; i < number_of_hexas; ++i)
+			for (uint32 i = 0 ; i < number_of_hexas; ++i)
 			{
 				(void) GmfGetLin(mesh_index, GmfHexahedra, &ids[0],&ids[1], &ids[2], &ids[3], &ids[4], &ids[5], &ids[6], &ids[7], &ref);
 				for (auto& id : ids)
@@ -118,7 +118,7 @@ protected:
 		{
 			GmfGotoKwd(mesh_index, GmfPrisms);
 			std::array<int, 6> ids;
-			for (int i = 0 ; i < number_of_prisms; ++i)
+			for (uint32 i = 0; i < number_of_prisms; ++i)
 			{
 				(void) GmfGetLin(mesh_index, GmfPrisms, &ids[0],&ids[1], &ids[2], &ids[3], &ids[4], &ids[5], &ref);
 				for (auto& id : ids)
@@ -131,7 +131,7 @@ protected:
 		{
 			GmfGotoKwd(mesh_index, GmfPyramids);
 			std::array<int, 5> ids;
-			for (int i = 0 ; i < number_of_pyramids; ++i)
+			for (uint32 i = 0; i < number_of_pyramids; ++i)
 			{
 				(void) GmfGetLin(mesh_index, GmfPyramids, &ids[0],&ids[1], &ids[2], &ids[3], &ids[4], &ref);
 				for (auto& id : ids)
@@ -199,7 +199,7 @@ protected:
 		{
 			GmfGotoKwd(mesh_index, GmfTriangles);
 			std::array<int, 3> ids;
-			for (int i = 0 ; i < number_of_triangles; ++i)
+			for (uint32 i = 0; i < number_of_triangles; ++i)
 			{
 				(void) GmfGetLin(mesh_index, GmfTriangles, &ids[0],&ids[1], &ids[2], &ref);
 				for (auto& id : ids)
@@ -213,7 +213,7 @@ protected:
 		{
 			GmfGotoKwd(mesh_index, GmfQuadrilaterals);
 			std::array<int, 4> ids;
-			for (int i = 0 ; i < number_of_quads; ++i)
+			for (uint32 i = 0; i < number_of_quads; ++i)
 			{
 				(void) GmfGetLin(mesh_index, GmfQuadrilaterals, &ids[0],&ids[1], &ids[2], &ids[3], &ref);
 				for (auto& id : ids)

--- a/cgogn/io/msh_io.h
+++ b/cgogn/io/msh_io.h
@@ -124,14 +124,14 @@ protected:
 	virtual uint32 msh_insert_line_vertex_container() = 0;
 	virtual void msh_clear() = 0;
 	virtual void msh_reserve(uint32 n) = 0;
-	virtual void msh_add_triangle(uint32 p0, uint32 p1, uint32 p2) {}
-	virtual void msh_add_quad(uint32 p0, uint32 p1, uint32 p2, uint32 p3) {}
-	virtual void msh_add_face(const std::vector<uint32>& v_ids) {}
-	virtual void msh_add_tetra(uint32 p0, uint32 p1, uint32 p2, uint32 p3, bool check_orientation) {}
-	virtual void msh_add_hexa(uint32 p0, uint32 p1, uint32 p2, uint32 p3, uint32 p4, uint32 p5, uint32 p6, uint32 p7, bool check_orientation) {}
-	virtual void msh_add_pyramid(uint32 p0, uint32 p1, uint32 p2, uint32 p3, uint32 p4, bool check_orientation) {}
-	virtual void msh_add_triangular_prism(uint32 p0, uint32 p1, uint32 p2, uint32 p3, uint32 p4, uint32 p5, bool check_orientation) {}
-	virtual void msh_add_connector(uint32 p0, uint32 p1, uint32 p2, uint32 p3) {}
+	virtual void msh_add_triangle(uint32 p0, uint32 p1, uint32 p2) { unused_parameters(p0, p1, p2); }
+	virtual void msh_add_quad(uint32 p0, uint32 p1, uint32 p2, uint32 p3) { unused_parameters(p0, p1, p2, p3); }
+	virtual void msh_add_face(const std::vector<uint32>& v_ids) { unused_parameters(v_ids); }
+	virtual void msh_add_tetra(uint32 p0, uint32 p1, uint32 p2, uint32 p3, bool check_orientation) { unused_parameters(p0, p1, p2, p3, check_orientation); }
+	virtual void msh_add_hexa(uint32 p0, uint32 p1, uint32 p2, uint32 p3, uint32 p4, uint32 p5, uint32 p6, uint32 p7, bool check_orientation) { unused_parameters(p0, p1, p2, p3, p4, p5, p6, p7, check_orientation); }
+	virtual void msh_add_pyramid(uint32 p0, uint32 p1, uint32 p2, uint32 p3, uint32 p4, bool check_orientation) { unused_parameters(p0, p1, p2, p3, p4, check_orientation); }
+	virtual void msh_add_triangular_prism(uint32 p0, uint32 p1, uint32 p2, uint32 p3, uint32 p4, uint32 p5, bool check_orientation) { unused_parameters(p0, p1, p2, p3, p4, p5, check_orientation); }
+	virtual void msh_add_connector(uint32 p0, uint32 p1, uint32 p2, uint32 p3) { unused_parameters(p0, p1, p2, p3); }
 
 
 	inline static std::string skip_empty_lines(std::istream& data_stream)
@@ -706,6 +706,7 @@ protected:
 
 	virtual void export_file_impl(const Map& map, std::ofstream& output, const ExportOptions& option) override
 	{
+		unused_parameters(option);
 		ChunkArrayGen const* pos = this->position_attribute();
 //		const std::string endianness = cgogn::internal::cgogn_is_little_endian ? "LittleEndian" : "BigEndian";
 //		const std::string format = (option.binary_?"binary" :"ascii");

--- a/cgogn/io/vtk_io.h
+++ b/cgogn/io/vtk_io.h
@@ -1567,7 +1567,7 @@ protected:
 			}
 		}
 
-		add_vtk_volumes(cells_buffer, *cell_types_vec, *(this->position_attribute()));
+		add_vtk_volumes(cells_buffer, *cell_types_vec);
 
 		return true;
 	}
@@ -1584,7 +1584,7 @@ protected:
 
 		ChunkArray<VEC3>* pos = this->position_attribute();
 		cgogn_assert(pos != nullptr);
-		add_vtk_volumes(*cells_vec,*cell_types_vec, *pos);
+		add_vtk_volumes(*cells_vec,*cell_types_vec);
 
 		return true;
 	}
@@ -1607,7 +1607,7 @@ protected:
 		}
 	}
 
-	inline void add_vtk_volumes(std::vector<uint32> ids, const std::vector<int>& type_vol, ChunkArray<VEC3> const& pos)
+	inline void add_vtk_volumes(std::vector<uint32> ids, const std::vector<int>& type_vol)
 	{
 		const uint32 nb_volumes = uint32(type_vol.size());
 		uint32 curr_offset = 0;

--- a/cgogn/multiresolution/cph/ihcmap3.h
+++ b/cgogn/multiresolution/cph/ihcmap3.h
@@ -76,7 +76,7 @@ public:
 	using VolumeAttribute = Attribute<T, Self::VOLUME>;
 	using DartMarker = typename cgogn::DartMarker<Self>;
 	using DartMarkerStore = typename cgogn::DartMarkerStore<Self>;
-
+	using Builder = CMap3Builder_T<Self>;
 	ChunkArray<uint32>* next_level_cell[NB_ORBITS];
 
 

--- a/cgogn/rendering/frame_manipulator.cpp
+++ b/cgogn/rendering/frame_manipulator.cpp
@@ -727,6 +727,7 @@ bool FrameManipulator::set_orientation(const QVector3D& X, const QVector3D& Y)
 
 void FrameManipulator::set_transformation( const QMatrix4x4& transfo)
 {
+	unused_parameters(transfo);
 	// TODO E.S.: transfo parameter is not used. It seems wrong.
 	QVector4D col = rotations_.column(3);
 	set_position(QVector3D(col[0],col[1],col[2]));

--- a/cgogn/rendering/map_render.h
+++ b/cgogn/rendering/map_render.h
@@ -217,6 +217,7 @@ protected:
 	inline auto init_boundaries(const MAP& m, const MASK& mask, std::vector<uint32>& table_indices)
 		-> typename std::enable_if<MAP::DIMENSION == 3 && !std::is_same<MASK, BoundaryCache<MAP>>::value, void>::type
 	{
+		unused_parameters(mask);
 		// if the given MASK is not a BoundaryCache, build a BoundaryCache and use it
 		BoundaryCache<MAP> bcache(m);
 		init_boundaries(m, bcache, table_indices);

--- a/cgogn/rendering/shaders/vbo.h
+++ b/cgogn/rendering/shaders/vbo.h
@@ -203,7 +203,7 @@ void update_vbo(const ATTR& attr, VBO* vbo)
 
 	uint32 byte_chunk_size;
 	std::vector<const void*> chunk_addr = ca->chunks_pointers(byte_chunk_size);
-	const uint32 nb_chunks = chunk_addr.size();
+	const uint32 nb_chunks = uint32(chunk_addr.size());
 
 	const uint32 vec_dim = geometry::nb_components_traits<typename ATTR::value_type>::value;
 
@@ -265,7 +265,7 @@ void update_vbo(const ATTR& attr, VBO* vbo, const FUNC& convert)
 	const typename ATTR::TChunkArray* ca = attr.data();
 	uint32 byte_chunk_size;
 	std::vector<const void*> chunk_addr = ca->chunks_pointers(byte_chunk_size);
-	const uint32 nb_chunks = chunk_addr.size();
+	const uint32 nb_chunks = uint32(chunk_addr.size());
 
 	// check that out of convert is float or std::array<float,2/3/4>
 	static_assert(is_func_return_same<FUNC,float32>::value || is_func_return_same<FUNC,Vec2f>::value || is_func_return_same<FUNC,Vec3f>::value || is_func_return_same<FUNC,Vec4f>::value, "convert output must be float or std::array<float,2/3/4>");

--- a/cgogn/rendering/topo_drawer.cpp
+++ b/cgogn/rendering/topo_drawer.cpp
@@ -123,7 +123,7 @@ void TopoDrawer::update_color(Dart d, const QColor& rgb)
 		vbo_color_darts_->bind();
 		float32 rgbf[6] = {float32(rgb.redF()),float32(rgb.greenF()),float32(rgb.blueF()),
 						  float32(rgb.redF()),float32(rgb.greenF()),float32(rgb.blueF())};
-		vbo_color_darts_->copy_data(x*24, 24, rgbf);
+		vbo_color_darts_->copy_data(uint32(x)*24u, 24u, rgbf);
 		vbo_color_darts_->release();
 	}
 }

--- a/cgogn/rendering/topo_drawer.h
+++ b/cgogn/rendering/topo_drawer.h
@@ -439,7 +439,7 @@ void TopoDrawer::update_color(Dart d, const RGB& rgb)
 		vbo_color_darts_->bind();
 		float32 rgbf[6] = {float32(rgb[0]),float32(rgb[1]),float32(rgb[2]),
 						  float32(rgb[0]),float32(rgb[1]),float32(rgb[2])};
-		vbo_color_darts_->copy_data(x*24, 24, rgbf);
+		vbo_color_darts_->copy_data(uint32(x)*24u, 24u, rgbf);
 		vbo_color_darts_->release();
 	}
 }


### PR DESCRIPTION
other changes:
- CMap2Builder and CMap3Builder directly take the map type as template parameter.
- added unused_params(T&&, ...) function to avoid some warnings.
