### PR TITLE
Bug markerstore

### DIFF
--- a/cgogn/core/basic/cell_marker.h
+++ b/cgogn/core/basic/cell_marker.h
@@ -179,9 +179,12 @@ public:
 	{
 		cgogn_message_assert(this->is_valid(), "Invalid CellMarkerStore");
 		auto it = std::find(marked_cells_->begin(), marked_cells_->end(), this->map_.embedding(c));
-		cgogn_message_assert(it != marked_cells_->end(), "Cell not found");
-		std::swap(*it, marked_cells_->back());
-		marked_cells_->pop_back();
+		if (it !=  marked_cells_->end())
+		{
+			Inherit::unmark(c);
+			std::swap(*it, marked_cells_->back());
+			marked_cells_->pop_back();
+		}
 	}
 
 	inline void unmark_all()

--- a/cgogn/core/basic/dart_marker.h
+++ b/cgogn/core/basic/dart_marker.h
@@ -188,8 +188,13 @@ public:
 		cgogn_message_assert(this->is_valid(), "Invalid DartMarkerStore");
 		auto it = std::find(marked_darts_->begin(), marked_darts_->end(), d);
 		cgogn_message_assert(it != marked_darts_->end(), "Dart not found");
-		std::swap(*it, marked_darts_->back());
-		marked_darts_->pop_back();
+		if (it != marked_darts_->end())
+		{
+			Inherit::unmark(d);
+			std::swap(*it, marked_darts_->back());
+			marked_darts_->pop_back();
+		}
+
 	}
 
 	template <Orbit ORBIT>

--- a/cgogn/core/basic/dart_marker.h
+++ b/cgogn/core/basic/dart_marker.h
@@ -187,7 +187,6 @@ public:
 	{
 		cgogn_message_assert(this->is_valid(), "Invalid DartMarkerStore");
 		auto it = std::find(marked_darts_->begin(), marked_darts_->end(), d);
-		cgogn_message_assert(it != marked_darts_->end(), "Dart not found");
 		if (it != marked_darts_->end())
 		{
 			Inherit::unmark(d);

--- a/cgogn/core/cmap/cmap2_quad.h
+++ b/cgogn/core/cmap/cmap2_quad.h
@@ -850,6 +850,8 @@ protected:
 		cgogn::dart_buffers()->release_buffer(visited_faces);
 	}
 
+public:
+
 	template <Orbit ORBIT, typename FUNC>
 	inline void foreach_dart_of_orbit(Cell<ORBIT> c, const FUNC& f) const
 	{
@@ -877,8 +879,6 @@ protected:
 	/*******************************************************************************
 	 * Incidence traversal
 	 *******************************************************************************/
-
-public:
 
 	template <typename FUNC>
 	inline void foreach_incident_edge(Vertex v, const FUNC& func) const

--- a/cgogn/core/cmap/cmap2_tri.h
+++ b/cgogn/core/cmap/cmap2_tri.h
@@ -1153,6 +1153,8 @@ protected:
 		cgogn::dart_buffers()->release_buffer(visited_faces);
 	}
 
+public:
+
 	template <Orbit ORBIT, typename FUNC>
 	inline void foreach_dart_of_orbit(Cell<ORBIT> c, const FUNC& f) const
 	{
@@ -1180,8 +1182,6 @@ protected:
 	/*******************************************************************************
 	 * Incidence traversal
 	 *******************************************************************************/
-
-public:
 
 	template <typename FUNC>
 	inline void foreach_incident_edge(Vertex v, const FUNC& func) const

--- a/cgogn/core/cmap/cmap3_hexa.h
+++ b/cgogn/core/cmap/cmap3_hexa.h
@@ -972,6 +972,8 @@ protected:
 		cgogn::dart_buffers()->release_buffer(visited_vols);
 	}
 
+public:
+
 	template <Orbit ORBIT, typename FUNC>
 	inline void foreach_dart_of_orbit(Cell<ORBIT> c, const FUNC& f) const
 	{
@@ -1001,8 +1003,6 @@ protected:
 	/*******************************************************************************
 	 * Incidence traversal (of dim 2)
 	 *******************************************************************************/
-
-public:
 
 	template <typename FUNC>
 	inline void foreach_incident_edge(Vertex2 v, const FUNC& func) const

--- a/cgogn/core/cmap/cmap3_tetra.h
+++ b/cgogn/core/cmap/cmap3_tetra.h
@@ -696,8 +696,6 @@ public:
 	 * Orbits traversal
 	 *******************************************************************************/
 
-protected:
-
 	template <Orbit ORBIT, typename FUNC>
 	inline void foreach_dart_of_orbit(Cell<ORBIT> c, const FUNC& f) const
 	{
@@ -723,6 +721,8 @@ protected:
 			default: cgogn_assert_not_reached("Orbit not supported in a CMap3Tetra"); break;
 		}
 	}
+
+protected:
 
 	template <typename FUNC>
 	inline void foreach_dart_of_PHI1(Dart d, const FUNC& f) const

--- a/cgogn/core/tests/CMakeLists.txt
+++ b/cgogn/core/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(cgogn_core REQUIRED)
 set(SOURCE_FILES
 	basic/dart_test.cpp
 	basic/cell_test.cpp
+	basic/dart_marker_test.cpp
 	basic/cell_marker_test.cpp
 
 	container/chunk_array_container_test.cpp

--- a/cgogn/core/tests/CMakeLists.txt
+++ b/cgogn/core/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(cgogn_core REQUIRED)
 set(SOURCE_FILES
 	basic/dart_test.cpp
 	basic/cell_test.cpp
+	basic/cell_marker_test.cpp
 
 	container/chunk_array_container_test.cpp
 

--- a/cgogn/core/tests/basic/cell_marker_test.cpp
+++ b/cgogn/core/tests/basic/cell_marker_test.cpp
@@ -1,15 +1,369 @@
+/*******************************************************************************
+* CGoGN: Combinatorial and Geometric modeling with Generic N-dimensional Maps  *
+* Copyright (C) 2015, IGG Group, ICube, University of Strasbourg, France       *
+*                                                                              *
+* This library is free software; you can redistribute it and/or modify it      *
+* under the terms of the GNU Lesser General Public License as published by the *
+* Free Software Foundation; either version 2.1 of the License, or (at your     *
+* option) any later version.                                                   *
+*                                                                              *
+* This library is distributed in the hope that it will be useful, but WITHOUT  *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *
+* for more details.                                                            *
+*                                                                              *
+* You should have received a copy of the GNU Lesser General Public License     *
+* along with this library; if not, write to the Free Software Foundation,      *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.           *
+*                                                                              *
+* Web site: http://cgogn.unistra.fr/                                           *
+* Contact information: cgogn@unistra.fr                                        *
+*                                                                              *
+*******************************************************************************/
+
 #include <gtest/gtest.h>
 
-#include <core/basic/cell_marker.h>
+#include <cgogn/core/basic/cell.h>
+#include <cgogn/core/cmap/cmap2_tri.h>
+#include <cgogn/core/cmap/cmap2_quad.h>
+#include <cgogn/core/cmap/cmap3.h>
+#include <cgogn/core/cmap/cmap3_tetra.h>
+#include <cgogn/core/cmap/cmap3_hexa.h>
+#include <memory>
 
-namespace cgogn
+using namespace cgogn;
+
+
+template<typename Map>
+class CellMarkerTest : public ::testing::Test
 {
+public:
+	using Inherit = ::testing::Test;
+	using Vertex = typename Map::Vertex;
+	using Edge = typename Map::Edge;
+	using Face = typename Map::Face;
+	using Volume = typename Map::Volume;
 
-TEST(CellMarkerTTest, DefaultConstructor)
+	template<Orbit ORB>
+	using CellMarker = typename Map::template CellMarker<ORB>;
+
+	template<Orbit ORB>
+	using CellMarkerNoUnmark = typename Map::template CellMarkerNoUnmark<ORB>;
+
+	template<Orbit ORB>
+	using CellMarkerStore = typename Map::template CellMarkerStore<ORB>;
+
+	inline CellMarkerTest() : Inherit()
+	{}
+
+	void init_markers()
+	{
+		vmarker = make_unique<CellMarker<Vertex::ORBIT>>(map);
+		emarker = make_unique<CellMarker<Edge::ORBIT>>(map);
+		fmarker = make_unique<CellMarker<Face::ORBIT>>(map);
+		wmarker = make_unique<CellMarker<Volume::ORBIT>>(map);
+
+		vmarkernounmark = make_unique<CellMarkerNoUnmark<Vertex::ORBIT>>(map);
+		emarkernounmark = make_unique<CellMarkerNoUnmark<Edge::ORBIT>>(map);
+		fmarkernounmark = make_unique<CellMarkerNoUnmark<Face::ORBIT>>(map);
+		wmarkernounmark = make_unique<CellMarkerNoUnmark<Volume::ORBIT>>(map);
+
+		vmarkerstore = make_unique<CellMarkerStore<Vertex::ORBIT>>(map);
+		emarkerstore = make_unique<CellMarkerStore<Edge::ORBIT>>(map);
+		fmarkerstore = make_unique<CellMarkerStore<Face::ORBIT>>(map);
+		wmarkerstore = make_unique<CellMarkerStore<Volume::ORBIT>>(map);
+	}
+
+	Map map;
+	std::unique_ptr<CellMarker<Vertex::ORBIT>> vmarker;
+	std::unique_ptr<CellMarker<Edge::ORBIT>> emarker;
+	std::unique_ptr<CellMarker<Face::ORBIT>> fmarker;
+	std::unique_ptr<CellMarker<Volume::ORBIT>> wmarker;
+
+	std::unique_ptr<CellMarkerNoUnmark<Vertex::ORBIT>> vmarkernounmark;
+	std::unique_ptr<CellMarkerNoUnmark<Edge::ORBIT>> emarkernounmark;
+	std::unique_ptr<CellMarkerNoUnmark<Face::ORBIT>> fmarkernounmark;
+	std::unique_ptr<CellMarkerNoUnmark<Volume::ORBIT>> wmarkernounmark;
+
+	std::unique_ptr<CellMarkerStore<Vertex::ORBIT>> vmarkerstore;
+	std::unique_ptr<CellMarkerStore<Edge::ORBIT>> emarkerstore;
+	std::unique_ptr<CellMarkerStore<Face::ORBIT>> fmarkerstore;
+	std::unique_ptr<CellMarkerStore<Volume::ORBIT>> wmarkerstore;
+};
+
+template<typename Map>
+class CellMarkerTriMapTest : public CellMarkerTest<Map>
 {
+public:
+	using Inherit = CellMarkerTest<Map>;
+	using MapBuilder = cgogn::CMap2Builder_T<Map>;
 
-	CellMakerT(map);
+	CellMarkerTriMapTest() : Inherit(), builder(this->map) {}
 
+	virtual void SetUp() override
+	{
+		std::cout << this->map.nb_darts() << std::endl;
+		Dart d1 = builder.add_face_topo_fp(3u);
+		Dart d2 = builder.add_face_topo_fp(3u);
+		builder.phi2_sew(d1,d2);
+		builder.close_map();
+		this->init_markers();
+	}
+
+
+	MapBuilder builder;
+};
+
+template<typename Map>
+class CellMarkerQuadMapTest : public CellMarkerTest<Map>
+{
+public:
+	using Inherit = CellMarkerTest<Map>;
+	using MapBuilder = cgogn::CMap2Builder_T<Map>;
+	CellMarkerQuadMapTest() : Inherit(), builder(this->map) {
+
+	}
+
+	virtual void SetUp() override
+	{
+		Dart d1 = builder.add_face_topo_fp(4u);
+		Dart d2 = builder.add_face_topo_fp(4u);
+		builder.phi2_sew(d1,d2);
+		builder.close_map();
+		this->init_markers();
+	}
+	MapBuilder builder;
+};
+
+template<typename Map>
+class CellMarkerTetraMapTest : public CellMarkerTest<Map>
+{
+public:
+	using Inherit = CellMarkerTest<Map>;
+	using MapBuilder = cgogn::CMap3Builder_T<Map>;
+	CellMarkerTetraMapTest() : Inherit(), builder(this->map) {}
+	MapBuilder builder;
+};
+
+
+template<typename Map>
+class CellMarkerHexaMapTest : public CellMarkerTest<Map>
+{
+public:
+	using Inherit = CellMarkerTest<Map>;
+	using MapBuilder = cgogn::CMap3Builder_T<Map>;
+	CellMarkerHexaMapTest() : Inherit(), builder(this->map) {}
+	MapBuilder builder;
+};
+
+
+using TriMapTypes = ::testing::Types<CMap2, CMap2Tri>;
+using QuadMapTypes = ::testing::Types<CMap2, CMap2Quad>;
+using TetraMapType = ::testing::Types<CMap3, CMap3Tetra>;
+using HexaMapType = ::testing::Types<CMap3, CMap3Hexa>;
+
+
+TYPED_TEST_CASE(CellMarkerTriMapTest, TriMapTypes);
+
+//TYPED_TEST_CASE(CellMarkerQuadMapTest, QuadMapTypes);
+//TYPED_TEST_CASE(CellMarkerTetraMapTest, TetraMapType);
+//TYPED_TEST_CASE(CellMarkerHexaMapTest, HexaMapType);
+
+TYPED_TEST(CellMarkerTriMapTest, default_unmarked)
+{
+	using Vertex = typename TypeParam::Vertex;
+	using Edge = typename TypeParam::Edge;
+	using Face = typename TypeParam::Face;
+	using Volume = typename TypeParam::Volume;
+
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			EXPECT_FALSE(this->vmarker->is_marked(Vertex(d)));
+			EXPECT_FALSE(this->emarker->is_marked(Edge(d)));
+			EXPECT_FALSE(this->fmarker->is_marked(Face(d)));
+			EXPECT_FALSE(this->wmarker->is_marked(Volume(d)));
+
+			EXPECT_FALSE(this->vmarkernounmark->is_marked(Vertex(d)));
+			EXPECT_FALSE(this->emarkernounmark->is_marked(Edge(d)));
+			EXPECT_FALSE(this->fmarkernounmark->is_marked(Face(d)));
+			EXPECT_FALSE(this->wmarkernounmark->is_marked(Volume(d)));
+
+			EXPECT_FALSE(this->vmarkerstore->is_marked(Vertex(d)));
+			EXPECT_FALSE(this->emarkerstore->is_marked(Edge(d)));
+			EXPECT_FALSE(this->fmarkerstore->is_marked(Face(d)));
+			EXPECT_FALSE(this->wmarkerstore->is_marked(Volume(d)));
+		}
+	});
 }
 
-} // namespace cgogn
+TYPED_TEST(CellMarkerTriMapTest, marking)
+{
+	using Vertex = typename TypeParam::Vertex;
+	using Edge = typename TypeParam::Edge;
+	using Face = typename TypeParam::Face;
+	using Volume = typename TypeParam::Volume;
+
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			Vertex v(d);
+			this->vmarker->mark(v);
+			this->vmarkernounmark->mark(v);
+			this->vmarkerstore->mark(v);
+			this->map.foreach_dart_of_orbit(v, [&](Dart d2)
+			{
+					EXPECT_TRUE(this->vmarker->is_marked(Vertex(d2)));
+					EXPECT_TRUE(this->vmarkernounmark->is_marked(Vertex(d2)));
+					EXPECT_TRUE(this->vmarkerstore->is_marked(Vertex(d2)));
+			});
+
+			Edge e(d);
+			this->emarker->mark(e);
+			this->emarkernounmark->mark(e);
+			this->emarkerstore->mark(e);
+			this->map.foreach_dart_of_orbit(e, [&](Dart d2)
+			{
+					EXPECT_TRUE(this->emarker->is_marked(Edge(d2)));
+					EXPECT_TRUE(this->emarkernounmark->is_marked(Edge(d2)));
+					EXPECT_TRUE(this->emarkerstore->is_marked(Edge(d2)));
+			});
+
+			Face f(d);
+			this->fmarker->mark(f);
+			this->fmarkernounmark->mark(f);
+			this->fmarkerstore->mark(f);
+			this->map.foreach_dart_of_orbit(f, [&](Dart d2)
+			{
+					EXPECT_TRUE(this->fmarker->is_marked(Face(d2)));
+					EXPECT_TRUE(this->fmarkernounmark->is_marked(Face(d2)));
+					EXPECT_TRUE(this->fmarkerstore->is_marked(Face(d2)));
+			});
+
+			Volume w(d);
+			this->wmarker->mark(w);
+			this->wmarkernounmark->mark(w);
+			this->wmarkerstore->mark(w);
+			this->map.foreach_dart_of_orbit(w, [&](Dart d2)
+			{
+					EXPECT_TRUE(this->wmarker->is_marked(Volume(d2)));
+					EXPECT_TRUE(this->wmarkernounmark->is_marked(Volume(d2)));
+					EXPECT_TRUE(this->wmarkerstore->is_marked(Volume(d2)));
+			});
+		}
+	});
+}
+
+TYPED_TEST(CellMarkerTriMapTest, unmarking)
+{
+	using Vertex = typename TypeParam::Vertex;
+	using Edge = typename TypeParam::Edge;
+	using Face = typename TypeParam::Face;
+	using Volume = typename TypeParam::Volume;
+
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			Vertex v(d);
+			this->vmarker->mark(v);
+			this->vmarkerstore->mark(v);
+			this->vmarker->unmark(v);
+			this->vmarkerstore->unmark(v);
+			this->map.foreach_dart_of_orbit(v, [&](Dart d2)
+			{
+					EXPECT_FALSE(this->vmarker->is_marked(Vertex(d2)));
+					EXPECT_FALSE(this->vmarkerstore->is_marked(Vertex(d2)));
+			});
+
+			Edge e(d);
+			this->emarker->mark(e);
+			this->emarkerstore->mark(e);
+			this->emarker->unmark(e);
+			this->emarkerstore->unmark(e);
+			this->map.foreach_dart_of_orbit(e, [&](Dart d2)
+			{
+					EXPECT_FALSE(this->emarker->is_marked(Edge(d2)));
+					EXPECT_FALSE(this->emarkerstore->is_marked(Edge(d2)));
+			});
+
+			Face f(d);
+			this->fmarker->mark(f);
+			this->fmarkerstore->mark(f);
+			this->fmarker->unmark(f);
+			this->fmarkerstore->unmark(f);
+			this->map.foreach_dart_of_orbit(f, [&](Dart d2)
+			{
+					EXPECT_FALSE(this->fmarker->is_marked(Face(d2)));
+					EXPECT_FALSE(this->fmarkerstore->is_marked(Face(d2)));
+			});
+
+			Volume w(d);
+			this->wmarker->mark(w);
+			this->wmarkerstore->mark(w);
+			this->wmarker->unmark(w);
+			this->wmarkerstore->unmark(w);
+			this->map.foreach_dart_of_orbit(w, [&](Dart d2)
+			{
+					EXPECT_FALSE(this->wmarker->is_marked(Volume(d2)));
+					EXPECT_FALSE(this->wmarkerstore->is_marked(Volume(d2)));
+			});
+		}
+	});
+}
+
+TYPED_TEST(CellMarkerTriMapTest, unmark_all)
+{
+	using Vertex = typename TypeParam::Vertex;
+	using Edge = typename TypeParam::Edge;
+	using Face = typename TypeParam::Face;
+	using Volume = typename TypeParam::Volume;
+
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			Vertex v(d);
+			this->vmarker->mark(v);
+			this->vmarkerstore->mark(v);
+
+			Edge e(d);
+			this->emarker->mark(e);
+			this->emarkerstore->mark(e);
+
+			Face f(d);
+			this->fmarker->mark(f);
+			this->fmarkerstore->mark(f);
+
+			Volume w(d);
+			this->wmarker->mark(w);
+			this->wmarkerstore->mark(w);
+		}
+	});
+
+	this->vmarker->unmark_all();
+	this->vmarkerstore->unmark_all();
+	this->emarker->unmark_all();
+	this->emarkerstore->unmark_all();
+	this->fmarker->unmark_all();
+	this->fmarkerstore->unmark_all();
+	this->wmarker->unmark_all();
+	this->wmarkerstore->unmark_all();
+
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			EXPECT_FALSE(this->vmarker->is_marked(Vertex(d)));
+			EXPECT_FALSE(this->vmarkerstore->is_marked(Vertex(d)));
+			EXPECT_FALSE(this->emarker->is_marked(Edge(d)));
+			EXPECT_FALSE(this->emarkerstore->is_marked(Edge(d)));
+			EXPECT_FALSE(this->fmarker->is_marked(Face(d)));
+			EXPECT_FALSE(this->fmarkerstore->is_marked(Face(d)));
+			EXPECT_FALSE(this->wmarker->is_marked(Volume(d)));
+			EXPECT_FALSE(this->wmarkerstore->is_marked(Volume(d)));
+		}
+	});
+}

--- a/cgogn/core/tests/basic/cell_marker_test.cpp
+++ b/cgogn/core/tests/basic/cell_marker_test.cpp
@@ -30,6 +30,9 @@
 #include <cgogn/core/cmap/cmap3_tetra.h>
 #include <cgogn/core/cmap/cmap3_hexa.h>
 
+namespace cell_marker_test
+{
+
 using namespace cgogn;
 
 using MapTypes = ::testing::Types<CMap2, CMap2Tri, CMap2Quad, CMap3, CMap3Tetra, CMap3Hexa>;
@@ -378,3 +381,5 @@ TYPED_TEST(CellMarkerTest, unmark_all)
 		}
 	});
 }
+
+} // namespace cell_marker_test

--- a/cgogn/core/tests/basic/dart_marker_test.cpp
+++ b/cgogn/core/tests/basic/dart_marker_test.cpp
@@ -1,0 +1,381 @@
+/*******************************************************************************
+* CGoGN: Combinatorial and Geometric modeling with Generic N-dimensional Maps  *
+* Copyright (C) 2015, IGG Group, ICube, University of Strasbourg, France       *
+*                                                                              *
+* This library is free software; you can redistribute it and/or modify it      *
+* under the terms of the GNU Lesser General Public License as published by the *
+* Free Software Foundation; either version 2.1 of the License, or (at your     *
+* option) any later version.                                                   *
+*                                                                              *
+* This library is distributed in the hope that it will be useful, but WITHOUT  *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *
+* for more details.                                                            *
+*                                                                              *
+* You should have received a copy of the GNU Lesser General Public License     *
+* along with this library; if not, write to the Free Software Foundation,      *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.           *
+*                                                                              *
+* Web site: http://cgogn.unistra.fr/                                           *
+* Contact information: cgogn@unistra.fr                                        *
+*                                                                              *
+*******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <cgogn/core/cmap/cmap2_tri.h>
+#include <cgogn/core/cmap/cmap2_quad.h>
+#include <cgogn/core/cmap/cmap3.h>
+#include <cgogn/core/cmap/cmap3_tetra.h>
+#include <cgogn/core/cmap/cmap3_hexa.h>
+
+namespace dart_marker_test
+{
+
+using namespace cgogn;
+
+using MapTypes = ::testing::Types<CMap2, CMap2Tri, CMap2Quad, CMap3, CMap3Tetra, CMap3Hexa>;
+
+template<typename Builder>
+void setup(Builder& builder)
+{
+	cgogn_assert_not_reached("The setup() function has to be specialized.");
+}
+
+template<>
+void setup(cgogn::CMap2Builder_T<CMap2> & builder)
+{
+	Dart d1 = builder.add_face_topo_fp(4u);
+	Dart d2 = builder.add_face_topo_fp(3u);
+	builder.phi2_sew(d1,d2);
+	builder.close_map();
+}
+
+template<>
+void setup(cgogn::CMap2Builder_T<CMap2Tri>& builder)
+{
+	Dart d1 = builder.add_face_topo_fp(3u);
+	Dart d2 = builder.add_face_topo_fp(3u);
+	builder.phi2_sew(d1,d2);
+	builder.close_map();
+}
+
+template<>
+void setup(cgogn::CMap2Builder_T<CMap2Quad>& builder)
+{
+	Dart d1 = builder.add_face_topo_fp(4u);
+	Dart d2 = builder.add_face_topo_fp(4u);
+	builder.phi2_sew(d1,d2);
+	builder.close_map();
+}
+
+template<>
+void setup(cgogn::CMap3Builder_T<CMap3>& builder)
+{
+	Dart p1 = builder.add_prism_topo_fp(3u);
+	Dart p2 = builder.add_prism_topo_fp(3u);
+	builder.sew_volumes_fp(p1, p2);
+
+	Dart p3 = builder.add_pyramid_topo_fp(4u);
+	Dart p4 = builder.add_pyramid_topo_fp(4u);
+	builder.sew_volumes_fp(p3, p4);
+
+	builder.close_map();
+}
+
+template<>
+void setup(cgogn::CMap3Builder_T<CMap3Tetra>& builder)
+{
+	Dart p1 = builder.add_pyramid_topo_fp(3u);
+	Dart p2 = builder.add_pyramid_topo_fp(3u);
+	builder.sew_volumes_fp(p1, p2);
+
+	Dart p3 = builder.add_pyramid_topo_fp(3u);
+	Dart p4 = builder.add_pyramid_topo_fp(3u);
+	builder.sew_volumes_fp(p3, p4);
+
+	builder.close_map();
+}
+
+template<>
+void setup(cgogn::CMap3Builder_T<CMap3Hexa>& builder)
+{
+	Dart p1 = builder.add_prism_topo_fp(4u);
+	Dart p2 = builder.add_prism_topo_fp(4u);
+	builder.sew_volumes_fp(p1, p2);
+
+	Dart p3 = builder.add_prism_topo_fp(4u);
+	Dart p4 = builder.add_prism_topo_fp(4u);
+	builder.sew_volumes_fp(p3, p4);
+
+	builder.close_map();
+}
+
+
+template<typename Map>
+class DartMarkerTest : public ::testing::Test
+{
+public:
+	using Inherit = ::testing::Test;
+	using Vertex = typename Map::Vertex;
+	using Edge = typename Map::Edge;
+	using Face = typename Map::Face;
+	using Volume = typename Map::Volume;
+
+	using DartMarker = typename cgogn::DartMarker<Map>;
+	using DartMarkerNoUnmark = typename cgogn::DartMarkerNoUnmark<Map>;
+	using DartMarkerStore = typename cgogn::DartMarkerStore<Map>;
+
+	using MapBuilder = typename std::conditional<Map::DIMENSION == 2, cgogn::CMap2Builder_T<Map>, cgogn::CMap3Builder_T<Map>>::type;
+
+	inline DartMarkerTest() : Inherit(),
+		builder(map)
+	{}
+
+	virtual void SetUp() override
+	{
+		setup(builder);
+		init_markers();
+	}
+
+	void init_markers()
+	{
+		marker = make_unique<DartMarker>(map);
+		markernounmark = make_unique<DartMarkerNoUnmark>(map);
+		markerstore = make_unique<DartMarkerStore>(map);
+
+		vmarker = make_unique<DartMarker>(map);
+		emarker = make_unique<DartMarker>(map);
+		fmarker = make_unique<DartMarker>(map);
+		wmarker = make_unique<DartMarker>(map);
+
+		vmarkernounmark = make_unique<DartMarkerNoUnmark>(map);
+		emarkernounmark = make_unique<DartMarkerNoUnmark>(map);
+		fmarkernounmark = make_unique<DartMarkerNoUnmark>(map);
+		wmarkernounmark = make_unique<DartMarkerNoUnmark>(map);
+
+		vmarkerstore = make_unique<DartMarkerStore>(map);
+		emarkerstore = make_unique<DartMarkerStore>(map);
+		fmarkerstore = make_unique<DartMarkerStore>(map);
+		wmarkerstore = make_unique<DartMarkerStore>(map);
+	}
+
+	Map map;
+	MapBuilder builder;
+	std::unique_ptr<DartMarker> marker;
+	std::unique_ptr<DartMarkerNoUnmark> markernounmark;
+	std::unique_ptr<DartMarkerStore> markerstore;
+
+
+	std::unique_ptr<DartMarker> vmarker;
+	std::unique_ptr<DartMarker> emarker;
+	std::unique_ptr<DartMarker> fmarker;
+	std::unique_ptr<DartMarker> wmarker;
+
+	std::unique_ptr<DartMarkerNoUnmark> vmarkernounmark;
+	std::unique_ptr<DartMarkerNoUnmark> emarkernounmark;
+	std::unique_ptr<DartMarkerNoUnmark> fmarkernounmark;
+	std::unique_ptr<DartMarkerNoUnmark> wmarkernounmark;
+
+	std::unique_ptr<DartMarkerStore> vmarkerstore;
+	std::unique_ptr<DartMarkerStore> emarkerstore;
+	std::unique_ptr<DartMarkerStore> fmarkerstore;
+	std::unique_ptr<DartMarkerStore> wmarkerstore;
+};
+
+TYPED_TEST_CASE(DartMarkerTest, MapTypes);
+
+TYPED_TEST(DartMarkerTest, default_unmarked)
+{
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			EXPECT_FALSE(this->marker->is_marked(d));
+			EXPECT_FALSE(this->markernounmark->is_marked(d));
+			EXPECT_FALSE(this->markerstore->is_marked(d));
+		}
+	});
+}
+
+TYPED_TEST(DartMarkerTest, marking)
+{
+	using Vertex = typename TypeParam::Vertex;
+	using Edge = typename TypeParam::Edge;
+	using Face = typename TypeParam::Face;
+	using Volume = typename TypeParam::Volume;
+
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			this->marker->mark(d);
+			this->markernounmark->mark(d);
+			this->markerstore->mark(d);
+			EXPECT_TRUE(this->marker->is_marked(d));
+			EXPECT_TRUE(this->markernounmark->is_marked(d));
+			EXPECT_TRUE(this->markerstore->is_marked(d));
+
+			Vertex v(d);
+			this->vmarker->mark_orbit(v);
+			this->vmarkernounmark->mark_orbit(v);
+			this->vmarkerstore->mark_orbit(v);
+			this->map.foreach_dart_of_orbit(v, [&](Dart d2)
+			{
+					EXPECT_TRUE(this->vmarker->is_marked(d2));
+					EXPECT_TRUE(this->vmarkernounmark->is_marked(d2));
+					EXPECT_TRUE(this->vmarkerstore->is_marked(d2));
+			});
+
+			Edge e(d);
+			this->emarker->mark_orbit(e);
+			this->emarkernounmark->mark_orbit(e);
+			this->emarkerstore->mark_orbit(e);
+			this->map.foreach_dart_of_orbit(e, [&](Dart d2)
+			{
+					EXPECT_TRUE(this->emarker->is_marked(d2));
+					EXPECT_TRUE(this->emarkernounmark->is_marked(d2));
+					EXPECT_TRUE(this->emarkerstore->is_marked(d2));
+			});
+
+			Face f(d);
+			this->fmarker->mark_orbit(f);
+			this->fmarkernounmark->mark_orbit(f);
+			this->fmarkerstore->mark_orbit(f);
+			this->map.foreach_dart_of_orbit(f, [&](Dart d2)
+			{
+					EXPECT_TRUE(this->fmarker->is_marked(d2));
+					EXPECT_TRUE(this->fmarkernounmark->is_marked(d2));
+					EXPECT_TRUE(this->fmarkerstore->is_marked(d2));
+			});
+
+			Volume w(d);
+			this->wmarker->mark_orbit(w);
+			this->wmarkernounmark->mark_orbit(w);
+			this->wmarkerstore->mark_orbit(w);
+			this->map.foreach_dart_of_orbit(w, [&](Dart d2)
+			{
+					EXPECT_TRUE(this->wmarker->is_marked(d2));
+					EXPECT_TRUE(this->wmarkernounmark->is_marked(d2));
+					EXPECT_TRUE(this->wmarkerstore->is_marked(d2));
+			});
+		}
+	});
+}
+
+TYPED_TEST(DartMarkerTest, unmarking)
+{
+	using Vertex = typename TypeParam::Vertex;
+	using Edge = typename TypeParam::Edge;
+	using Face = typename TypeParam::Face;
+	using Volume = typename TypeParam::Volume;
+
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			Vertex v(d);
+			this->vmarker->mark_orbit(v);
+			this->vmarkerstore->mark_orbit(v);
+			this->vmarker->unmark_orbit(v);
+			this->vmarkerstore->unmark_orbit(v);
+			this->map.foreach_dart_of_orbit(v, [&](Dart d2)
+			{
+					EXPECT_FALSE(this->vmarker->is_marked(d2));
+					EXPECT_FALSE(this->vmarkerstore->is_marked(d2));
+			});
+
+			Edge e(d);
+			this->emarker->mark_orbit(e);
+			this->emarkerstore->mark_orbit(e);
+			this->emarker->unmark_orbit(e);
+			this->emarkerstore->unmark_orbit(e);
+			this->map.foreach_dart_of_orbit(e, [&](Dart d2)
+			{
+					EXPECT_FALSE(this->emarker->is_marked(d2));
+					EXPECT_FALSE(this->emarkerstore->is_marked(d2));
+			});
+
+			Face f(d);
+			this->fmarker->mark_orbit(f);
+			this->fmarkerstore->mark_orbit(f);
+			this->fmarker->unmark_orbit(f);
+			this->fmarkerstore->unmark_orbit(f);
+			this->map.foreach_dart_of_orbit(f, [&](Dart d2)
+			{
+					EXPECT_FALSE(this->fmarker->is_marked(d2));
+					EXPECT_FALSE(this->fmarkerstore->is_marked(d2));
+			});
+
+			Volume w(d);
+			this->wmarker->mark_orbit(w);
+			this->wmarkerstore->mark_orbit(w);
+			this->wmarker->unmark_orbit(w);
+			this->wmarkerstore->unmark_orbit(w);
+			this->map.foreach_dart_of_orbit(w, [&](Dart d2)
+			{
+					EXPECT_FALSE(this->wmarker->is_marked(d2));
+					EXPECT_FALSE(this->wmarkerstore->is_marked(d2));
+			});
+		}
+	});
+}
+
+TYPED_TEST(DartMarkerTest, unmark_all)
+{
+	using Vertex = typename TypeParam::Vertex;
+	using Edge = typename TypeParam::Edge;
+	using Face = typename TypeParam::Face;
+	using Volume = typename TypeParam::Volume;
+
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			this->marker->mark(d);
+			this->markerstore->mark(d);
+
+			Vertex v(d);
+			this->vmarker->mark_orbit(v);
+			this->vmarkerstore->mark_orbit(v);
+
+			Edge e(d);
+			this->emarker->mark_orbit(e);
+			this->emarkerstore->mark_orbit(e);
+
+			Face f(d);
+			this->fmarker->mark_orbit(f);
+			this->fmarkerstore->mark_orbit(f);
+
+			Volume w(d);
+			this->wmarker->mark_orbit(w);
+			this->wmarkerstore->mark_orbit(w);
+		}
+	});
+
+	this->vmarker->unmark_all();
+	this->vmarkerstore->unmark_all();
+	this->emarker->unmark_all();
+	this->emarkerstore->unmark_all();
+	this->fmarker->unmark_all();
+	this->fmarkerstore->unmark_all();
+	this->wmarker->unmark_all();
+	this->wmarkerstore->unmark_all();
+
+	this->map.foreach_dart([&](Dart d)
+	{
+		if (!this->map.is_boundary(d))
+		{
+			EXPECT_FALSE(this->vmarker->is_marked(d));
+			EXPECT_FALSE(this->vmarkerstore->is_marked(d));
+			EXPECT_FALSE(this->emarker->is_marked(d));
+			EXPECT_FALSE(this->emarkerstore->is_marked(d));
+			EXPECT_FALSE(this->fmarker->is_marked(d));
+			EXPECT_FALSE(this->fmarkerstore->is_marked(d));
+			EXPECT_FALSE(this->wmarker->is_marked(d));
+			EXPECT_FALSE(this->wmarkerstore->is_marked(d));
+		}
+	});
+}
+
+} // namespace dart_marker_test


### PR DESCRIPTION
Fixed a bug in CellMarkerStore::unmark() and CellMarkerStore::unmark(): the mark attribute was not updated, making the is_marked() method returning wrong results.

Added some tests for the DartMarker and CellMarker classes.