### PR TITLE
correct mixing opaque with transparent objects

### DIFF
--- a/cgogn/rendering/CMakeLists.txt
+++ b/cgogn/rendering/CMakeLists.txt
@@ -8,6 +8,7 @@ if (Qt5Widgets_VERSION VERSION_GREATER 5.5.99)
 	set(HEADER_W_QT56
 	transparency_shaders/shader_transparent_quad.h
 	transparency_shaders/shader_transparent_flat.h
+	transparency_shaders/shader_transparent_phong.h
 	transparency_shaders/shader_transparent_volumes.h
 	transparency_shaders/shader_copy_depth.h
 	transparency_drawer.h
@@ -17,6 +18,7 @@ if (Qt5Widgets_VERSION VERSION_GREATER 5.5.99)
 	set(SOURCE_W_QT56
 	transparency_shaders/shader_transparent_quad.cpp
 	transparency_shaders/shader_transparent_flat.cpp
+	transparency_shaders/shader_transparent_phong.cpp
 	transparency_shaders/shader_transparent_volumes.cpp
 	transparency_shaders/shader_copy_depth.cpp
 	transparency_drawer.cpp

--- a/cgogn/rendering/CMakeLists.txt
+++ b/cgogn/rendering/CMakeLists.txt
@@ -9,6 +9,7 @@ if (Qt5Widgets_VERSION VERSION_GREATER 5.5.99)
 	transparency_shaders/shader_transparent_quad.h
 	transparency_shaders/shader_transparent_flat.h
 	transparency_shaders/shader_transparent_volumes.h
+	transparency_shaders/shader_copy_depth.h
 	transparency_drawer.h
 	transparency_volume_drawer.h
 	)
@@ -17,6 +18,7 @@ if (Qt5Widgets_VERSION VERSION_GREATER 5.5.99)
 	transparency_shaders/shader_transparent_quad.cpp
 	transparency_shaders/shader_transparent_flat.cpp
 	transparency_shaders/shader_transparent_volumes.cpp
+	transparency_shaders/shader_copy_depth.cpp
 	transparency_drawer.cpp
 	transparency_volume_drawer.cpp
 	)

--- a/cgogn/rendering/examples/transparency_viewer.cpp
+++ b/cgogn/rendering/examples/transparency_viewer.cpp
@@ -199,7 +199,10 @@ void ViewerTransparency::draw()
 		param_point_sprite_->release();
 	}
 
-	transp_drawer_->draw(proj,view, [&] { render_->draw(cgogn::rendering::TRIANGLES); });
+	transp_drawer_->draw(proj,view, [&] { render_->draw(cgogn::rendering::TRIANGLES); },
+					  [&] { param_point_sprite_->bind(proj, view);
+							render_->draw(cgogn::rendering::POINTS);
+							param_point_sprite_->release(); });
 
 	nb_fps_++;
 	std::chrono::duration<float64> elapsed_seconds = std::chrono::system_clock::now() - start_fps_;

--- a/cgogn/rendering/examples/transparency_viewer.cpp
+++ b/cgogn/rendering/examples/transparency_viewer.cpp
@@ -199,10 +199,7 @@ void ViewerTransparency::draw()
 		param_point_sprite_->release();
 	}
 
-	transp_drawer_->draw(proj,view, [&] { render_->draw(cgogn::rendering::TRIANGLES); },
-					  [&] { param_point_sprite_->bind(proj, view);
-							render_->draw(cgogn::rendering::POINTS);
-							param_point_sprite_->release(); });
+	transp_drawer_->draw(proj,view, [&] { render_->draw(cgogn::rendering::TRIANGLES); });
 
 	nb_fps_++;
 	std::chrono::duration<float64> elapsed_seconds = std::chrono::system_clock::now() - start_fps_;

--- a/cgogn/rendering/transparency_drawer.cpp
+++ b/cgogn/rendering/transparency_drawer.cpp
@@ -30,7 +30,7 @@ namespace cgogn
 namespace rendering
 {
 
-FlatTransparencyDrawer::~FlatTransparencyDrawer()
+SurfaceTransparencyDrawer::~SurfaceTransparencyDrawer()
 {
 	param_flat_.reset();
 	param_trq_.reset();
@@ -39,7 +39,7 @@ FlatTransparencyDrawer::~FlatTransparencyDrawer()
 		ogl33_->glDeleteQueries(1, &oq_transp);
 }
 
-FlatTransparencyDrawer::FlatTransparencyDrawer(int w, int h, QOpenGLFunctions_3_3_Core* ogl33):
+SurfaceTransparencyDrawer::SurfaceTransparencyDrawer(int w, int h, QOpenGLFunctions_3_3_Core* ogl33):
 	max_nb_layers_(8),
 	param_flat_(nullptr),
 	param_trq_(nullptr),
@@ -54,6 +54,13 @@ FlatTransparencyDrawer::FlatTransparencyDrawer(int w, int h, QOpenGLFunctions_3_
 	param_flat_->front_color_ = QColor(0,250,0,120);
 	param_flat_->back_color_ = QColor(0,0,250,120);
 	param_flat_->ambiant_color_ = QColor(0,0,0,0);
+
+	param_phong_ = cgogn::rendering::ShaderPhongTransp::generate_param();
+	param_phong_->front_color_ = QColor(0,250,0,120);
+	param_phong_->back_color_ = QColor(0,0,250,120);
+	param_phong_->ambiant_color_ = QColor(0,0,0,0);
+	param_phong_->specular_color_ = QColor(255,255,255,0);
+	param_phong_->specular_coef_ = 100.0f;
 
 	param_trq_ = cgogn::rendering::ShaderTranspQuad::generate_param();
 
@@ -73,7 +80,7 @@ FlatTransparencyDrawer::FlatTransparencyDrawer(int w, int h, QOpenGLFunctions_3_
 	param_copy_depth_ = ShaderCopyDepth::generate_param();
 }
 
-void FlatTransparencyDrawer::resize(int w, int h)
+void SurfaceTransparencyDrawer::resize(int w, int h)
 {
 	if (ogl33_ == nullptr)
 		return;

--- a/cgogn/rendering/transparency_drawer.cpp
+++ b/cgogn/rendering/transparency_drawer.cpp
@@ -61,7 +61,7 @@ FlatTransparencyDrawer::FlatTransparencyDrawer(int w, int h, QOpenGLFunctions_3_
 	fbo_layer_->addColorAttachment(width_,height_,GL_R32F);
 	fbo_layer_->addColorAttachment(width_,height_);
 	fbo_layer_->addColorAttachment(width_,height_,GL_R32F); // first depth
-
+	fbo_layer_->addColorAttachment(width_, height_);
 	ogl33_->glGenQueries(1, &oq_transp);
 }
 
@@ -75,6 +75,7 @@ void FlatTransparencyDrawer::resize(int w, int h)
 	fbo_layer_->addColorAttachment(width_,height_,GL_R32F);
 	fbo_layer_->addColorAttachment(width_,height_);
 	fbo_layer_->addColorAttachment(width_,height_,GL_R32F); // first depth
+	fbo_layer_->addColorAttachment(width_, height_);
 }
 
 

--- a/cgogn/rendering/transparency_drawer.h
+++ b/cgogn/rendering/transparency_drawer.h
@@ -26,6 +26,7 @@
 
 #include <cgogn/rendering/dll.h>
 #include <cgogn/rendering/transparency_shaders/shader_transparent_flat.h>
+#include <cgogn/rendering/transparency_shaders/shader_transparent_phong.h>
 #include <cgogn/rendering/transparency_shaders/shader_transparent_quad.h>
 #include <cgogn/rendering/transparency_shaders/shader_copy_depth.h>
 
@@ -41,12 +42,14 @@ namespace cgogn
 namespace rendering
 {
 
-class CGOGN_RENDERING_API FlatTransparencyDrawer
+class CGOGN_RENDERING_API SurfaceTransparencyDrawer
 {
 	int max_nb_layers_;
 
 	/// rendering shader
 	std::unique_ptr<cgogn::rendering::ShaderFlatTransp::Param> param_flat_;
+
+	std::unique_ptr<cgogn::rendering::ShaderPhongTransp::Param> param_phong_;
 
 	/// shader for quad blending  with opaque scene
 	std::unique_ptr<cgogn::rendering::ShaderTranspQuad::Param> param_trq_;
@@ -69,7 +72,7 @@ class CGOGN_RENDERING_API FlatTransparencyDrawer
 
 public:
 
-	~FlatTransparencyDrawer();
+	~SurfaceTransparencyDrawer();
 
 	/**
 	 * @brief create and init
@@ -77,7 +80,7 @@ public:
 	 * @param h height GL widget (do not forget to multiply by devicePixelRatio())
 	 * @param ogl33
 	 */
-	FlatTransparencyDrawer(int w, int h, QOpenGLFunctions_3_3_Core* ogl33);
+	SurfaceTransparencyDrawer(int w, int h, QOpenGLFunctions_3_3_Core* ogl33);
 
 
 	/**
@@ -94,7 +97,16 @@ public:
 	 * @param draw_func the func/lambda that draw transparent objects
 	 */
 	template<typename TFUNC>
-	void draw(const QMatrix4x4& proj, const QMatrix4x4& view, const TFUNC& draw_func);
+	void draw_flat(const QMatrix4x4& proj, const QMatrix4x4& view, const TFUNC& draw_func);
+
+	/**
+	 * @brief draw the transparent objects mixed with opaque (also drawn separatly)
+	 * @param proj projection matrix
+	 * @param view modelview matrix
+	 * @param draw_func the func/lambda that draw transparent objects
+	 */
+	template<typename TFUNC>
+	void draw_phong(const QMatrix4x4& proj, const QMatrix4x4& view, const TFUNC& draw_func);
 
 
 	/**
@@ -109,31 +121,43 @@ public:
 	inline void set_light_position(const QVector3D& l)
 	{
 		param_flat_->light_pos_ = l;
+		param_phong_->light_pos_ = l;
 	}
 
 	inline void set_front_color(const QColor& rgba)
 	{
 		param_flat_->front_color_ = rgba;
+		param_phong_->front_color_ = rgba;
 	}
 
 	inline void set_back_color(const QColor& rgba)
 	{
 		param_flat_->back_color_ = rgba;
+		param_phong_->back_color_ = rgba;
 	}
 
 	inline void set_ambiant_color(const QColor& rgba)
 	{
 		param_flat_->ambiant_color_ = rgba;
+		param_phong_->ambiant_color_ = rgba;
 	}
 
 	inline void set_position_vbo(cgogn::rendering::VBO* vbo_pos)
 	{
 		param_flat_->set_position_vbo(vbo_pos);
+		param_phong_->set_position_vbo(vbo_pos);
 	}
+
+	inline void set_normal_vbo(cgogn::rendering::VBO* vbo_norm)
+	{
+		param_phong_->set_normal_vbo(vbo_norm);
+	}
+
 
 	inline void set_back_face_culling(bool cull)
 	{
 		param_flat_->bf_culling_ = cull;
+		param_phong_->bf_culling_ = cull;
 	}
 
 	inline void  set_lighted(bool lighted)
@@ -146,19 +170,19 @@ public:
 
 
 /**
- * @brief FlatTransparencyDrawer::draw
+ * @brief SurfaceTransparencyDrawer::draw
  * @param proj projection matrix
  * @param view modelview matrix
  * @param draw_func geometry drawing drawing function
  */
 template<typename TFUNC>
-void FlatTransparencyDrawer::draw(const QMatrix4x4& proj, const QMatrix4x4& view, const TFUNC& draw_func)
+void SurfaceTransparencyDrawer::draw_flat(const QMatrix4x4& proj, const QMatrix4x4& view, const TFUNC& draw_func)
 {
-	GLfloat bkColor[4];
-	glGetFloatv(GL_COLOR_CLEAR_VALUE, bkColor);
-
 	if (ogl33_ == nullptr)
 		return;
+
+	GLfloat bkColor[4];
+	ogl33_->glGetFloatv(GL_COLOR_CLEAR_VALUE, bkColor);
 
 	ogl33_->glEnable(GL_TEXTURE_2D);
 
@@ -253,7 +277,120 @@ void FlatTransparencyDrawer::draw(const QMatrix4x4& proj, const QMatrix4x4& view
 	param_trq_->release();
 	ogl33_->glDisable(GL_BLEND);
 
-	glClearColor(bkColor[0],bkColor[1],bkColor[2],bkColor[3]);
+	ogl33_->glClearColor(bkColor[0],bkColor[1],bkColor[2],bkColor[3]);
+
+}
+
+
+/**
+ * @brief SurfaceTransparencyDrawer::draw
+ * @param proj projection matrix
+ * @param view modelview matrix
+ * @param draw_func geometry drawing drawing function
+ */
+template<typename TFUNC>
+void SurfaceTransparencyDrawer::draw_phong(const QMatrix4x4& proj, const QMatrix4x4& view, const TFUNC& draw_func)
+{
+	if (ogl33_ == nullptr)
+		return;
+
+	GLfloat bkColor[4];
+	ogl33_->glGetFloatv(GL_COLOR_CLEAR_VALUE, bkColor);
+
+	ogl33_->glEnable(GL_TEXTURE_2D);
+
+	ogl33_->glEnable(GL_TEXTURE_2D);
+	ogl33_->glBindTexture(GL_TEXTURE_2D, depthTexture_);
+	ogl33_->glReadBuffer(GL_BACK);
+	ogl33_->glCopyTexSubImage2D(GL_TEXTURE_2D,0,0,0,0,0, width_, height_);
+
+	QVector<GLuint> textures = fbo_layer_->textures();
+	GLenum buffs[2] = {GL_COLOR_ATTACHMENT0,GL_COLOR_ATTACHMENT2};
+
+	param_phong_->rgba_texture_sampler_ = 0;
+	param_phong_->depth_texture_sampler_ = 1;
+	fbo_layer_->bind();
+
+	GLenum clear_buff[1] = {GL_COLOR_ATTACHMENT3};
+	ogl33_->glDrawBuffers(1,clear_buff);
+	ogl33_->glClearColor(0.0f,0.0f,0.0f,1.0f);
+	ogl33_->glClear(GL_COLOR_BUFFER_BIT);
+
+	ogl33_->glDrawBuffers(1,buffs);
+	ogl33_->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+	GLenum opaq_buff[1] = { GL_COLOR_ATTACHMENT5 };
+
+	for (int p=0;p<max_nb_layers_;++p)
+	{
+		ogl33_->glClear(GL_DEPTH_BUFFER_BIT);
+
+		if (p > 0)
+		{
+			ogl33_->glDrawBuffers(1, opaq_buff);
+			param_copy_depth_->bind(proj, view);
+			ogl33_->glBindTexture(GL_TEXTURE_2D, depthTexture_);
+			ogl33_->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+			param_copy_depth_->release();
+		}
+
+		ogl33_->glDrawBuffers(2,buffs);
+		param_phong_->layer_ = p;
+		ogl33_->glActiveTexture(GL_TEXTURE0);
+		ogl33_->glBindTexture(GL_TEXTURE_2D,textures[3]);
+		ogl33_->glActiveTexture(GL_TEXTURE1);
+		ogl33_->glBindTexture(GL_TEXTURE_2D,textures[1]);
+
+		ogl33_->glBeginQuery(GL_SAMPLES_PASSED, oq_transp);
+		param_phong_->bind(proj,view);
+		draw_func();
+		param_phong_->release();
+		ogl33_->glEndQuery(GL_SAMPLES_PASSED);
+
+		GLuint nb_samples;
+		ogl33_->glGetQueryObjectuiv(oq_transp, GL_QUERY_RESULT, &nb_samples);
+
+		if (nb_samples==0) // finished ?
+			p = max_nb_layers_;
+		else
+		{
+			ogl33_->glReadBuffer(GL_COLOR_ATTACHMENT2);
+			ogl33_->glBindTexture(GL_TEXTURE_2D,textures[1]);
+			ogl33_->glCopyTexImage2D(GL_TEXTURE_2D,0,GL_R32F,0,0,width_,height_,0);
+
+			if (p==0)
+			{
+				ogl33_->glBindTexture(GL_TEXTURE_2D,textures[4]);
+				ogl33_->glCopyTexImage2D(GL_TEXTURE_2D,0,GL_R32F,0,0,width_,height_,0);
+			}
+
+			ogl33_->glReadBuffer(GL_COLOR_ATTACHMENT0);
+			ogl33_->glBindTexture(GL_TEXTURE_2D,textures[3]);
+			ogl33_->glCopyTexImage2D(GL_TEXTURE_2D,0, GL_RGBA32F,0,0,width_,height_,0);
+		}
+	}
+
+	fbo_layer_->release();
+
+	// real draw with blending with opaque object
+
+	param_trq_->rgba_texture_sampler_ = 0;
+	param_trq_->depth_texture_sampler_ = 1;
+
+	ogl33_->glActiveTexture(GL_TEXTURE0);
+	ogl33_->glBindTexture(GL_TEXTURE_2D,textures[3]);
+
+	ogl33_->glActiveTexture(GL_TEXTURE1);
+	ogl33_->glBindTexture(GL_TEXTURE_2D,textures[4]);
+
+	ogl33_->glEnable(GL_BLEND);
+	ogl33_->glBlendFunc(GL_ONE,GL_SRC_ALPHA);
+	param_trq_->bind(proj,view);
+	ogl33_->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	param_trq_->release();
+	ogl33_->glDisable(GL_BLEND);
+
+	ogl33_->glClearColor(bkColor[0],bkColor[1],bkColor[2],bkColor[3]);
 
 }
 

--- a/cgogn/rendering/transparency_shaders/shader_copy_depth.cpp
+++ b/cgogn/rendering/transparency_shaders/shader_copy_depth.cpp
@@ -49,11 +49,9 @@ const char* ShaderCopyDepth::fragment_shader_source_ =
 "#version 330\n"
 "uniform sampler2D depth_texture;\n"
 "in vec2 tc;\n"
-//"out vec4 col;\n"
 "void main(void)\n"
 "{\n"
-"	gl_FragDepth = texture(depth_texture, tc).r;\n"
-//"	col = vec4(0.0,0.0,0.0,1.0);"
+"	gl_FragDepth = texture(depth_texture,tc).r;\n"
 "}\n";
 
 std::unique_ptr<ShaderCopyDepth> ShaderCopyDepth::instance_ = nullptr;
@@ -93,7 +91,8 @@ void ShaderParamCopyDepth::set_uniforms()
 	ShaderCopyDepth* sh = static_cast<ShaderCopyDepth*>(this->shader_);
 	sh->set_depth_sampler(0);
 	QOpenGLContext::currentContext()->functions()->glActiveTexture(GL_TEXTURE0);
-
+	if (texture_!=nullptr)
+		texture_->bind();
 }
 
 } // namespace rendering

--- a/cgogn/rendering/transparency_shaders/shader_copy_depth.cpp
+++ b/cgogn/rendering/transparency_shaders/shader_copy_depth.cpp
@@ -1,0 +1,99 @@
+/*******************************************************************************
+* CGoGN: Combinatorial and Geometric modeling with Generic N-dimensional Maps  *
+* Copyright (C) 2015, IGG Group, ICube, University of Strasbourg, France       *
+*                                                                              *
+* This library is free software; you can redistribute it and/or modify it      *
+* under the terms of the GNU Lesser General Public License as published by the *
+* Free Software Foundation; either version 2.1 of the License, or (at your     *
+* option) any later version.                                                   *
+*                                                                              *
+* This library is distributed in the hope that it will be useful, but WITHOUT  *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *
+* for more details.                                                            *
+*                                                                              *
+* You should have received a copy of the GNU Lesser General Public License     *
+* along with this library; if not, write to the Free Software Foundation,      *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.           *
+*                                                                              *
+* Web site: http://cgogn.unistra.fr/                                           *
+* Contact information: cgogn@unistra.fr                                        *
+*                                                                              *
+*******************************************************************************/
+
+#define CGOGN_RENDER_FLAT_TR_DR_CPP_
+
+
+#include <iostream>
+
+#include <cgogn/rendering/transparency_shaders/shader_copy_depth.h>
+
+
+namespace cgogn
+{
+
+namespace rendering
+{
+
+const char* ShaderCopyDepth::vertex_shader_source_ =
+"#version 330\n"
+"out vec2 tc;\n"
+"void main(void)\n"
+"{\n"
+"	vec4 vertices[4] = vec4[4](vec4(-1.0, -1.0, 0.0, 1.0), vec4(1.0, -1.0, 0.0, 1.0), vec4(-1.0, 1.0, 0.0, 1.0), vec4(1.0, 1.0, 0.0, 1.0));\n"
+"	gl_Position = vertices[gl_VertexID];\n"
+"	tc = (gl_Position.xy + vec2(1,1))/2;\n"
+"}\n";
+
+const char* ShaderCopyDepth::fragment_shader_source_ =
+"#version 330\n"
+"uniform sampler2D depth_texture;\n"
+"in vec2 tc;\n"
+"void main(void)\n"
+"{\n"
+"	gl_FragDepth = texture(depth_texture, tc).r;\n"
+"}\n";
+
+std::unique_ptr<ShaderCopyDepth> ShaderCopyDepth::instance_ = nullptr;
+
+ShaderCopyDepth::ShaderCopyDepth()
+{
+	prg_.addShaderFromSourceCode(QOpenGLShader::Vertex, vertex_shader_source_);
+	prg_.addShaderFromSourceCode(QOpenGLShader::Fragment, fragment_shader_source_);
+	prg_.link();
+
+	unif_depth_texture_sampler_ = prg_.uniformLocation("depth_texture");
+}
+
+
+void ShaderCopyDepth::set_depth_sampler(GLuint depth_samp)
+{
+	prg_.setUniformValue(unif_depth_texture_sampler_, depth_samp);
+}
+
+std::unique_ptr< ShaderCopyDepth::Param> ShaderCopyDepth::generate_param()
+{
+	if (!instance_)
+		instance_ = std::unique_ptr<ShaderCopyDepth>(new ShaderCopyDepth());
+	return cgogn::make_unique<ShaderCopyDepth::Param>(instance_.get());
+}
+
+
+
+ShaderParamCopyDepth::ShaderParamCopyDepth(ShaderCopyDepth* sh) :
+	ShaderParam(sh),
+	texture_(nullptr)
+{}
+
+
+void ShaderParamCopyDepth::set_uniforms()
+{
+	ShaderCopyDepth* sh = static_cast<ShaderCopyDepth*>(this->shader_);
+	sh->set_depth_sampler(0);
+	QOpenGLContext::currentContext()->functions()->glActiveTexture(GL_TEXTURE0);
+
+}
+
+} // namespace rendering
+
+} // namespace cgogn

--- a/cgogn/rendering/transparency_shaders/shader_copy_depth.cpp
+++ b/cgogn/rendering/transparency_shaders/shader_copy_depth.cpp
@@ -49,9 +49,11 @@ const char* ShaderCopyDepth::fragment_shader_source_ =
 "#version 330\n"
 "uniform sampler2D depth_texture;\n"
 "in vec2 tc;\n"
+//"out vec4 col;\n"
 "void main(void)\n"
 "{\n"
 "	gl_FragDepth = texture(depth_texture, tc).r;\n"
+//"	col = vec4(0.0,0.0,0.0,1.0);"
 "}\n";
 
 std::unique_ptr<ShaderCopyDepth> ShaderCopyDepth::instance_ = nullptr;

--- a/cgogn/rendering/transparency_shaders/shader_copy_depth.h
+++ b/cgogn/rendering/transparency_shaders/shader_copy_depth.h
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* CGoGN: Combinatorial and Geometric modeling with Generic N-dimensional Maps  *
+* Copyright (C) 2015, IGG Group, ICube, University of Strasbourg, France       *
+*                                                                              *
+* This library is free software; you can redistribute it and/or modify it      *
+* under the terms of the GNU Lesser General Public License as published by the *
+* Free Software Foundation; either version 2.1 of the License, or (at your     *
+* option) any later version.                                                   *
+*                                                                              *
+* This library is distributed in the hope that it will be useful, but WITHOUT  *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *
+* for more details.                                                            *
+*                                                                              *
+* You should have received a copy of the GNU Lesser General Public License     *
+* along with this library; if not, write to the Free Software Foundation,      *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.           *
+*                                                                              *
+* Web site: http://cgogn.unistra.fr/                                           *
+* Contact information: cgogn@unistra.fr                                        *
+*                                                                              *
+*******************************************************************************/
+
+#ifndef CGOGN_RENDERING_SHADER_COPY_DEPTH_H_
+#define CGOGN_RENDERING_SHADER_COPY_DEPTH_H_
+
+#include <cgogn/rendering/dll.h>
+#include <cgogn/rendering/shaders/shader_program.h>
+#include <cgogn/rendering/shaders/vbo.h>
+
+#include <QOpenGLFunctions>
+#include <QOpenGLTexture>
+
+namespace cgogn
+{
+
+namespace rendering
+{
+
+// forward
+class ShaderCopyDepth;
+
+
+
+class CGOGN_RENDERING_API ShaderParamCopyDepth : public ShaderParam
+{
+protected:
+	void set_uniforms() override;
+public:
+	QOpenGLTexture* texture_;
+	GLuint depth_texture_sampler_;
+	ShaderParamCopyDepth(ShaderCopyDepth* sh);
+};
+
+
+class CGOGN_RENDERING_API ShaderCopyDepth : public ShaderProgram
+{
+	friend class ShaderParamCopyDepth;
+
+protected:
+
+	static const char* vertex_shader_source_;
+	static const char* fragment_shader_source_;
+
+	// uniform ids
+	GLint unif_depth_texture_sampler_;
+
+public:
+
+	using Self = ShaderCopyDepth;
+	CGOGN_NOT_COPYABLE_NOR_MOVABLE(ShaderCopyDepth);
+
+	void set_depth_sampler(GLuint depth_samp);
+
+	using Param = ShaderParamCopyDepth;
+
+	static std::unique_ptr<Param> generate_param();
+
+private:
+
+	ShaderCopyDepth();
+	static std::unique_ptr<ShaderCopyDepth> instance_;
+
+};
+
+} // namespace rendering
+
+} // namespace cgogn
+
+#endif // CGOGN_RENDERING_SHADER_COPY_DEPTH_H_

--- a/cgogn/rendering/transparency_shaders/shader_transparent_phong.cpp
+++ b/cgogn/rendering/transparency_shaders/shader_transparent_phong.cpp
@@ -1,0 +1,249 @@
+/*******************************************************************************
+* CGoGN: Combinatorial and Geometric modeling with Generic N-dimensional Maps  *
+* Copyright (C) 2015, IGG Group, ICube, University of Strasbourg, France       *
+*                                                                              *
+* This library is free software; you can redistribute it and/or modify it      *
+* under the terms of the GNU Lesser General Public License as published by the *
+* Free Software Foundation; either version 2.1 of the License, or (at your     *
+* option) any later version.                                                   *
+*                                                                              *
+* This library is distributed in the hope that it will be useful, but WITHOUT  *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *
+* for more details.                                                            *
+*                                                                              *
+* You should have received a copy of the GNU Lesser General Public License     *
+* along with this library; if not, write to the Free Software Foundation,      *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.           *
+*                                                                              *
+* Web site: http://cgogn.unistra.fr/                                           *
+* Contact information: cgogn@unistra.fr                                        *
+*                                                                              *
+*******************************************************************************/
+
+#include <iostream>
+
+#include <cgogn/rendering/transparency_shaders/shader_transparent_phong.h>
+
+
+namespace cgogn
+{
+
+namespace rendering
+{
+
+
+const char* ShaderPhongTransp::vertex_shader_source_ =
+"#version 330\n"
+"in vec3 vertex_pos;\n"
+"in vec3 vertex_normal;\n"
+"uniform mat4 projection_matrix;\n"
+"uniform mat4 model_view_matrix;\n"
+"uniform mat3 normal_matrix;\n"
+"out vec3 Normal;\n"
+"out vec3 pos;\n"
+"out vec4 projCoord;\n"
+"void main()\n"
+"{\n"
+"	Normal = normal_matrix * vertex_normal;\n"
+"	vec4 pos4 = model_view_matrix * vec4(vertex_pos,1.0);\n"
+"	pos = pos4.xyz;"
+"	gl_Position = projection_matrix * pos4;\n"
+"   projCoord = gl_Position;\n"
+"}\n";
+
+const char* ShaderPhongTransp::fragment_shader_source_ =
+"#version 330\n"
+"layout(location = 0) out vec4 color_out;\n"
+"layout(location = 1) out float depth_out;\n"
+"in vec3 pos;\n"
+"in vec4 projCoord;\n"
+"in vec3 Normal;\n"
+"uniform vec4 front_color;\n"
+"uniform vec4 back_color;\n"
+"uniform vec4 ambiant_color;\n"
+"uniform vec4 spec_color;\n"
+"uniform float spec_coef;\n"
+"uniform vec3 lightPosition;\n"
+"uniform sampler2D rgba_texture ;\n"
+"uniform sampler2D depth_texture ;\n"
+"uniform int layer;\n"
+"uniform bool cull_back_face;\n"
+"void main()\n"
+"{\n"
+"	vec3 EyeVector = -pos;"
+"	vec3 N = normalize (Normal);\n"
+"	vec3 L = normalize (lightPosition - pos);\n"
+"	vec3 E = normalize(-pos);\n"
+"	vec3 R = reflect(-L, N);\n"
+"	float specular = pow( max(dot(R, E), 0.0), spec_coef );\n"
+
+"	vec3 tc = 0.5*projCoord.xyz/projCoord.w + vec3(0.5,0.5,0.5);\n"
+"	if ((layer>0) && (tc.z <= texture(depth_texture, tc.xy).r)) discard;\n"
+"	if (gl_FrontFacing==false)\n" // do not use ! because of bug on old intel under OS/X
+"	{\n"
+"		N *= -1.0;\n"
+"	}\n"
+"	float lambert = clamp(dot(N,L),0.0,1.0);\n"
+"	vec3 color;\n"
+"	float alpha;\n"
+"	if (gl_FrontFacing)\n"
+"		{ color = ambiant_color.rgb+lambert*front_color.rgb+spec_color.rgb*specular; alpha = front_color.a;}\n"
+"	else \n"
+"		if (cull_back_face) discard;\n"
+"		 else { color = ambiant_color.rgb+lambert*back_color.rgb+spec_color.rgb*specular; alpha = back_color.a;}\n"
+"	vec4 dst = texture(rgba_texture, tc.xy);\n"
+"	color_out = vec4( (dst.a * (alpha * color) + dst.rgb), (1.0-alpha)*dst.a);"
+"	depth_out = tc.z;\n"
+"}\n";
+
+std::unique_ptr<ShaderPhongTransp> ShaderPhongTransp::instance_ = nullptr;
+
+ShaderPhongTransp::ShaderPhongTransp()
+{
+	prg_.addShaderFromSourceCode(QOpenGLShader::Vertex, vertex_shader_source_);
+	prg_.addShaderFromSourceCode(QOpenGLShader::Fragment, fragment_shader_source_);
+	prg_.bindAttributeLocation("vertex_pos", ATTRIB_POS);
+	prg_.link();
+	get_matrices_uniforms();
+
+	unif_front_color_ = prg_.uniformLocation("front_color");
+	unif_back_color_ = prg_.uniformLocation("back_color");
+	unif_ambiant_color_ = prg_.uniformLocation("ambiant_color");
+	unif_specular_color_ = prg_.uniformLocation("spec_color");
+	unif_specular_coef_ = prg_.uniformLocation("spec_coef");
+
+	unif_light_position_ = prg_.uniformLocation("lightPosition");
+	unif_layer_ = prg_.uniformLocation("layer");
+	unif_bf_culling_ = prg_.uniformLocation("cull_back_face");
+	unif_rgba_texture_sampler_ =  prg_.uniformLocation("rgba_texture");
+	unif_depth_texture_sampler_ = prg_.uniformLocation("depth_texture");
+}
+
+void ShaderPhongTransp::set_light_position(const QVector3D& l)
+{
+	prg_.setUniformValue(unif_light_position_, l);
+}
+
+void ShaderPhongTransp::set_front_color(const QColor& rgb)
+{
+	if (unif_front_color_ >= 0)
+		prg_.setUniformValue(unif_front_color_, rgb);
+}
+
+void ShaderPhongTransp::set_back_color(const QColor& rgb)
+{
+	if (unif_back_color_ >= 0)
+		prg_.setUniformValue(unif_back_color_, rgb);
+}
+
+void ShaderPhongTransp::set_ambiant_color(const QColor& rgb)
+{
+	prg_.setUniformValue(unif_ambiant_color_, rgb);
+}
+
+void ShaderPhongTransp::set_specular_color(const QColor& rgb)
+{
+	prg_.setUniformValue(unif_specular_color_, rgb);
+}
+
+void ShaderPhongTransp::set_specular_coef(GLfloat coef)
+{
+	prg_.setUniformValue(unif_specular_coef_, coef);
+}
+
+
+void ShaderPhongTransp::set_bf_culling(bool cull)
+{
+	prg_.setUniformValue(unif_bf_culling_, cull);
+}
+
+
+void ShaderPhongTransp::set_layer(int layer)
+{
+	prg_.setUniformValue(unif_layer_, layer);
+}
+
+void ShaderPhongTransp::set_rgba_sampler(GLuint rgba_samp)
+{
+	prg_.setUniformValue(unif_rgba_texture_sampler_, rgba_samp);
+}
+
+void ShaderPhongTransp::set_depth_sampler(GLuint depth_samp)
+{
+	prg_.setUniformValue(unif_depth_texture_sampler_, depth_samp);
+}
+
+
+std::unique_ptr< ShaderPhongTransp::Param> ShaderPhongTransp::generate_param()
+{
+	if (!instance_)
+		instance_ = std::unique_ptr<ShaderPhongTransp>(new ShaderPhongTransp());
+	return cgogn::make_unique<ShaderPhongTransp::Param>(instance_.get());
+}
+
+
+
+
+
+ShaderParamPhongTransp::ShaderParamPhongTransp(ShaderPhongTransp* sh) :
+	ShaderParam(sh),
+	front_color_(250, 0, 0),
+	back_color_(0, 250, 0),
+	ambiant_color_(5, 5, 5),
+	specular_color_(255, 255, 255),
+	specular_coef_(100),
+	light_pos_(10, 100, 1000),
+	rgba_texture_sampler_(0),
+	depth_texture_sampler_(1),
+	bf_culling_(false)
+{}
+
+void ShaderParamPhongTransp::set_position_vbo(VBO* vbo_pos)
+{
+	QOpenGLFunctions* ogl = QOpenGLContext::currentContext()->functions();
+	shader_->bind();
+	vao_->bind();
+	// position vbo
+	vbo_pos->bind();
+	ogl->glEnableVertexAttribArray(ShaderPhongTransp::ATTRIB_POS);
+	ogl->glVertexAttribPointer(ShaderPhongTransp::ATTRIB_POS, vbo_pos->vector_dimension(), GL_FLOAT, GL_FALSE, 0, 0);
+	vbo_pos->release();
+	vao_->release();
+	shader_->release();
+}
+
+void ShaderParamPhongTransp::set_normal_vbo(VBO* vbo_normal)
+{
+	QOpenGLFunctions* ogl = QOpenGLContext::currentContext()->functions();
+	shader_->bind();
+	vao_->bind();
+	// position vbo
+	vbo_normal->bind();
+	ogl->glEnableVertexAttribArray(ShaderPhongTransp::ATTRIB_NORM);
+	ogl->glVertexAttribPointer(ShaderPhongTransp::ATTRIB_NORM, vbo_normal->vector_dimension(), GL_FLOAT, GL_FALSE, 0, 0);
+	vbo_normal->release();
+	vao_->release();
+	shader_->release();
+}
+
+
+
+void ShaderParamPhongTransp::set_uniforms()
+{
+	ShaderPhongTransp* sh = static_cast<ShaderPhongTransp*>(this->shader_);
+	sh->set_front_color(front_color_);
+	sh->set_back_color(back_color_);
+	sh->set_ambiant_color(ambiant_color_);
+	sh->set_specular_color(specular_color_);
+	sh->set_specular_coef(specular_coef_);
+	sh->set_light_position(light_pos_);
+	sh->set_layer(layer_);
+	sh->set_bf_culling(bf_culling_);
+	sh->set_rgba_sampler(rgba_texture_sampler_);
+	sh->set_depth_sampler(depth_texture_sampler_);
+}
+
+} // namespace rendering
+
+} // namespace cgogn

--- a/cgogn/rendering/transparency_shaders/shader_transparent_phong.h
+++ b/cgogn/rendering/transparency_shaders/shader_transparent_phong.h
@@ -1,0 +1,165 @@
+/*******************************************************************************
+* CGoGN: Combinatorial and Geometric modeling with Generic N-dimensional Maps  *
+* Copyright (C) 2015, IGG Group, ICube, University of Strasbourg, France       *
+*                                                                              *
+* This library is free software; you can redistribute it and/or modify it      *
+* under the terms of the GNU Lesser General Public License as published by the *
+* Free Software Foundation; either version 2.1 of the License, or (at your     *
+* option) any later version.                                                   *
+*                                                                              *
+* This library is distributed in the hope that it will be useful, but WITHOUT  *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *
+* for more details.                                                            *
+*                                                                              *
+* You should have received a copy of the GNU Lesser General Public License     *
+* along with this library; if not, write to the Free Software Foundation,      *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.           *
+*                                                                              *
+* Web site: http://cgogn.unistra.fr/                                           *
+* Contact information: cgogn@unistra.fr                                        *
+*                                                                              *
+*******************************************************************************/
+
+#ifndef CGOGN_RENDERING_SHADER_TRANSP_PHONG_H_
+#define CGOGN_RENDERING_SHADER_TRANSP_PHONG_H_
+
+#include <cgogn/rendering/dll.h>
+#include <cgogn/rendering/shaders/shader_program.h>
+#include <cgogn/rendering/shaders/vbo.h>
+
+#include <QOpenGLFunctions>
+#include <QColor>
+#include <QOpenGLFramebufferObject>
+
+namespace cgogn
+{
+
+namespace rendering
+{
+
+// forward
+class ShaderPhongTransp;
+
+class CGOGN_RENDERING_API ShaderParamPhongTransp : public ShaderParam
+{
+protected:
+
+	void set_uniforms() override;
+
+public:
+
+	QColor front_color_;
+	QColor back_color_;
+	QColor ambiant_color_;
+	QColor specular_color_;
+	GLfloat specular_coef_;
+	QVector3D light_pos_;
+	GLint layer_;
+	GLuint rgba_texture_sampler_;
+	GLuint depth_texture_sampler_;
+	bool bf_culling_;
+
+	ShaderParamPhongTransp(ShaderPhongTransp* sh);
+
+	void set_position_vbo(VBO* vbo_pos);
+
+	void set_normal_vbo(VBO* vbo_normal);
+
+};
+
+
+
+
+class CGOGN_RENDERING_API ShaderPhongTransp : public ShaderProgram
+{
+	friend class ShaderParamPhongTransp;
+
+protected:
+
+	static const char* vertex_shader_source_;
+	static const char* fragment_shader_source_;
+
+	// uniform ids
+	GLint unif_front_color_;
+	GLint unif_back_color_;
+	GLint unif_ambiant_color_;
+	GLint unif_specular_color_;
+	GLint unif_specular_coef_;
+	GLint unif_light_position_;
+	GLint unif_bf_culling_;
+	GLint unif_layer_;
+	GLint unif_depth_texture_sampler_;
+	GLint unif_rgba_texture_sampler_;
+
+public:
+
+	using Self = ShaderPhongTransp;
+	CGOGN_NOT_COPYABLE_NOR_MOVABLE(ShaderPhongTransp);
+
+	enum
+	{
+		ATTRIB_POS = 0, ATTRIB_NORM
+	};
+
+	/**
+	 * @brief set current front color
+	 * @param rgb
+	 */
+	void set_front_color(const QColor& rgb);
+
+	/**
+	 * @brief set current front color
+	 * @param rgb
+	 */
+	void set_back_color(const QColor& rgb);
+
+	/**
+	 * @brief set current ambiant color
+	 * @param rgb
+	 */
+	void set_ambiant_color(const QColor& rgb);
+
+	/**
+	 * @brief set current specular color
+	 * @param rgb
+	 */
+	void set_specular_color(const QColor& rgb);
+
+	/**
+	 * @brief set current specular coefficient
+	 * @param rgb
+	 */
+	void set_specular_coef(float32 coef);
+
+	/**
+	 * @brief set light position relative to screen
+	 * @param l light position
+	 */
+	void set_light_position(const QVector3D& l);
+
+	void set_bf_culling(bool cull);
+
+	void set_layer(int layer);
+
+	void set_rgba_sampler(GLuint rgba_samp);
+
+	void set_depth_sampler(GLuint depth_samp);
+
+	using Param = ShaderParamPhongTransp;
+
+	static std::unique_ptr<Param> generate_param();
+
+private:
+
+	ShaderPhongTransp();
+	static std::unique_ptr<ShaderPhongTransp> instance_;
+
+};
+
+
+} // namespace rendering
+
+} // namespace cgogn
+
+#endif // CGOGN_RENDERING_SHADER_TRANSP_PHONG_H_

--- a/cgogn/rendering/transparency_volume_drawer.cpp
+++ b/cgogn/rendering/transparency_volume_drawer.cpp
@@ -72,6 +72,9 @@ VolumeTransparencyDrawer::Renderer::Renderer(VolumeTransparencyDrawer* vr, int w
 	param_transp_vol_->color_ = vr->face_color_;
 	param_trq_ = cgogn::rendering::ShaderTranspQuad::generate_param();
 
+	param_copy_depth_ = ShaderCopyDepth::generate_param();
+
+
 	fbo_layer_= cgogn::make_unique<QOpenGLFramebufferObject>(width_,height_,QOpenGLFramebufferObject::Depth,GL_TEXTURE_2D,/*GL_RGBA8*/GL_RGBA32F);
 	fbo_layer_->addColorAttachment(width_,height_,GL_R32F);
 	fbo_layer_->addColorAttachment(width_,height_,GL_R32F);

--- a/cgogn/rendering/transparency_volume_drawer.cpp
+++ b/cgogn/rendering/transparency_volume_drawer.cpp
@@ -113,7 +113,7 @@ void VolumeTransparencyDrawer::Renderer::resize(int w, int h)
 void VolumeTransparencyDrawer::Renderer::draw_faces(const QMatrix4x4& projection, const QMatrix4x4& modelview)
 {
 	GLfloat bkColor[4];
-	glGetFloatv(GL_COLOR_CLEAR_VALUE, bkColor);
+	ogl33_->glGetFloatv(GL_COLOR_CLEAR_VALUE, bkColor);
 
 	if (ogl33_ == nullptr)
 		return;
@@ -213,7 +213,7 @@ void VolumeTransparencyDrawer::Renderer::draw_faces(const QMatrix4x4& projection
 	param_trq_->release();
 	ogl33_->glDisable(GL_BLEND);
 
-	glClearColor(bkColor[0],bkColor[1],bkColor[2],bkColor[3]);
+	ogl33_->glClearColor(bkColor[0],bkColor[1],bkColor[2],bkColor[3]);
 
 }
 

--- a/cgogn/rendering/transparency_volume_drawer.h
+++ b/cgogn/rendering/transparency_volume_drawer.h
@@ -86,17 +86,46 @@ public:
 		void resize(int w, int h);
 
 		~Renderer();
-		void draw_faces(const QMatrix4x4& projection, const QMatrix4x4& modelview);
+
+		/**
+		 * @brief draw the transparent volumes mixed with opaque (also drawn separatly)
+		 * @param projection projection matrix
+		 * @param modelview modelview matrix
+		 * @param of the func/lambda that draw opaque objects (use to get zbuffer, not drawn on screen)
+		 */
+		template<typename OPAQUE_FUNC>
+		void draw_faces(const QMatrix4x4& projection, const QMatrix4x4& modelview, const OPAQUE_FUNC& of);
+
+		/**
+		 * @brief draw only the transparent volumes (bad mixing with opaque objects)
+		 * @param projection projection matrix
+		 * @param modelview modelview matrix
+		 * @param of the func/lambda that draw opaque objects (use to get zbuffer, not drawn on screen)
+		 */
+		inline void draw_faces(const QMatrix4x4& projection, const QMatrix4x4& modelview)
+		{
+			draw_faces(projection,modelview,[]{});
+		}
 
 		void set_explode_volume(float32 x);
-		void set_color(const QColor& rgb);
-		void set_clipping_plane(const QVector4D& pl);
-		void set_clipping_plane2(const QVector4D& pl);
-		void set_thick_clipping_plane(const QVector4D& p, float32 th);
-		void set_back_face_culling(bool cull);
-		void set_lighted(bool lighted);
-		void set_max_nb_layers(int nbl);
 
+		void set_color(const QColor& rgb);
+
+		void set_clipping_plane(const QVector4D& pl);
+
+		void set_clipping_plane2(const QVector4D& pl);
+
+		void set_thick_clipping_plane(const QVector4D& p, float32 th);
+
+		void set_back_face_culling(bool cull);
+
+		void set_lighted(bool lighted);
+
+		/**
+		 * @brief set the max number of layers (eq drawing passes)
+		 * @param nbl
+		 */
+		void set_max_nb_layers(int nbl);
 
 	};
 
@@ -182,6 +211,100 @@ void VolumeTransparencyDrawer::update_face(const MAP& m, const typename MAP::tem
 	vbo_pos_->release();
 }
 
+
+template<typename OPAQUE_FUNC>
+void VolumeTransparencyDrawer::Renderer::draw_faces(const QMatrix4x4& projection, const QMatrix4x4& modelview, const OPAQUE_FUNC& opaque_func)
+{
+	ogl33_->glEnable(GL_TEXTURE_2D);
+	QVector<GLuint> textures = fbo_layer_->textures();
+	GLenum buffs[2] = { GL_COLOR_ATTACHMENT0,GL_COLOR_ATTACHMENT2 };
+
+	param_transp_vol_->rgba_texture_sampler_ = 0;
+	param_transp_vol_->depth_texture_sampler_ = 1;
+	fbo_layer_->bind();
+
+	GLenum clear_buff[1] = { GL_COLOR_ATTACHMENT3 };
+	ogl33_->glDrawBuffers(1, clear_buff);
+	ogl33_->glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+	ogl33_->glClear(GL_COLOR_BUFFER_BIT);
+
+	ogl33_->glDrawBuffers(1, buffs);
+	ogl33_->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+	GLenum opaq_buff[1] = { GL_COLOR_ATTACHMENT5 };
+
+	for (int p = 0; p<max_nb_layers_; ++p)
+	{
+		ogl33_->glClear(GL_DEPTH_BUFFER_BIT);
+
+		if (p > 0)
+		{
+			ogl33_->glDrawBuffers(1, opaq_buff);
+			ogl33_->glClear(GL_COLOR_BUFFER_BIT);
+			opaque_func();
+		}
+
+		ogl33_->glDrawBuffers(2, buffs);
+		param_transp_vol_->layer_ = p;
+		ogl33_->glActiveTexture(GL_TEXTURE0);
+		ogl33_->glBindTexture(GL_TEXTURE_2D, textures[3]);
+		ogl33_->glActiveTexture(GL_TEXTURE1);
+		ogl33_->glBindTexture(GL_TEXTURE_2D, textures[1]);
+
+		ogl33_->glBeginQuery(GL_SAMPLES_PASSED, oq_transp);
+
+		param_transp_vol_->bind(projection, modelview);
+		ogl33_->glDrawArrays(GL_LINES_ADJACENCY, 0, volume_drawer_data_->vbo_pos_->size());
+		param_transp_vol_->release();
+
+		ogl33_->glEndQuery(GL_SAMPLES_PASSED);
+
+		GLuint nb_samples;
+		ogl33_->glGetQueryObjectuiv(oq_transp, GL_QUERY_RESULT, &nb_samples);
+
+		if (nb_samples == 0) // finished ?
+		{
+			p = max_nb_layers_;
+		}
+		else
+		{
+			ogl33_->glReadBuffer(GL_COLOR_ATTACHMENT2);
+			ogl33_->glBindTexture(GL_TEXTURE_2D, textures[1]);
+			ogl33_->glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, 0, 0, width_, height_, 0);
+
+			if (p == 0)
+			{
+				ogl33_->glBindTexture(GL_TEXTURE_2D, textures[4]);
+				ogl33_->glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, 0, 0, width_, height_, 0);
+			}
+
+			ogl33_->glReadBuffer(GL_COLOR_ATTACHMENT0);
+			ogl33_->glBindTexture(GL_TEXTURE_2D, textures[3]);
+			ogl33_->glCopyTexImage2D(GL_TEXTURE_2D, 0,/*GL_RGBA8*/GL_RGBA32F, 0, 0, width_, height_, 0);
+		}
+	}
+
+	fbo_layer_->release();
+
+	// real draw with blending with opaque object
+
+	param_trq_->rgba_texture_sampler_ = 0;
+	param_trq_->depth_texture_sampler_ = 1;
+
+	ogl33_->glActiveTexture(GL_TEXTURE0);
+	ogl33_->glBindTexture(GL_TEXTURE_2D, textures[3]);
+
+	ogl33_->glActiveTexture(GL_TEXTURE1);
+	ogl33_->glBindTexture(GL_TEXTURE_2D, textures[4]);
+
+	ogl33_->glEnable(GL_BLEND);
+	ogl33_->glBlendFunc(GL_ONE, GL_SRC_ALPHA);
+	param_trq_->bind(projection, modelview);
+	ogl33_->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+	param_trq_->release();
+	ogl33_->glDisable(GL_BLEND);
+
+}
 
 } // namespace rendering
 

--- a/cgogn/rendering/transparency_volume_drawer.h
+++ b/cgogn/rendering/transparency_volume_drawer.h
@@ -225,9 +225,10 @@ void VolumeTransparencyDrawer::Renderer::draw_faces(const QMatrix4x4& projection
 	QOpenGLTexture depth_tex(QOpenGLTexture::Target2D);
 	depth_tex.setFormat(QOpenGLTexture::D24);
 	depth_tex.setSize(width_,height_);
-	depth_tex.allocateStorage(QOpenGLTexture::Depth,QOpenGLTexture::Float32);
-	ogl33_->glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, width_, height_);
-
+	depth_tex.bind();
+	ogl33_->glReadBuffer(GL_FRONT);
+	ogl33_->glCopyTexImage2D(GL_TEXTURE_2D, 0,GL_DEPTH_COMPONENT24, 0, 0, width_, height_,0);
+	depth_tex.release();
 	param_copy_depth_->texture_ = &depth_tex;
 
 	QVector<GLuint> textures = fbo_layer_->textures();
@@ -249,18 +250,14 @@ void VolumeTransparencyDrawer::Renderer::draw_faces(const QMatrix4x4& projection
 
 	for (int p = 0; p<max_nb_layers_; ++p)
 	{
-		ogl33_->glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
+		ogl33_->glClear(GL_DEPTH_BUFFER_BIT);
 
 		if (p > 0)
 		{
 			ogl33_->glDrawBuffers(1, opaq_buff);
-			ogl33_->glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT);
-
-//			param_copy_depth_->bind(projection, modelview);
-//			ogl33_->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-//			param_copy_depth_->release();
-
-
+			param_copy_depth_->bind(projection, modelview);
+			ogl33_->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+			param_copy_depth_->release();
 		}
 
 		ogl33_->glDrawBuffers(2, buffs);

--- a/cgogn/rendering/wall_paper.cpp
+++ b/cgogn/rendering/wall_paper.cpp
@@ -34,31 +34,104 @@ namespace cgogn
 namespace rendering
 {
 
-WallPaper::WallPaper(const QImage& img)
+void WallPaper::init(const QImage& img)
 {
-	vbo_pos_ = cgogn::make_unique<cgogn::rendering::VBO>(3);
-	vbo_pos_->allocate(4,3);
-	vbo_tc_ = cgogn::make_unique<cgogn::rendering::VBO>(2);
-	vbo_tc_->allocate(4,2);
-
-	texture_ = cgogn::make_unique<QOpenGLTexture>(img);
-
+	if (vbo_pos_ == nullptr)
+	{
+		vbo_pos_ = cgogn::make_unique<cgogn::rendering::VBO>(3);
+		vbo_pos_->allocate(4, 3);
+	}
+	if (vbo_tc_ == nullptr)
+	{
+		vbo_tc_ = cgogn::make_unique<cgogn::rendering::VBO>(2);
+		vbo_tc_->allocate(4, 2);
+		float32* ptr_tc = vbo_tc_->lock_pointer();
+		*ptr_tc++ = 0.0f;
+		*ptr_tc++ = 0.0f;
+		*ptr_tc++ = 1.0f;
+		*ptr_tc++ = 0.0f;
+		*ptr_tc++ = 1.0f;
+		*ptr_tc++ = 1.0f;
+		*ptr_tc++ = 0.0f;
+		*ptr_tc++ = 1.0f;
+		vbo_tc_->release_pointer();
+	}
+	texture_ = cgogn::make_unique<QOpenGLTexture>(img,QOpenGLTexture::DontGenerateMipMaps);
 	set_full_screen(false);
-
-	float32* ptr_tc = vbo_tc_->lock_pointer();
-	*ptr_tc++ = 0.0f;
-	*ptr_tc++ = 0.0f;
-	*ptr_tc++ = 1.0f;
-	*ptr_tc++ = 0.0f;
-	*ptr_tc++ = 1.0f;
-	*ptr_tc++ = 1.0f;
-	*ptr_tc++ = 0.0f;
-	*ptr_tc++ = 1.0f;
-	vbo_tc_->release_pointer();
 }
 
+WallPaper::WallPaper(const QImage& img):
+	vbo_pos_(nullptr),
+	vbo_tc_(nullptr),
+	texture_(nullptr)
+{
+	init(img);
+}
+
+WallPaper::WallPaper(const QColor& col) :
+	vbo_pos_(nullptr),
+	vbo_tc_(nullptr),
+	texture_(nullptr)
+{
+	QImage img(1, 1, QImage::Format_RGB32);
+	img.setPixelColor(0, 0, col);
+	init(img);
+}
+
+WallPaper::WallPaper(const QColor& col_tl, const QColor& col_tr, const QColor& col_bl, const QColor& col_br) :
+	vbo_pos_(nullptr),
+	vbo_tc_(nullptr),
+	texture_(nullptr)
+{
+	QImage img(2, 2, QImage::Format_RGB32);
+	img.setPixelColor(0, 1, col_bl);
+	img.setPixelColor(1, 1, col_br);
+	img.setPixelColor(1, 0, col_tr);
+	img.setPixelColor(0, 0, col_tl);
+	init(img);
+	texture_->setWrapMode(QOpenGLTexture::ClampToEdge);
+}
+
+
 WallPaper::~WallPaper()
-{}
+{
+}
+
+
+void WallPaper::change_color(const QColor& col)
+{
+	if ((texture_->width()==1)&&(texture_->height()==1))
+	{
+		float32 color[3] = {float32(col.red()), float32(col.green()), float32(col.blue())};
+		texture_->setData(QOpenGLTexture::RGB, QOpenGLTexture::Float32, color);
+	}
+	else
+	{
+		cgogn_log_warning("change colors")<< "Attemping to change color with a wall paper initialized with more than one color";
+	}
+}
+
+void WallPaper::change_colors(const QColor& col_tl, const QColor& col_tr, const QColor& col_bl, const QColor& col_br)
+{
+	if ((texture_->width()==2)&&(texture_->height()==2))
+	{
+		float32 colors[12] =
+		{float32(col_tl.red()), float32(col_tl.green()), float32(col_tl.blue()),
+		 float32(col_tr.red()), float32(col_tr.green()), float32(col_tr.blue()),
+		 float32(col_bl.red()), float32(col_bl.green()), float32(col_bl.blue()),
+		 float32(col_br.red()), float32(col_br.green()), float32(col_br.blue())
+		 };
+
+		texture_->setData(QOpenGLTexture::RGB, QOpenGLTexture::Float32, colors);
+		texture_->setWrapMode(QOpenGLTexture::ClampToEdge);
+	}
+	else
+	{
+		cgogn_log_warning("change colors")<< "Attemping to change colors with a wall paper not initialized with 4 colors";
+	}
+}
+
+
 
 void WallPaper::set_full_screen(bool front)
 {

--- a/cgogn/rendering/wall_paper.h
+++ b/cgogn/rendering/wall_paper.h
@@ -59,6 +59,7 @@ protected:
 	std::unique_ptr<VBO> vbo_pos_;
 	std::unique_ptr<VBO> vbo_tc_;
 	std::unique_ptr<QOpenGLTexture> texture_;
+	void init(const QImage& img);
 
 public:
 
@@ -81,10 +82,41 @@ public:
 	using Self = WallPaper;
 
 	/**
-	 * constructor, init all buffers (data and OpenGL) and shader
-	 * @Warning need OpenGL context
+	 * @brief constructor, init all buffers (data and OpenGL) and shader
+	 * @param img image
+	 * @warning need OpenGL context
 	 */
 	WallPaper(const QImage& img);
+
+	/**
+	 * @brief constructor, init all buffers (data and OpenGL) and shader
+	 * @param col color unique color of wallPaper
+	 */
+	WallPaper(const QColor& col);
+
+	/**
+	 * @brief  constructor, init all buffers (data and OpenGL) and shader
+	 * @param col_tl top left color
+	 * @param col_tr top right color
+	 * @param col_bl bottom left color
+	 * @param col_br botton right color
+	 */
+	WallPaper(const QColor& col_tl, const QColor& col_tr, const QColor& col_bl, const QColor& col_br);
+
+	/**
+	 * @brief change color for unique color image
+	 * @param col color
+	 */
+	void change_color(const QColor& col);
+
+	/**
+	 * @brief change colors for 4 colors image only
+	 * @param col_tl top left color
+	 * @param col_tr top right color
+	 * @param col_bl bottom left color
+	 * @param col_br botton right color
+	 */
+	void change_colors(const QColor& col_tl, const QColor& col_tr, const QColor& col_bl, const QColor& col_br);
 
 	/**
 	 * release buffers and shader


### PR DESCRIPTION
- Corrige le mélange transparence opaque.
- Plus besoin du rendu opaque pour mélanger
- Ajout du rendu phong transparent (renommage en SurfaceTransparencyDrawer)
- Résolution du bug du glClearColor (plus besoin de WallPaper)
- Parametre ogl33 uniquement pour resize