### PR TITLE
remove normal reading in obj

### DIFF
--- a/cgogn/core/cmap/attribute.h
+++ b/cgogn/core/cmap/attribute.h
@@ -141,7 +141,6 @@ public:
 			chunk_array_->add_external_ref(reinterpret_cast<ChunkArrayGen**>(&chunk_array_));
 	}
 
-
 	inline Attribute_T& operator=(const Self& att)
 	{
 		if (this != &att)
@@ -283,7 +282,6 @@ public:
 		{
 			return index_;
 		}
-
 	};
 
 	inline const_iterator begin() const
@@ -341,8 +339,6 @@ public:
 		{
 			return index_;
 		}
-
-
 	};
 
 	inline iterator begin()

--- a/cgogn/core/cmap/cmap0.h
+++ b/cgogn/core/cmap/cmap0.h
@@ -70,8 +70,9 @@ public:
 	template <Orbit ORBIT>
 	using CellMarkerStore = typename cgogn::CellMarkerStore<Self, ORBIT>;
 
-	using CellCache = typename cgogn::CellCache<Self>;
+	using FilteredQuickTraversor = typename cgogn::FilteredQuickTraversor<Self>;
 	using QuickTraversor = typename cgogn::QuickTraversor<Self>;
+	using CellCache = typename cgogn::CellCache<Self>;
 	using BoundaryCache = typename cgogn::BoundaryCache<Self>;
 
 public:

--- a/cgogn/core/cmap/cmap1.h
+++ b/cgogn/core/cmap/cmap1.h
@@ -73,8 +73,9 @@ public:
 	template <Orbit ORBIT>
 	using CellMarkerStore = typename cgogn::CellMarkerStore<Self, ORBIT>;
 
-	using CellCache = typename cgogn::CellCache<Self>;
+	using FilteredQuickTraversor = typename cgogn::FilteredQuickTraversor<Self>;
 	using QuickTraversor = typename cgogn::QuickTraversor<Self>;
+	using CellCache = typename cgogn::CellCache<Self>;
 	using BoundaryCache = typename cgogn::BoundaryCache<Self>;
 
 protected:

--- a/cgogn/core/cmap/cmap2.h
+++ b/cgogn/core/cmap/cmap2.h
@@ -281,6 +281,11 @@ protected:
 		return Inherit::add_face_topo(size);
 	}
 
+	void remove_face_topo_fp(Dart d)
+	{
+		Inherit::remove_face_topo(d);
+	}
+
 public:
 
 	/**

--- a/cgogn/core/cmap/cmap2.h
+++ b/cgogn/core/cmap/cmap2.h
@@ -86,8 +86,9 @@ public:
 	template <Orbit ORBIT>
 	using CellMarkerStore = typename cgogn::CellMarkerStore<Self, ORBIT>;
 
-	using CellCache = typename cgogn::CellCache<Self>;
+	using FilteredQuickTraversor = typename cgogn::FilteredQuickTraversor<Self>;
 	using QuickTraversor = typename cgogn::QuickTraversor<Self>;
+	using CellCache = typename cgogn::CellCache<Self>;
 	using BoundaryCache = typename cgogn::BoundaryCache<Self>;
 
 protected:

--- a/cgogn/core/cmap/cmap2.h
+++ b/cgogn/core/cmap/cmap2.h
@@ -497,7 +497,7 @@ protected:
 			darts->push_back(e);
 		});
 
-		for(Dart e: *darts)
+		for (Dart e: *darts)
 			this->remove_topology_element(e);
 	}
 
@@ -763,19 +763,19 @@ public:
 		uint32 val_v1 = degree(v.first);
 		uint32 val_v2 = degree(v.second);
 
-		if(val_v1 + val_v2 < 8 || val_v1 + val_v2 > 14)
+		if (val_v1 + val_v2 < 8 || val_v1 + val_v2 > 14)
 			return false;
 
 		Dart e1 = e.dart;
 		Dart e2 = phi2(e.dart);
 
-		if(codegree(Face(e1)) == 3)
+		if (codegree(Face(e1)) == 3)
 		{
 			if (degree(Vertex(this->phi_1(e1))) < 4)
 				return false;
 		}
 
-		if(codegree(Face(e2)) == 3)
+		if (codegree(Face(e2)) == 3)
 		{
 			if (degree(Vertex(this->phi_1(e2))) < 4)
 				return false;
@@ -797,7 +797,7 @@ public:
 		do
 		{
 			auto vn1it = std::find(vn1->begin(), vn1->end(), this->embedding(Vertex(this->phi1(it))));
-			if(vn1it != vn1->end())
+			if (vn1it != vn1->end())
 				return false;
 			it = next_edge(it);
 		} while(it != end);
@@ -1115,10 +1115,10 @@ protected:
 		Dart f = this->boundary_dart(Vertex(d));
 		Dart ff = this->boundary_dart(Vertex(dd));
 
-		if(!f.is_nil())
+		if (!f.is_nil())
 			this->phi1_sew(e, this->phi_1(f));
 
-		if(!ff.is_nil())
+		if (!ff.is_nil())
 			this->phi1_sew(ee, this->phi_1(ff));
 
 		phi2_unsew(d);
@@ -1295,7 +1295,7 @@ protected:
 
 			e_darts->push_back(e_fit);
 			e_fit = this->phi_1(e_fit);
-		}while(d_fit != d);
+		} while(d_fit != d);
 
 		std::vector<Dart>::iterator d_it, e_it;
 
@@ -1344,23 +1344,23 @@ public:
 			if (this->template is_embedded<Vertex>())
 				v_emb->push_back(this->embedding(Vertex(phi2(f_it))));
 
-			if(this->template is_embedded<Edge>())
+			if (this->template is_embedded<Edge>())
 				e_emb->push_back(this->embedding(Edge(f_it)));
 
 			f_it = this->phi1(f_it);
-		}while(f_it != d);
+		} while(f_it != d);
 
-		if(this->template is_embedded<Volume>())
+		if (this->template is_embedded<Volume>())
 			this->template set_orbit_embedding<Volume>(Volume(e), this->embedding(Volume(d)));
 
 		merge_volumes_topo(d, e);
 
-		for(uint32 i = 0 ; i < darts->size() ; ++i)
+		for (uint32 i = 0 ; i < darts->size() ; ++i)
 		{
-			if(this->template is_embedded<Vertex>())
+			if (this->template is_embedded<Vertex>())
 				this->template set_orbit_embedding<Vertex>(Vertex((*darts)[i]), (*v_emb)[i]);
 
-			if(this->template is_embedded<Edge>())
+			if (this->template is_embedded<Edge>())
 				this->template set_orbit_embedding<Edge>(Edge((*darts)[i]), (*e_emb)[i]);
 		}
 
@@ -1491,7 +1491,7 @@ public:
 	{
 		CGOGN_CHECK_CONCRETE_TYPE;
 
-		if(this->template is_embedded<Vertex::ORBIT>())
+		if (this->template is_embedded<Vertex::ORBIT>())
 		{
 			ChunkArray<uint32>* emb0 = this->embeddings_[Vertex::ORBIT];
 			ChunkArray<uint32>* new_emb0 = this->topology_.template add_chunk_array<uint32>("new_EMB_0");
@@ -1593,11 +1593,11 @@ public:
 		Dart prev = path.back();
 		for (Dart d : path)
 		{
-			if(dm.is_marked(d))
+			if (dm.is_marked(d))
 				return false;
 			dm.mark_orbit(Vertex(d));
 
-			if(!this->same_cell(Vertex(d), Vertex(this->phi1(prev))))
+			if (!this->same_cell(Vertex(d), Vertex(this->phi1(prev))))
 				return false;
 
 			prev = d;
@@ -1702,7 +1702,7 @@ protected:
 		visited_faces->push_back(d); // Start with the face of d
 
 		// For every face added to the list
-		for(uint32 i = 0; i < visited_faces->size(); ++i)
+		for (uint32 i = 0; i < visited_faces->size(); ++i)
 		{
 			const Dart e = (*visited_faces)[i];
 			if (!marker.is_marked(e))	// Face has not been visited yet

--- a/cgogn/core/cmap/cmap2_builder.h
+++ b/cgogn/core/cmap/cmap2_builder.h
@@ -96,6 +96,11 @@ public:
 		map_.phi2_unsew(d);
 	}
 
+	inline void remove_face_topo_fp(Dart d)
+	{
+		map_.remove_face_topo_fp(d);
+	}
+
 	inline Dart add_face_topo_fp(uint32 nb_edges)
 	{
 		return map_.add_face_topo_fp(nb_edges);

--- a/cgogn/core/cmap/cmap2_quad.h
+++ b/cgogn/core/cmap/cmap2_quad.h
@@ -81,8 +81,9 @@ public:
 	template <Orbit ORBIT>
 	using CellMarkerNoUnmark = typename cgogn::CellMarkerNoUnmark<Self, ORBIT>;
 
-	using CellCache = typename cgogn::CellCache<Self>;
+	using FilteredQuickTraversor = typename cgogn::FilteredQuickTraversor<Self>;
 	using QuickTraversor = typename cgogn::QuickTraversor<Self>;
+	using CellCache = typename cgogn::CellCache<Self>;
 	using BoundaryCache = typename cgogn::BoundaryCache<Self>;
 
 protected:

--- a/cgogn/core/cmap/cmap2_tri.h
+++ b/cgogn/core/cmap/cmap2_tri.h
@@ -81,8 +81,9 @@ public:
 	template <Orbit ORBIT>
 	using CellMarkerNoUnmark = typename cgogn::CellMarkerNoUnmark<Self, ORBIT>;
 
-	using CellCache = typename cgogn::CellCache<Self>;
+	using FilteredQuickTraversor = typename cgogn::FilteredQuickTraversor<Self>;
 	using QuickTraversor = typename cgogn::QuickTraversor<Self>;
+	using CellCache = typename cgogn::CellCache<Self>;
 	using BoundaryCache = typename cgogn::BoundaryCache<Self>;
 
 protected:

--- a/cgogn/core/cmap/cmap2_tri.h
+++ b/cgogn/core/cmap/cmap2_tri.h
@@ -293,7 +293,7 @@ protected:
 	 * @brief remove a triangle (3 darts)
 	 * @param d
 	 */
-	inline void remove_tri_topo_fp(Dart d)
+	inline void remove_face_topo_fp(Dart d)
 	{
 		this->remove_topology_element(d); // in fact remove PRIM_SIZE darts
 	}
@@ -549,8 +549,8 @@ protected:
 		phi2_sew(phi<12>(d),res);
 		phi2_sew(phi<12>(e),phi2(phi_1(e)));
 
-		remove_tri_topo_fp(d);
-		remove_tri_topo_fp(e);
+		remove_face_topo_fp(d);
+		remove_face_topo_fp(e);
 
 		return res;
 	}
@@ -721,8 +721,8 @@ protected:
 		phi2_unsew(e4);
 #endif
 
-		remove_tri_topo_fp(e.dart);
-		remove_tri_topo_fp(phi2(e.dart));
+		remove_face_topo_fp(e.dart);
+		remove_face_topo_fp(phi2(e.dart));
 
 		Dart f1 = add_tri_topo_fp();
 		Dart f2 = add_tri_topo_fp();
@@ -838,7 +838,7 @@ protected:
 		phi2_sew(e1,f1);
 		phi2_sew(e2,f2);
 		phi2_sew(e3,f3);
-		remove_tri_topo_fp(f.dart);
+		remove_face_topo_fp(f.dart);
 
 		return Vertex(phi_1(f1));
 	}

--- a/cgogn/core/cmap/cmap3.h
+++ b/cgogn/core/cmap/cmap3.h
@@ -88,8 +88,9 @@ public:
 	template <Orbit ORBIT>
 	using CellMarkerStore = typename cgogn::CellMarkerStore<Self, ORBIT>;
 
-	using CellCache = typename cgogn::CellCache<Self>;
+	using FilteredQuickTraversor = typename cgogn::FilteredQuickTraversor<Self>;
 	using QuickTraversor = typename cgogn::QuickTraversor<Self>;
+	using CellCache = typename cgogn::CellCache<Self>;
 	using BoundaryCache = typename cgogn::BoundaryCache<Self>;
 
 protected:

--- a/cgogn/core/cmap/cmap3.h
+++ b/cgogn/core/cmap/cmap3.h
@@ -628,7 +628,7 @@ protected:
 
 		this->Inherit::split_vertex_topo(prev, this->phi2(this->phi_1(this->phi2(this->phi_1(prev)))));
 
-		for(uint32 i = 1; i < vd.size(); ++i)
+		for (uint32 i = 1; i < vd.size(); ++i)
 		{
 			prev = vd[i];
 			const Dart fs = this->phi_1(this->phi2(this->phi_1(prev)));	//first side
@@ -643,7 +643,7 @@ protected:
 		if (this->is_incident_to_boundary(Face(this->phi2(this->phi_1(prev)))))
 			db2 = this->phi2(phi3(this->phi2(this->phi_1(prev))));
 
-		if(!db1.is_nil() && !db2.is_nil())
+		if (!db1.is_nil() && !db2.is_nil())
 		{
 			this->Inherit::split_vertex_topo(db1, db2);
 			phi3_sew(this->phi1(this->phi2(db2)), this->phi_1(phi3(this->phi2(db2))));
@@ -704,7 +704,7 @@ public:
 
 		if (this->template is_embedded<Volume>())
 		{
-			for(auto dit1 : vd)
+			for (auto dit1 : vd)
 				this->template set_orbit_embedding<Volume>(Volume(dit1), this->embedding(Volume(dit1)));
 		}
 
@@ -929,7 +929,7 @@ protected:
 				Dart d3 = phi3(fit);
 				Dart d32 = this->phi2(d3);
 
-				if(res.is_nil())
+				if (res.is_nil())
 					res = d2;
 
 				this->phi2_unsew(d2);
@@ -1194,7 +1194,7 @@ protected:
 		{
 			const Dart fa_it2 = this->phi2(fa_it);
 			const Dart fb_it2 = this->phi2(fb_it);
-			if(fa_it2 != fb_it)
+			if (fa_it2 != fb_it)
 			{
 				this->phi2_unsew(fa_it);
 				this->phi2_unsew(fb_it);
@@ -1406,7 +1406,7 @@ protected:
 		uint32 count = 0u;
 
 		// For every face added to the list
-		for(uint32 i = 0u; i < visitedFaces.size(); ++i)
+		for (uint32 i = 0u; i < visitedFaces.size(); ++i)
 		{
 			Dart it = visitedFaces[i];
 			Dart f = it;
@@ -1709,7 +1709,7 @@ protected:
 		const std::vector<Dart>& marked_darts = marker.marked_darts();
 
 		marker.mark(d);
-		for(uint32 i = 0; i < marked_darts.size(); ++i)
+		for (uint32 i = 0; i < marked_darts.size(); ++i)
 		{
 			const Dart curr_dart = marked_darts[i];
 			if ( !(this->is_boundary(curr_dart) && this->is_boundary(phi3(curr_dart))) )
@@ -1720,9 +1720,9 @@ protected:
 			const Dart d2_1 = this->phi2(d_1); // turn in volume
 			const Dart d3_1 = phi3(d_1); // change volume
 
-			if(!marker.is_marked(d2_1))
+			if (!marker.is_marked(d2_1))
 				marker.mark(d2_1);
-			if(!marker.is_marked(d3_1))
+			if (!marker.is_marked(d3_1))
 				marker.mark(d3_1);
 		}
 	}
@@ -1774,7 +1774,7 @@ protected:
 		visited_face2->push_back(d); // Start with the face of d
 
 		// For every face added to the list
-		for(uint32 i = 0; i < visited_face2->size(); ++i)
+		for (uint32 i = 0; i < visited_face2->size(); ++i)
 		{
 			const Dart e = (*visited_face2)[i];
 			if (!marker.is_marked(e))	// Face2 has not been visited yet
@@ -2504,7 +2504,7 @@ public:
 	bool merge(const CMap2& map2, DartMarker& newdarts)
 	{
 		// check attributes compatibility
-		for(uint32 i = 0; i < NB_ORBITS; ++i)
+		for (uint32 i = 0; i < NB_ORBITS; ++i)
 		{
 			if (this->embeddings_[i] != nullptr)
 			{
@@ -2584,7 +2584,7 @@ public:
 		}
 
 		// change embedding indices of moved lines
-		for(uint32 i = 0; i < NB_ORBITS; ++i)
+		for (uint32 i = 0; i < NB_ORBITS; ++i)
 		{
 			ChunkArray<uint32>* emb = this->embeddings_[i];
 			if (emb != nullptr)

--- a/cgogn/core/cmap/cmap3_hexa.h
+++ b/cgogn/core/cmap/cmap3_hexa.h
@@ -84,8 +84,9 @@ public:
 	template <Orbit ORBIT>
 	using CellMarkerNoUnmark = typename cgogn::CellMarkerNoUnmark<Self, ORBIT>;
 
-	using CellCache = typename cgogn::CellCache<Self>;
+	using FilteredQuickTraversor = typename cgogn::FilteredQuickTraversor<Self>;
 	using QuickTraversor = typename cgogn::QuickTraversor<Self>;
+	using CellCache = typename cgogn::CellCache<Self>;
 	using BoundaryCache = typename cgogn::BoundaryCache<Self>;
 
 protected:

--- a/cgogn/core/cmap/cmap3_tetra.h
+++ b/cgogn/core/cmap/cmap3_tetra.h
@@ -84,8 +84,9 @@ public:
 	template <Orbit ORBIT>
 	using CellMarkerNoUnmark = typename cgogn::CellMarkerNoUnmark<Self, ORBIT>;
 
-	using CellCache = typename cgogn::CellCache<Self>;
+	using FilteredQuickTraversor = typename cgogn::FilteredQuickTraversor<Self>;
 	using QuickTraversor = typename cgogn::QuickTraversor<Self>;
+	using CellCache = typename cgogn::CellCache<Self>;
 	using BoundaryCache = typename cgogn::BoundaryCache<Self>;
 
 protected:

--- a/cgogn/core/cmap/map_base.h
+++ b/cgogn/core/cmap/map_base.h
@@ -1504,7 +1504,7 @@ public:
 	bool merge(const ConcreteMap& map, DartMarker& newdarts)
 	{
 		// check attributes compatibility
-		for(uint32 i = 0; i < NB_ORBITS; ++i)
+		for (uint32 i = 0; i < NB_ORBITS; ++i)
 		{
 			if (this->embeddings_[i] != nullptr)
 			{
@@ -1552,7 +1552,7 @@ public:
 		});
 
 		// change embedding indices of moved lines
-		for(uint32 i = 0; i < NB_ORBITS; ++i)
+		for (uint32 i = 0; i < NB_ORBITS; ++i)
 		{
 			ChunkArray<uint32>* emb = this->embeddings_[i];
 			if (emb != nullptr)

--- a/cgogn/core/graph/undirected_graph.h
+++ b/cgogn/core/graph/undirected_graph.h
@@ -34,6 +34,7 @@ template <typename MAP_TYPE>
 class UndirectedGraph_T : public MapBase<MAP_TYPE>
 {
 public:
+
 	static const uint8 DIMENSION = 2;
 	static const uint8 PRIM_SIZE = 1;
 
@@ -97,18 +98,16 @@ protected:
 	}
 
 public:
+
 	UndirectedGraph_T() : Inherit()
 	{
 		init();
 	}
 
+	CGOGN_NOT_COPYABLE_NOR_MOVABLE(UndirectedGraph_T);
+
 	~UndirectedGraph_T() override
 	{}
-
-	UndirectedGraph_T(Self const&) = delete;
-	UndirectedGraph_T(Self &&) = delete;
-	Self& operator=(Self const&) = delete;
-	Self& operator=(Self &&) = delete;
 
 	inline bool check_embedding_integrity()
 	{
@@ -127,6 +126,7 @@ public:
 	}
 
 protected:
+
 	inline void init_dart(Dart d)
 	{
 		(*alpha0_)[d.index] = d;
@@ -141,8 +141,7 @@ protected:
 				alpha_1(alpha1(d)) == d;
 	}
 
-	/* alpha0 is an involution
-		 */
+	/* alpha0 is an involution */
 	inline void alpha0_sew(Dart d, Dart e)
 	{
 		(*alpha0_)[d.index] = e;
@@ -156,8 +155,7 @@ protected:
 		(*alpha0_)[e.index] = e;
 	}
 
-	/* alpha1 is a permutation
-		 */
+	/* alpha1 is a permutation */
 	inline void alpha1_sew(Dart d, Dart e)
 	{
 		Dart f = alpha1(d);
@@ -179,6 +177,7 @@ protected:
 	}
 
 public:
+
 	inline Dart alpha0(Dart d) const
 	{
 		return (*alpha0_)[d.index];
@@ -195,6 +194,7 @@ public:
 	}
 
 protected:
+
 	inline Dart add_vertex_topo(std::size_t size)
 	{
 		cgogn_message_assert(size > 0u, "Cannot create an empty vertex");
@@ -202,7 +202,7 @@ protected:
 		Dart d = this->add_topology_element();
 		Dart first = d;
 		Dart dit;
-		for(size_t i = 0 ; i < size - 1 ; ++i)
+		for (size_t i = 0 ; i < size - 1 ; ++i)
 		{
 			dit = this->add_topology_element();
 			alpha1_sew(d,dit);
@@ -239,14 +239,15 @@ protected:
 	}
 
 public:
+
 	inline Vertex insert_vertex(Edge e)
 	{
 		Vertex v(insert_vertex_topo(e.dart));
 
-		if(this->template is_embedded<Vertex>())
+		if (this->template is_embedded<Vertex>())
 			this->new_orbit_embedding(v);
 
-		if(this->template is_embedded<Edge>())
+		if (this->template is_embedded<Edge>())
 		{
 			this->template set_orbit_embedding<Edge>(e, this->embedding(e));
 			Edge e2(alpha1(v.dart));
@@ -257,6 +258,7 @@ public:
 	}
 
 protected:
+
 	inline Dart collapse_vertex_topo(Dart d)
 	{
 		Dart e = alpha0(d);
@@ -269,17 +271,35 @@ protected:
 	}
 
 public:
+
 	inline void collapse_vertex(Vertex v)
 	{
 		cgogn_message_assert(degree(v) == 2, "Can only collapse vertex of degree 2");
 
 		Edge e(collapse_vertex_topo(v.dart));
 
-		if(this->template is_embedded<Edge>())
-			this->template set_orbit_embedding<Edge>(Edge(e), this->embedding(e));
+		if (this->template is_embedded<Edge>())
+			this->template set_orbit_embedding<Edge>(e, this->embedding(e));
 	}
 
 protected:
+
+	inline void merge_vertices_topo(Dart v1, Dart v2)
+	{
+		alpha1_sew(v1, v2);
+	}
+
+public:
+
+	inline void merge_vertices(Vertex v1, Vertex v2)
+	{
+		merge_vertices_topo(v1.dart, v2.dart);
+		if (this->template is_embedded<Vertex>())
+			this->template set_orbit_embedding<Vertex>(v1, this->embedding(v1));
+	}
+
+protected:
+
 	inline Dart add_edge_topo()
 	{
 		Dart d = this->add_topology_element();
@@ -291,39 +311,41 @@ protected:
 	}
 
 public:
+
 	inline Edge add_edge()
 	{
 		Edge e(add_edge_topo());
 
-		if(this->template is_embedded<Vertex>())
+		if (this->template is_embedded<Vertex>())
 		{
 			this->new_orbit_embedding(Vertex(e.dart));
 			this->new_orbit_embedding(Vertex(alpha0(e.dart)));
 		}
 
-		if(this->template is_embedded<Edge>())
+		if (this->template is_embedded<Edge>())
 			this->new_orbit_embedding(e);
 
 		return e;
 	}
 
 protected:
+
 	inline void disconnect_edge_topo(Dart e)
 	{
 		alpha1_unsew(e);
 	}
 
 public:
+
 	inline void disconnect_edge(Edge e)
 	{
 		disconnect_edge_topo(e.dart);
-		if(this->template is_embedded<Vertex>())
-		{
-			this->new_orbit_embedding(Vertex(e.dart));			
-		}
+		if (this->template is_embedded<Vertex>())
+			this->new_orbit_embedding(Vertex(e.dart));
 	}
 
 protected:
+
 	inline Dart collapse_edge_topo(Dart e)
 	{
 		Dart e0 = alpha0(e);
@@ -341,10 +363,11 @@ protected:
 	}
 
 public:
+
 	inline Vertex collapse_edge(Edge e)
 	{
 		Vertex v(collapse_edge_topo(e.dart));
-		if(this->template is_embedded<Vertex>())
+		if (this->template is_embedded<Vertex>())
 		{
 			this->template set_orbit_embedding<Vertex>(v, this->embedding(v));
 		}
@@ -353,18 +376,19 @@ public:
 	}
 
 public:
+
 	inline Vertex make_polyline(uint32 n)
 	{
 		Vertex last;
 
-		for(uint32 i = 0; i < n - 1; ++i)
+		for (uint32 i = 0; i < n - 1; ++i)
 		{
 			Edge cur = add_edge();
-			if(last.is_valid())
+			if (last.is_valid())
 			{
 				alpha1_sew(last.dart, cur.dart);
 
-				if(this->template is_embedded<Vertex>())
+				if (this->template is_embedded<Vertex>())
 					this->template copy_embedding<Vertex>(cur.dart, last.dart);
 			}
 			last = Vertex(alpha0(cur.dart));
@@ -378,14 +402,14 @@ public:
 		Vertex last;
 		Vertex first;
 
-		for(uint32 i = 0; i < n; ++i)
+		for (uint32 i = 0; i < n; ++i)
 		{
 			Edge cur = add_edge();
-			if(last.is_valid())
+			if (last.is_valid())
 			{
 				alpha1_sew(last.dart, cur.dart);
 
-				if(this->template is_embedded<Vertex>())
+				if (this->template is_embedded<Vertex>())
 					this->template copy_embedding<Vertex>(cur.dart, last.dart);
 			}
 			else
@@ -395,7 +419,7 @@ public:
 		}
 		alpha1_sew(first.dart, last.dart);
 
-		if(this->template is_embedded<Vertex>())
+		if (this->template is_embedded<Vertex>())
 			this->template copy_embedding<Vertex>(last.dart, first.dart);
 
 		return first;
@@ -409,13 +433,14 @@ public:
 	/*******************************************************************************
 	 * Connectivity information
 	 *******************************************************************************/
+
 public:
+
 	inline uint32 degree(Vertex v) const
 	{
 		return this->nb_darts_of_orbit(v);
 	}
 
-public:
 	/*******************************************************************************
 	* Orbits traversal                                                             *
 	*******************************************************************************/
@@ -455,7 +480,7 @@ protected:
 		Dart it = d;
 		do
 		{
-			if(!internal::void_to_true_binder(f, it))
+			if (!internal::void_to_true_binder(f, it))
 				break;
 			it = alpha1(alpha0(it));
 		} while (it != d);
@@ -464,7 +489,7 @@ protected:
 	template <typename FUNC>
 	inline void foreach_dart_of_ALPHA0(Dart d, const FUNC& f) const
 	{
-		if(internal::void_to_true_binder(f, d))
+		if (internal::void_to_true_binder(f, d))
 			f(alpha0(d));
 	}
 
@@ -474,13 +499,14 @@ protected:
 		Dart it = d;
 		do
 		{			
-			if(!internal::void_to_true_binder(f, it))
+			if (!internal::void_to_true_binder(f, it))
 				break;
 			it = alpha1(it);
 		} while (it != d);
 	}
 
-public:	
+public:
+
 	/******************************************************************************
 	* Incidence traversal                                                         *
 	******************************************************************************/
@@ -566,15 +592,15 @@ public:
 	*/
 	void merge_check_embedding(const Self& map)
 	{
-		const static auto create_embedding = [=](Self* map_ptr, Orbit orb)
+		const static auto create_embedding = [=] (Self* map_ptr, Orbit orb)
 		{
 			switch (orb)
 			{
-			case Orbit::DART: map_ptr->template create_embedding<Orbit::DART>(); break;
-			case Orbit::PHI1: map_ptr->template create_embedding<Orbit::PHI1>(); break;
-			case Orbit::PHI2: map_ptr->template create_embedding<Orbit::PHI2>(); break;
-			case Orbit::PHI21: map_ptr->template create_embedding<Orbit::PHI21>(); break;
-			default: break;
+				case Orbit::DART: map_ptr->template create_embedding<Orbit::DART>(); break;
+				case Orbit::PHI1: map_ptr->template create_embedding<Orbit::PHI1>(); break;
+				case Orbit::PHI2: map_ptr->template create_embedding<Orbit::PHI2>(); break;
+				case Orbit::PHI21: map_ptr->template create_embedding<Orbit::PHI21>(); break;
+				default: break;
 			}
 		};
 
@@ -589,15 +615,15 @@ public:
 	*/
 	void merge_finish_embedding(uint32 first)
 	{
-		const static auto new_orbit_embedding = [=](Self* map, Dart d, cgogn::Orbit orb)
+		const static auto new_orbit_embedding = [=] (Self* map, Dart d, cgogn::Orbit orb)
 		{
 			switch (orb)
 			{
-			case Orbit::DART: map->new_orbit_embedding(Cell<Orbit::DART>(d)); break;
-			case Orbit::PHI1: map->new_orbit_embedding(Cell<Orbit::PHI1>(d)); break;
-			case Orbit::PHI2: map->new_orbit_embedding(Cell<Orbit::PHI2>(d)); break;
-			case Orbit::PHI21: map->new_orbit_embedding(Cell<Orbit::PHI21>(d)); break;
-			default: break;
+				case Orbit::DART: map->new_orbit_embedding(Cell<Orbit::DART>(d)); break;
+				case Orbit::PHI1: map->new_orbit_embedding(Cell<Orbit::PHI1>(d)); break;
+				case Orbit::PHI2: map->new_orbit_embedding(Cell<Orbit::PHI2>(d)); break;
+				case Orbit::PHI21: map->new_orbit_embedding(Cell<Orbit::PHI21>(d)); break;
+				default: break;
 			}
 		};
 

--- a/cgogn/core/utils/masks.h
+++ b/cgogn/core/utils/masks.h
@@ -255,7 +255,7 @@ public:
 
 		inline Dart operator*() const
 		{
-			return qt_ptr_->qt_attributes_[orbit_]->operator[](index_);
+			return qt_ptr_->qt_attributes_[orbit_](this->operator[](index_));
 		}
 
 		inline bool operator!=(const_iterator it) const

--- a/cgogn/core/utils/masks.h
+++ b/cgogn/core/utils/masks.h
@@ -255,7 +255,7 @@ public:
 
 		inline Dart operator*() const
 		{
-			return qt_ptr_->qt_attributes_[orbit_]->operator[](index_);
+			return (qt_ptr_->qt_attributes_[orbit_])[index_];
 		}
 
 		inline bool operator!=(const_iterator it) const
@@ -411,6 +411,20 @@ public:
 			[] (CellType) { return true; },
 			[] (CellType c) -> Dart { return c.dart; }
 		);
+	}
+
+	template <typename CellType, typename DartSelectionFunction>
+	inline void add(CellType c, const DartSelectionFunction& dart_select)
+	{
+		static_assert(is_func_return_same<DartSelectionFunction, Dart>::value && is_func_parameter_same<DartSelectionFunction, CellType>::value, "Badly formed DartSelectionFunction");
+		static const Orbit ORBIT = CellType::ORBIT;
+		cells_[ORBIT].push_back(dart_select(c));
+	}
+
+	template <typename CellType>
+	inline void add(CellType c)
+	{
+		this->add<CellType>(c, [] (CellType c) -> Dart { return c.dart; });
 	}
 
 private:

--- a/cgogn/core/utils/masks.h
+++ b/cgogn/core/utils/masks.h
@@ -255,7 +255,7 @@ public:
 
 		inline Dart operator*() const
 		{
-			return qt_ptr_->qt_attributes_[orbit_](this->operator[](index_));
+			return qt_ptr_->qt_attributes_[orbit_]->operator[](index_);
 		}
 
 		inline bool operator!=(const_iterator it) const

--- a/cgogn/core/utils/masks.h
+++ b/cgogn/core/utils/masks.h
@@ -222,10 +222,9 @@ public:
 		inline const_iterator(const Self* qt, Orbit orbit, uint32 i) :
 			qt_ptr_(qt),
 			orbit_(orbit),
+			ca_cont_(qt->map_.attribute_container(orbit)),
 			index_(i)
-		{
-			ca_cont_ = qt_ptr_->map_.attribute_container(orbit);
-		}
+		{}
 
 		inline const_iterator(const const_iterator& it) :
 			qt_ptr_(it.qt_ptr_),
@@ -270,8 +269,8 @@ public:
 	{
 		static const Orbit ORBIT = CellType::ORBIT;
 		const_iterator it(
-			&qt_attributes_[ORBIT],
-			map_.template attribute_container<ORBIT>(),
+			this,
+			ORBIT,
 			map_.template attribute_container<ORBIT>().begin()
 		);
 		if (!qt_filters_[ORBIT](*it))
@@ -284,8 +283,8 @@ public:
 	{
 		static const Orbit ORBIT = CellType::ORBIT;
 		return const_iterator(
-			&qt_attributes_[ORBIT],
-			map_.template attribute_container<ORBIT>(),
+			this,
+			ORBIT,
 			map_.template attribute_container<ORBIT>().end()
 		);
 	}
@@ -301,9 +300,9 @@ public:
 	template <typename CellType, typename FilterFunction>
 	inline void set_filter(const FilterFunction& filter)
 	{
-		static_assert(is_func_return_same<FilterFunction, bool>::value && is_func_parameter_same<FilterFunction, CellType>::value, "Badly formed FilterFunction");
+		static_assert(is_func_return_same<FilterFunction, bool>::value && is_func_parameter_same<FilterFunction, Dart>::value, "Badly formed FilterFunction");
 		static const Orbit ORBIT = CellType::ORBIT;
-		qt_filters_[ORBIT] = [&] (Dart d) -> bool { return filter(CellType(d)); };
+		qt_filters_[ORBIT] = filter;
 	}
 
 	template <typename CellType, typename DartSelectionFunction>

--- a/cgogn/geometry/algos/angle.h
+++ b/cgogn/geometry/algos/angle.h
@@ -39,6 +39,21 @@ namespace cgogn
 namespace geometry
 {
 
+template <typename VEC3, typename MAP>
+inline typename vector_traits<VEC3>::Scalar angle(
+	const MAP& map,
+	const Cell<Orbit::DART> v,
+	const typename MAP::template VertexAttribute<VEC3>& position
+)
+{
+	using Vertex = typename MAP::Vertex;
+
+	const VEC3& p = position[Vertex(v.dart)];
+	VEC3 v1 = position[Vertex(map.phi1(v.dart))] - p;
+	VEC3 v2 = position[Vertex(map.phi_1(v.dart))] - p;
+	return angle(v1, v2);
+}
+
 /**
  * compute and return the angle formed by the normals of the two faces incident to the given edge
  */

--- a/cgogn/geometry/examples/filtering.cpp
+++ b/cgogn/geometry/examples/filtering.cpp
@@ -165,10 +165,7 @@ void Viewer::import(const std::string& surface_mesh)
 	cell_cache_.build<Edge>();
 
 	fqt_.build<Vertex>();
-	fqt_.set_filter<Vertex>([&] (Vertex v)
-	{
-		return vertex_position_[v][0] > 0;
-	});
+	fqt_.set_filter<Vertex>([&] (cgogn::Dart d) { return vertex_position_[Vertex(d)][0] > 0; });
 
 	filter_ = cgogn::make_unique<CustomFilter>(vertex_position_);
 

--- a/cgogn/geometry/examples/filtering.cpp
+++ b/cgogn/geometry/examples/filtering.cpp
@@ -108,6 +108,7 @@ private:
 	VertexAttribute<Vec3> vertex_normal_;
 
 	Map2::CellCache cell_cache_;
+	cgogn::FilteredQuickTraversor<Map2> fqt_;
 	std::unique_ptr<CustomFilter> filter_;
 
 	cgogn::geometry::AABB<Vec3> bb_;
@@ -163,6 +164,12 @@ void Viewer::import(const std::string& surface_mesh)
 	cell_cache_.build<Vertex>();
 	cell_cache_.build<Edge>();
 
+	fqt_.build<Vertex>();
+	fqt_.set_filter<Vertex>([&] (Vertex v)
+	{
+		return vertex_position_[v][0] > 0;
+	});
+
 	filter_ = cgogn::make_unique<CustomFilter>(vertex_position_);
 
 	cgogn::geometry::compute_AABB(vertex_position_, bb_);
@@ -194,6 +201,7 @@ Viewer::Viewer() :
 	vertex_position_(),
 	vertex_normal_(),
 	cell_cache_(map_),
+	fqt_(map_),
 	bb_(),
 	render_(nullptr),
 	vbo_pos_(nullptr),
@@ -235,7 +243,8 @@ void Viewer::keyPressEvent(QKeyEvent *ev)
 //			bb_rendering_ = !bb_rendering_;
 //			break;
 		case Qt::Key_A: {
-			cgogn::geometry::filter_average<Vec3>(map_, *filter_, vertex_position_, vertex_position2_);
+			cgogn::geometry::filter_average<Vec3>(map_, fqt_, vertex_position_, vertex_position2_);
+//			cgogn::geometry::filter_average<Vec3>(map_, *filter_, vertex_position_, vertex_position2_);
 //			cgogn::geometry::filter_average<Vec3>(map_, cell_cache_, vertex_position_, vertex_position2_);
 //			cgogn::geometry::filter_average<Vec3>(map_, vertex_position_, vertex_position2_);
 			map_.swap_attributes(vertex_position_, vertex_position2_);

--- a/cgogn/geometry/functions/area.h
+++ b/cgogn/geometry/functions/area.h
@@ -35,11 +35,25 @@ namespace geometry
 /**
  * area of the triangle formed by 3 points in 3D
  */
-template <typename VEC3>
-inline typename vector_traits<VEC3>::Scalar area(const VEC3& p1, const VEC3& p2, const VEC3& p3)
+template <typename VEC>
+inline auto area(const VEC& p1, const VEC& p2, const VEC& p3)
+	-> typename std::enable_if<vector_traits<VEC>::SIZE == 3, typename vector_traits<VEC>::Scalar>::type
 {
-	using Scalar = typename vector_traits<VEC3>::Scalar;
+	using Scalar = typename vector_traits<VEC>::Scalar;
 	return (Scalar(0.5) * ((p2 - p1).cross(p3 - p1)).norm());
+}
+
+/**
+ * area of the triangle formed by 3 points in 2D
+ */
+template <typename VEC>
+inline auto area(const VEC& p1, const VEC& p2, const VEC& p3)
+	-> typename std::enable_if<vector_traits<VEC>::SIZE == 2, typename vector_traits<VEC>::Scalar>::type
+{
+	using Scalar = typename vector_traits<VEC>::Scalar;
+	VEC v1 = p2 - p1;
+	VEC v2 = p3 - p1;
+	return (Scalar(0.5) * (v1[0] * v2[1] - v1[1] * v2[0]));
 }
 
 } // namespace geometry

--- a/cgogn/geometry/functions/intersection.h
+++ b/cgogn/geometry/functions/intersection.h
@@ -166,7 +166,7 @@ Intersection intersection_segment_segment(
 	)
 		return NO_INTERSECTION;
 
-	if(numerics::almost_equal_absolute(PA, Inter) || numerics::almost_equal_absolute(PB, Inter) || numerics::almost_equal_absolute(QA, Inter) || numerics::almost_equal_absolute(QB, Inter))
+	if(PA.isApprox(Inter) || PB.isApprox(Inter) || QA.isApprox(Inter) || QB.isApprox(Inter))
 		return VERTEX_INTERSECTION;
 
 	return EDGE_INTERSECTION;

--- a/cgogn/geometry/types/aabb.h
+++ b/cgogn/geometry/types/aabb.h
@@ -44,7 +44,6 @@ namespace geometry
 template <typename VEC_T>
 class AABB
 {
-
 public:
 
 	using Vec = VEC_T;
@@ -54,6 +53,7 @@ public:
 	// https://eigen.tuxfamily.org/dox-devel/group__TopicStructHavingEigenMembers.html
 	static const bool eigen_make_aligned = std::is_same<Eigen::AlignedVector3<Scalar>, Vec>::value;
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW_IF(eigen_make_aligned)
+
 private:
 
 	bool initialized_;
@@ -224,11 +224,11 @@ public:
 		cgogn_message_assert(initialized_, "Axis-Aligned Bounding box not initialized");
 		Vec bbmin = bb.min();
 		Vec bbmax = bb.max();
-		for(uint32 i = 0; i < dim_; ++i)
+		for (uint32 i = 0; i < dim_; ++i)
 		{
-			if(bbmin[i] < p_min_[i])
+			if (bbmin[i] < p_min_[i])
 				p_min_[i] = bbmin[i];
-			if(bbmax[i] > p_max_[i])
+			if (bbmax[i] > p_max_[i])
 				p_max_[i] = bbmax[i];
 		}
 	}
@@ -237,11 +237,11 @@ public:
 	bool contains(const Vec& p) const
 	{
 		cgogn_message_assert(initialized_, "Axis-Aligned Bounding box not initialized");
-		for(uint32 i = 0; i < dim_; ++i)
+		for (uint32 i = 0; i < dim_; ++i)
 		{
-			if(p_min_[i] > p[i])
+			if (p_min_[i] > p[i])
 				return false;
-			if(p[i] > p_max_[i])
+			if (p[i] > p_max_[i])
 				return false;
 		}
 			return true;
@@ -272,10 +272,11 @@ public:
 		p_max_ = ((p_max_ - center) * size) + center;
 	}
 
-	/// \brief Test if a ray intersectes an axis-aligned box
+	/// \brief Test if a ray intersects an axis-aligned box
 	/// \tparam VEC3 the domain of the box. Has to be of dimension 3
+	template <bool B = true>
 	auto ray_intersect(const Vec& P, const Vec& V) const
-	  -> typename std::enable_if<nb_components_traits<Vec>::value == 3, bool>::type
+	  -> typename std::enable_if<B && vector_traits<Vec>::SIZE == 3, bool>::type
 	{
 		if (!cgogn::almost_equal_relative(V[2], Scalar(0)))
 		{

--- a/cgogn/geometry/types/quadric.h
+++ b/cgogn/geometry/types/quadric.h
@@ -87,40 +87,32 @@ public:
 		return *this;
 	}
 
-	template <
-		typename VEC3,
-		typename std::enable_if<nb_components_traits<VEC3>::value == 3 && std::is_same<typename vector_traits<VEC3>::Scalar, double>::value>::type* = nullptr
-	>
-	double operator()(const VEC3& v)
+	template <typename VEC3>
+	auto operator()(const VEC3& v)
+		-> typename std::enable_if<vector_traits<VEC3>::SIZE == 3 && std::is_same<typename vector_traits<VEC3>::Scalar, double>::value, double>::type
 	{
 		return (*this)(Vec4d(v[0], v[1], v[2], 1.));
 	}
 
-	template <
-		typename VEC3,
-		typename std::enable_if<nb_components_traits<VEC3>::value == 3 && !std::is_same<typename vector_traits<VEC3>::Scalar, double>::value>::type* = nullptr
-	>
-	typename vector_traits<VEC3>::Scalar operator()(const VEC3& v)
+	template <typename VEC3>
+	auto operator()(const VEC3& v)
+		-> typename std::enable_if<vector_traits<VEC3>::SIZE == 3 && !std::is_same<typename vector_traits<VEC3>::Scalar, double>::value, typename vector_traits<VEC3>::Scalar>::type
 	{
 		using Scalar = typename vector_traits<VEC3>::Scalar;
 
 		return Scalar((*this)(Vec4d(double(v[0]), double(v[1]), double(v[2]), 1.)));
 	}
 
-	template <
-		typename VEC4,
-		typename std::enable_if<nb_components_traits<VEC4>::value == 4 && std::is_same<VEC4, Vec4d>::value>::type* = nullptr
-	>
-	double operator()(const VEC4& v)
+	template <typename VEC4>
+	auto operator()(const VEC4& v)
+		-> typename std::enable_if<vector_traits<VEC4>::SIZE == 4 && std::is_same<VEC4, Vec4d>::value, double>::type
 	{
 		return v.transpose() * matrix_ * v;
 	}
 
-	template <
-		typename VEC4,
-		typename std::enable_if<nb_components_traits<VEC4>::value == 4 && !std::is_same<VEC4, Vec4d>::value>::type* = nullptr
-	>
-	typename vector_traits<VEC4>::Scalar operator()(const VEC4& v)
+	template <typename VEC4>
+	auto operator()(const VEC4& v)
+		-> typename std::enable_if<vector_traits<VEC4>::SIZE == 4 && !std::is_same<VEC4, Vec4d>::value, typename vector_traits<VEC4>::Scalar>::type
 	{
 		using Scalar = typename vector_traits<VEC4>::Scalar;
 
@@ -133,11 +125,9 @@ public:
 		return Scalar(res);
 	}
 
-	template <
-		typename VEC3,
-		typename std::enable_if<nb_components_traits<VEC3>::value == 3>::type* = nullptr
-	>
-	bool optimized(VEC3& v)
+	template <typename VEC3>
+	auto optimized(VEC3& v)
+		-> typename std::enable_if<vector_traits<VEC3>::SIZE == 3, bool>::type
 	{
 		using Scalar = typename vector_traits<VEC3>::Scalar;
 
@@ -152,11 +142,9 @@ public:
 		return b;
 	}
 
-	template <
-		typename VEC4,
-		typename std::enable_if<nb_components_traits<VEC4>::value == 4 && std::is_same<VEC4, Vec4d>::value>::type* = nullptr
-	>
-	bool optimized(VEC4& v)
+	template <typename VEC4>
+	auto optimized(VEC4& v)
+		-> typename std::enable_if<vector_traits<VEC4>::SIZE == 4 && std::is_same<VEC4, Vec4d>::value, bool>::type
 	{
 		Matrix4d m(matrix_);
 		for (uint32 i = 0; i < 3; ++i) m(3,i) = 0.;
@@ -170,11 +158,9 @@ public:
 		return invertible;
 	}
 
-	template <
-		typename VEC4,
-		typename std::enable_if<nb_components_traits<VEC4>::value == 4 && !std::is_same<VEC4, Vec4d>::value>::type* = nullptr
-	>
-	bool optimized(VEC4& v)
+	template <typename VEC4>
+	auto optimized(VEC4& v)
+		-> typename std::enable_if<vector_traits<VEC4>::SIZE == 4 && !std::is_same<VEC4, Vec4d>::value, bool>::type
 	{
 		using Scalar = typename vector_traits<VEC4>::Scalar;
 

--- a/cgogn/io/data_io.h
+++ b/cgogn/io/data_io.h
@@ -316,7 +316,7 @@ public:
 
 	virtual uint32 nb_components() const override
 	{
-		return geometry::nb_components_traits<T>::value;
+		return geometry::vector_traits<T>::SIZE;
 	}
 
 	virtual std::size_t size() const override

--- a/cgogn/io/examples/convert_mesh.cpp
+++ b/cgogn/io/examples/convert_mesh.cpp
@@ -39,7 +39,9 @@ int main(int argc, char** argv)
 	{
 		cgogn_log_info("convert_mesh") << "USAGE: " << argv[0] << " [input_filename] [output_filename] [bool(is_surface)] [bool(binary_output)](optional, default 0) [bool(compress_output)](optional, default 0) [bool(overwrite_output)](optional, default 0)";
 		return 0;
-	} else {
+	}
+	else
+	{
 		input_filename = std::string(argv[1]);
 		output_filename = std::string(argv[2]);
 		is_surface = string_to_bool(argv[3]);
@@ -56,11 +58,11 @@ int main(int argc, char** argv)
 		cgogn_log_info("convert_mesh") << "compress output : " << compress_output;
 	}
 	auto export_options = cgogn::io::ExportOptions::create()
-			.filename(output_filename)
-			.binary(output_is_binary)
-			.compress(compress_output)
-			.overwrite(overwrite_output)
-			.position_attribute(is_surface? vertex2:vertex3, "position");
+		.filename(output_filename)
+		.binary(output_is_binary)
+		.compress(compress_output)
+		.overwrite(overwrite_output)
+		.position_attribute(is_surface? vertex2:vertex3, "position");
 	if (is_surface)
 	{
 		export_options.add_attribute(vertex2,"normal")
@@ -68,7 +70,9 @@ int main(int argc, char** argv)
 		Map2 map;
 		cgogn::io::import_surface<Vec3>(map, input_filename);
 		cgogn::io::export_surface(map, export_options);
-	} else {
+	}
+	else
+	{
 		Map3 map;
 		cgogn::io::import_volume<Vec3>(map, input_filename);
 		cgogn::io::export_volume(map, export_options);

--- a/cgogn/io/formats/cg.h
+++ b/cgogn/io/formats/cg.h
@@ -63,19 +63,40 @@ protected:
     virtual bool import_file_impl(const std::string& filename) override
     {
         std::ifstream fp(filename.c_str(), std::ios::in);
-		ChunkArray<VEC3>* position = this->template add_vertex_attribute<VEC3>("position");
 
         std::string line;
         line.reserve(512);
 
+		io::getline_safe(fp, line);
+		if (line.rfind("# D") == std::string::npos)
+		{
+				cgogn_log_error("CgGraphImport::import_file_impl") << "File \"" << filename << "\" is not a valid cg file.";
+				return false;
+		}
 
-		uint32 nb_vertices = 0, nb_edges = 0;
+		// read header
+		std::replace(line.begin(), line.end(), ':', ' ');
+		std::stringstream oss(line);
+		std::string tag;
+		uint32 value;
+		oss >> tag;
+		oss >> tag;
+		oss >> value; // dimension unused for now
+		oss >> tag;
+		oss >> value;
+		const uint32 nb_vertices = value;
+		oss >> tag;
+		oss >> value;
+		const uint32 nb_edges = value;
 
-        // lecture des sommets
+		this->reserve(nb_vertices);
+
+		ChunkArray<VEC3>* position = this->template add_vertex_attribute<VEC3>("position");
+
+		// read vertices
         std::vector<uint32> vertices_id;
-        vertices_id.reserve(102400);
-        VEC3 centroid;
-        centroid.setZero();
+		vertices_id.reserve(nb_vertices);
+
         for (uint32 i = 0; i < nb_vertices; ++i)
         {
             io::getline_safe(fp, line);
@@ -93,19 +114,14 @@ protected:
 
                 VEC3 pos{Scalar(x), Scalar(y), Scalar(z)};
 
-                centroid += pos;
-
                 uint32 vertex_id = this->vertex_attributes_.template insert_lines<1>();
                 (*position)[vertex_id] = pos;
 
                 vertices_id.push_back(vertex_id);
             }
-        }
+		}
 
-        centroid /= (Scalar)vertices_id.size();
-		//for(int vid=0; vid<(int)vertices_id.size(); ++vid)
-		//    (*position)[vid].coord -= centroid;
-
+		// read edges
         for (uint32 i = 0; i < nb_edges; ++i)
         {
             io::getline_safe(fp, line);
@@ -120,11 +136,9 @@ protected:
                 oss >> a;
                 oss >> b;
 
-                //TODO potentially a-1 and b-1
-
                 this->edges_nb_vertices_.push_back(2);
-                this->edges_vertex_indices_.push_back(a);
-                this->edges_vertex_indices_.push_back(b);
+				this->edges_vertex_indices_.push_back(a-1);
+				this->edges_vertex_indices_.push_back(b-1);
             }
         }
 
@@ -148,12 +162,24 @@ public:
 
 protected:
     virtual void export_file_impl(const Map& map, std::ofstream& output, const ExportOptions& ) override
-    {
-		uint32 count = 0;
+	{
+		// Header
+		output << "# D:3 NV:" << map.template nb_cells<Vertex::ORBIT>() << " NE:" << map.template nb_cells<Edge::ORBIT>() << std::endl;
+
+		// Vertices
 		map.foreach_cell([&] (Vertex v)
 		{
-			++count;
-		});
+			output << "v ";
+			this->position_attribute(Vertex::ORBIT)->export_element(map.embedding(v), output, false, false);
+			output << std::endl;
+		}, *(this->cell_cache_));
+
+		// Edges (index from 1)
+		map.foreach_cell([&] (Edge e)
+		{
+			std::pair<Vertex, Vertex> vs = map.vertices(e);
+			output << "e " << (this->vindices_[vs.first]+1u) << " " << (this->vindices_[vs.second]+1u) << std::endl;
+		}, *(this->cell_cache_));
     }
 };
 

--- a/cgogn/io/formats/cskel.h
+++ b/cgogn/io/formats/cskel.h
@@ -73,6 +73,8 @@ namespace io
 ///the eccentricity value and the indices of the vertices
 ///of the dual Delaunay triangle in the original triangle
 ///mesh.
+///
+/// \todo import/export of the edge properties
 template <typename VEC3>
 class CskelGraphImport : public GraphFileImport
 {
@@ -98,14 +100,6 @@ protected:
 
         std::string line;
         line.reserve(512);
-
-//        // read SKEL header
-//        io::getline_safe(fp, line);
-//        if (line.rfind("ID") == std::string::npos)
-//        {
-//                cgogn_log_error("SkelSkeletonImport::import_file_impl") << "File \"" << filename << "\" is not a valid off file.";
-//                return false;
-//        }
 
         // reading number of points and number of edges
         uint32 nb_vertices = 0u, nb_edges = 0u;
@@ -177,7 +171,28 @@ public:
 protected:
     virtual void export_file_impl(const Map& map, std::ofstream& output, const ExportOptions& ) override
     {
+		// Header
+		output << map.template nb_cells<Vertex::ORBIT>() << " " << map.template nb_cells<Edge::ORBIT>() << std::endl;
 
+		// Vertices
+		map.foreach_cell([&] (Vertex v)
+		{
+			this->position_attribute(Vertex::ORBIT)->export_element(map.embedding(v), output, false, false);
+			output << std::endl;
+		}, *(this->cell_cache_));
+
+
+		// Edges
+		map.foreach_cell([&] (Edge e)
+		{
+			std::pair<Vertex, Vertex> vs = map.vertices(e);
+			output << (this->vindices_[vs.first]) << " " << (this->vindices_[vs.second]) << std::endl;
+			output << "0" << std::endl;
+			output << "0" << std::endl;
+			output << "0" << std::endl;
+			output << "0" << std::endl;
+
+		}, *(this->cell_cache_));
     }
 };
 

--- a/cgogn/io/formats/obj.h
+++ b/cgogn/io/formats/obj.h
@@ -373,14 +373,6 @@ public:
 protected:
     virtual void export_file_impl(const Map& map, std::ofstream& output, const ExportOptions& ) override
     {
-        const ChunkArrayGen* radius_attribute(nullptr);
-
-        for(const ChunkArrayGen* vatt: this->vertex_attributes())
-		{
-            if(to_lower(vatt->name()) == "radius" || to_lower(vatt->name()) == "radii")
-                radius_attribute = vatt;
-		}
-
         // set precision for float output
         output << std::setprecision(12);
 

--- a/cgogn/io/formats/obj.h
+++ b/cgogn/io/formats/obj.h
@@ -102,38 +102,6 @@ protected:
 			getline_safe(fp, line);
 		} while (!fp.eof());
 
-		fp.clear();
-		fp.seekg(0, std::ios::beg);
-
-		do
-		{
-			fp >> tag;
-			getline_safe(fp, line);
-		} while (tag != std::string("vn") && (!fp.eof()));
-
-		if (tag == "vn")
-		{
-			uint32 counter{0u};
-			ChunkArray<VEC3>* normal = this->vertex_container().template add_chunk_array<VEC3>("normal");
-			do
-			{
-				if (tag == std::string("vn"))
-				{
-					std::stringstream oss(line);
-
-					float64 x, y, z;
-					oss >> x;
-					oss >> y;
-					oss >> z;
-
-					VEC3 norm{Scalar(x), Scalar(y), Scalar(z)};
-					(*normal)[vertices_id[counter++]] = norm;
-				}
-
-				fp >> tag;
-				getline_safe(fp, line);
-			} while (!fp.eof());
-		}
 
 		fp.clear();
 		fp.seekg(0, std::ios::beg);

--- a/cgogn/io/formats/obj.h
+++ b/cgogn/io/formats/obj.h
@@ -66,7 +66,6 @@ protected:
 		ChunkArray<VEC3>* position = this->template add_vertex_attribute<VEC3>("position");
 		ChunkArray<VEC3>* normal;
 		std::vector<VEC3> norm_buff;
-		std::vector<uint32> norm_nb;
 
 		std::string line, tag;
 		bool has_normals = false;
@@ -145,7 +144,6 @@ protected:
 		{
 			normal = this->template add_vertex_attribute<VEC3>("normal");
 			normal->set_all_values(VEC3(0,0,0));
-			norm_nb.assign(max_id,0);
 		}
 
 		fp.clear();
@@ -216,17 +214,8 @@ protected:
 					this->faces_vertex_indices_.push_back(vertices_id[index]);
 					if (has_normals)
 					{
-						// ensure copy with no operation if 1 normal (no precision pb)
-						if (norm_nb[vertices_id[index]] == 0)
-						{
-							(*normal)[vertices_id[index]] = norm_buff[tableN[j] - 1];
-							norm_nb[vertices_id[index]] = 1;
-						}
-						else
-						{
-							(*normal)[vertices_id[index]] += norm_buff[tableN[j] - 1];
-							norm_nb[vertices_id[index]]++;
-						}
+						auto k = vertices_id[index];
+						(*normal)[k] += norm_buff[tableN[j] - 1];
 					}
 				}
 			}
@@ -234,20 +223,12 @@ protected:
 			getline_safe(fp, line);
 		} while (!fp.eof());
 
-		// normalize only if more than one N in the sum
+		// normalize
 		if (has_normals)
 		{
-			bool has_normalized = false;
 			for(auto i: vertices_id)
-				if (norm_nb[i]>1)
-				{
-					(*normal)[i].normalize();
-					has_normalized = true;
-				}
-			if (has_normalized)
-				cgogn_log_warning("import obj") << " some vertices have more than one normal, normalized sums done ";
+				(*normal)[i].normalize();
 		}
-
 		return true;
 	}
 };

--- a/cgogn/io/formats/obj.h
+++ b/cgogn/io/formats/obj.h
@@ -90,7 +90,8 @@ protected:
 					oss >> x;
 					oss >> y;
 					oss >> z;
-					norm_buff.emplace_back(Scalar(x), Scalar(y), Scalar(z));
+					float64 n = std::sqrt(x*x+y*y+z*z);
+					norm_buff.emplace_back(Scalar(x/n), Scalar(y/n), Scalar(z/n));
 				}
 
 				fp >> tag;

--- a/cgogn/io/formats/skel.h
+++ b/cgogn/io/formats/skel.h
@@ -71,7 +71,7 @@ protected:
         io::getline_safe(fp, line);
         if (line.rfind("ID") == std::string::npos)
         {
-                cgogn_log_error("SkelSkeletonImport::import_file_impl") << "File \"" << filename << "\" is not a valid off file.";
+				cgogn_log_error("SkelGraphImport::import_file_impl") << "File \"" << filename << "\" is not a valid skel file.";
                 return false;
         }
 

--- a/cgogn/io/graph_import.cpp
+++ b/cgogn/io/graph_import.cpp
@@ -29,12 +29,33 @@ namespace cgogn
 namespace io
 {
 
-void GraphImport::clear()
+uint32 GraphImport::insert_line_vertex_container()
 {
-	edges_nb_vertices_.clear();
-	edges_vertex_indices_.clear();
-	vertex_attributes_.remove_chunk_arrays();
-	edge_attributes_.remove_chunk_arrays();
+	return vertex_attributes_.template insert_lines<1>();
+}
+
+void GraphImport::reserve(uint32 nb_edges)
+{
+	edges_nb_vertices_.reserve(nb_edges);
+	edges_vertex_indices_.reserve(nb_edges);
+}
+
+void GraphImport::add_edge(uint32 p0, uint32 p1)
+{
+	edges_nb_vertices_.push_back(2);
+	edges_vertex_indices_.push_back(p0);
+	edges_vertex_indices_.push_back(p1);
+}
+
+void GraphImport::add_edge_attribute(const DataInputGen& in_data, const std::string& att_name)
+{
+	ChunkArrayGen* att = in_data.add_attribute(edge_attributes_, att_name);
+	in_data.to_chunk_array(att);
+}
+
+uint32 GraphImport::nb_edges() const
+{
+	return uint32(edges_nb_vertices_.size());
 }
 
 } // namespace io

--- a/cgogn/io/graph_import.h
+++ b/cgogn/io/graph_import.h
@@ -26,6 +26,8 @@
 
 #include <cgogn/core/cmap/map_base_data.h>
 
+#include <cgogn/io/dll.h>
+
 #include <cgogn/io/mesh_io_gen.h>
 #include <cgogn/io/data_io.h>
 
@@ -35,7 +37,7 @@ namespace cgogn
 namespace io
 {
 
-class GraphImport
+class CGOGN_IO_API GraphImport
 {
 public:
 

--- a/cgogn/io/graph_import.h
+++ b/cgogn/io/graph_import.h
@@ -63,8 +63,6 @@ public:
 
 	CGOGN_NOT_COPYABLE_NOR_MOVABLE(GraphImport);
 
-	virtual void clear();
-
 	template <typename Map>
 	void create(Map& map)
 	{
@@ -124,95 +122,13 @@ public:
 				}
 			}
 		});
-
-		//PRIMALE VERSION
-		/*
-		if (nb_vertices() == 0u)
-			return;
-
-		MapBuilder mbuild(map);
-		map.clear_and_remove_attributes();
-
-		mbuild.template create_embedding<Vertex::ORBIT>();
-		mbuild.template create_embedding<CDart::ORBIT>();
-		mbuild.template swap_chunk_array_container<Vertex::ORBIT>(this->vertex_attributes_);
-
-		auto darts_per_vertex = map.template add_attribute<std::vector<Dart>, Vertex>("darts_per_vertex");
-		auto opposite_vertex = map.template add_attribute<uint32, CDart>("opposite_vertex");
-
-		uint32 edges_vertex_index = 0;
-		std::vector<uint32> edges_buffer;
-		edges_buffer.reserve(16);
-
-		for (uint32 i = 0, end = nb_edges(); i < end; ++i)
-		{
-			uint32 nbe = this->edges_nb_vertices_[i];
-
-			edges_buffer.clear();
-			for (uint32 j = 0u; j < nbe; ++j)
-			{
-				uint32 idx = this->edges_vertex_indices_[edges_vertex_index++];
-				edges_buffer.push_back(idx);
-			}
-
-			Dart d = mbuild.add_vertex_topo(nbe);
-			map.foreach_dart_of_orbit(Vertex(d), [&mbuild, &i, &darts_per_vertex] (Dart e)
-			{
-				mbuild.template new_orbit_embedding(CDart(e));
-				mbuild.template set_embedding<Vertex>(e, i);
-				darts_per_vertex[i].push_back(e);
-			});
-
-			for (uint32 j = 0u; j < nbe; ++j)
-			{
-				const uint32 vertex_index = edges_buffer[j];
-				opposite_vertex[d] = vertex_index;
-				d = map.alpha1(d);
-			}
-		}
-
-		typename Map::DartMarker treated(map);
-		map.foreach_dart([&] (Dart d)
-		{
-			if (!treated.is_marked(d))
-			{
-				uint32 emb = opposite_vertex[d];
-				std::vector<Dart>& per_vertex = darts_per_vertex[emb];
-				treated.mark(d);
-
-				for (auto it = per_vertex.begin();
-					 it != per_vertex.end();
-					 ++it)
-				{
-					if (opposite_vertex[CDart(*it)] == map.embedding(Vertex(d)))
-					{
-						mbuild.alpha0_sew(d, *it);
-						treated.mark(*it);
-					}
-				}
-			}
-		});
-
-		*/
 	}
 
-	inline uint32 insert_line_vertex_container()
-	{
-		return vertex_attributes_.template insert_lines<1>();
-	}
+	uint32 insert_line_vertex_container();
 
-	inline void reserve(uint32 nb_edges)
-	{
-		edges_nb_vertices_.reserve(nb_edges);
-		edges_vertex_indices_.reserve(nb_edges);
-	}
+	void reserve(uint32 nb_edges);
 
-	inline void add_edge(uint32 p0, uint32 p1)
-	{
-		edges_nb_vertices_.push_back(2);
-		edges_vertex_indices_.push_back(p0);
-		edges_vertex_indices_.push_back(p1);
-	}
+	void add_edge(uint32 p0, uint32 p1);
 
 	inline ChunkArrayGen* add_vertex_attribute(const DataInputGen& in_data, const std::string& att_name)
 	{
@@ -221,11 +137,7 @@ public:
 		return att;
 	}
 
-	inline void add_edge_attribute(const DataInputGen& in_data, const std::string& att_name)
-	{
-		ChunkArrayGen* att = in_data.add_attribute(edge_attributes_, att_name);
-		in_data.to_chunk_array(att);
-	}
+	void add_edge_attribute(const DataInputGen& in_data, const std::string& att_name);
 
 	template <typename T>
 	inline ChunkArray<T>* add_vertex_attribute(const std::string& att_name)
@@ -241,10 +153,7 @@ public:
 
 private:
 
-	inline uint32 nb_edges() const
-	{
-		return uint32(edges_nb_vertices_.size());
-	}
+	uint32 nb_edges() const;
 
 protected:
 

--- a/cgogn/io/graph_import.h
+++ b/cgogn/io/graph_import.h
@@ -88,7 +88,7 @@ public:
 
 		for (uint32 i = 0, end = nb_edges(); i < end; ++i)
 		{
-			uint nbe = this->edges_nb_vertices_[i];
+			uint32 nbe = this->edges_nb_vertices_[i];
 
 			edges_buffer.clear();
 			for (uint32 j = 0u; j < nbe; ++j)
@@ -146,7 +146,7 @@ public:
 
 		for (uint32 i = 0, end = nb_edges(); i < end; ++i)
 		{
-			uint nbe = this->edges_nb_vertices_[i];
+			uint32 nbe = this->edges_nb_vertices_[i];
 
 			edges_buffer.clear();
 			for (uint32 j = 0u; j < nbe; ++j)

--- a/cgogn/io/io_utils.cpp
+++ b/cgogn/io/io_utils.cpp
@@ -97,13 +97,17 @@ CGOGN_IO_API std::vector<unsigned char> zlib_decompress(const char* input, DataT
 			nb_blocks = *reinterpret_cast<const std::uint64_t*>(&header_data[0]);
 			uncompressed_block_size = *reinterpret_cast<const std::uint64_t*>(&header_data[8]);
 			last_block_size = *reinterpret_cast<const std::uint64_t*>(&header_data[16]);
-		} else {
+		}
+		else
+		{
 			nb_blocks = *reinterpret_cast<const uint32*>(&header_data[0]);
 			uncompressed_block_size = *reinterpret_cast<const uint32*>(&header_data[4]);
 			last_block_size = *reinterpret_cast<const uint32*>(&header_data[8]);
 		}
 		compressed_size.resize(nb_blocks);
-	} else {
+	}
+	else
+	{
 		cgogn_log_warning("zlib_decompress") << "Unable to decode the header.";
 		return std::vector<unsigned char>();
 	}
@@ -214,7 +218,6 @@ CGOGN_IO_API std::vector<char> base64_encode(const char* input_buffer, std::size
 	return res;
 }
 
-
 CGOGN_IO_API std::vector<unsigned char> base64_decode(const char* input, std::size_t length)
 {
 	const std::locale locale;
@@ -310,7 +313,7 @@ CGOGN_IO_API FileType file_type(const std::string& filename)
 	};
 
 	const auto it = file_type_map.find(ext);
-	if ( it != file_type_map.end())
+	if (it != file_type_map.end())
 		return it->second;
 	else
 		return FileType::FileType_UNKNOWN;
@@ -443,4 +446,3 @@ ExportOptions ExportOptions::create()
 } // namespace io
 
 } // namespace cgogn
-

--- a/cgogn/io/io_utils.cpp
+++ b/cgogn/io/io_utils.cpp
@@ -306,7 +306,12 @@ CGOGN_IO_API FileType file_type(const std::string& filename)
 		{"nas", FileType_NASTRAN},
 		{"bdf", FileType_NASTRAN},
 		{"tet", FileType_AIMATSHAPE},
-		{"tetmesh", FileType_TETMESH}
+		{"tetmesh", FileType_TETMESH},
+		{"skel", FileType::FileType_SKEL},
+		{"cg", FileType::FileType_CG},
+		{"cskel", FileType::FileType_CSKEL},
+		{"skc", FileType::FileType_CSKEL},
+		{"dot", FileType::FileType_DOT}
 	};
 
 	const auto it = file_type_map.find(ext);

--- a/cgogn/io/io_utils.h
+++ b/cgogn/io/io_utils.h
@@ -78,12 +78,12 @@ public:
 	ExportOptions(const ExportOptions& eo);
 	ExportOptions(ExportOptions&& eo);
 	inline ~ExportOptions() {}
-	inline ExportOptions& filename(const std::string & filename) { filename_ = filename; return *this; }
-	inline ExportOptions& position_attribute(Orbit orb, const std::string & name)
+	inline ExportOptions& filename(const std::string& filename) { filename_ = filename; return *this; }
+	inline ExportOptions& position_attribute(Orbit orb, const std::string& name)
 	{
 		position_attributes_.insert(std::make_pair(orb, name)); return *this;
 	}
-	inline ExportOptions& add_attribute(Orbit orb, const std::string & name) { attributes_to_export_.push_back(std::make_pair(orb,name)); return *this; }
+	inline ExportOptions& add_attribute(Orbit orb, const std::string& name) { attributes_to_export_.push_back(std::make_pair(orb, name)); return *this; }
 	inline ExportOptions& binary(bool b) { binary_ = b; return *this; }
 	inline ExportOptions& compress(bool b) { compress_ = b; return *this; }
 	inline ExportOptions& overwrite(bool b) { overwrite_ = b; return *this; }

--- a/cgogn/io/io_utils.h
+++ b/cgogn/io/io_utils.h
@@ -105,6 +105,9 @@ public:
 enum FileType
 {
 	FileType_UNKNOWN = 0,
+	FileType_CG,
+	FileType_CSKEL,
+	FileType_DOT,
 	FileType_OFF,
 	FileType_OBJ,
 	FileType_2DM,
@@ -115,6 +118,7 @@ enum FileType
 	FileType_VTP,
 	FileType_MESHB,
 	FileType_MSH,
+	FileType_SKEL,
 	FileType_TETGEN,
 	FileType_NASTRAN,
 	FileType_AIMATSHAPE,

--- a/cgogn/io/io_utils.h
+++ b/cgogn/io/io_utils.h
@@ -41,7 +41,7 @@ namespace cgogn
 template <typename T>
 inline std::ostream& operator<<(std::ostream& o, const Attribute_T<T>& att)
 {
-	for(auto it = att.begin(), end = att.end() ; it != end;)
+	for (auto it = att.begin(), end = att.end() ; it != end;)
 	{
 		o << (*it);
 		++it;
@@ -67,7 +67,6 @@ inline std::istream& operator>>(std::istream& in, Attribute_T<T>& att)
 namespace io
 {
 
-
 class CGOGN_IO_API ExportOptions final
 {
 private:
@@ -80,8 +79,10 @@ public:
 	ExportOptions(ExportOptions&& eo);
 	inline ~ExportOptions() {}
 	inline ExportOptions& filename(const std::string & filename) { filename_ = filename; return *this; }
-	inline ExportOptions& position_attribute(Orbit orb, const std::string & name) {
-		position_attributes_.insert(std::make_pair(orb, name)); return *this;}
+	inline ExportOptions& position_attribute(Orbit orb, const std::string & name)
+	{
+		position_attributes_.insert(std::make_pair(orb, name)); return *this;
+	}
 	inline ExportOptions& add_attribute(Orbit orb, const std::string & name) { attributes_to_export_.push_back(std::make_pair(orb,name)); return *this; }
 	inline ExportOptions& binary(bool b) { binary_ = b; return *this; }
 	inline ExportOptions& compress(bool b) { compress_ = b; return *this; }
@@ -157,7 +158,7 @@ CGOGN_IO_API DataType                       data_type(const std::string& type_na
  * @param buffer_size, the number of bytes we want to encode ( with buffer_size <= strlen(input_buffer) )
  * @return a vector containing the encoded data.
  */
-CGOGN_IO_API std::vector<char>          base64_encode(const char* input_buffer, std::size_t buffer_size);
+CGOGN_IO_API std::vector<char> base64_encode(const char* input_buffer, std::size_t buffer_size);
 
 /**
  * @brief base64_decode
@@ -174,7 +175,7 @@ CGOGN_IO_API std::vector<unsigned char> base64_decode(const char* const input, s
  * @param length, the length of the data we want to decompress.
  * @return  the decompressed data if successful, otherwise an empty vector.
  */
-CGOGN_IO_API std::vector<unsigned char>              zlib_decompress(const char* input, DataType header_type, std::size_t length);
+CGOGN_IO_API std::vector<unsigned char> zlib_decompress(const char* input, DataType header_type, std::size_t length);
 
 /**
  * @brief zlib_compress
@@ -190,7 +191,7 @@ namespace internal
 
 // #1 return default value when U and T don't have the same nb of components.
 template <typename U, typename T>
-inline auto convert(const T&) -> typename std::enable_if<!std::is_same< std::integral_constant<uint32, geometry::nb_components_traits<T>::value>, std::integral_constant<uint32, geometry::nb_components_traits<U>::value>>::value,U>::type
+inline auto convert(const T&) -> typename std::enable_if<!std::is_same< std::integral_constant<uint32, geometry::vector_traits<T>::SIZE>, std::integral_constant<uint32, geometry::vector_traits<U>::SIZE>>::value,U>::type
 {
 	cgogn_log_warning("convert") << "Cannot convert data of type\"" << name_of_type(T()) << "\" to type \"" << name_of_type(U()) << "\".";
 	return U();
@@ -205,10 +206,10 @@ inline auto convert(const T&x) -> typename std::enable_if<std::is_arithmetic<T>:
 
 // #3 copy component by component if both type have the same number of components (>1)
 template <typename U, typename T>
-inline auto convert(const T& x) -> typename std::enable_if<!std::is_arithmetic<T>::value && std::is_same< std::integral_constant<uint32, geometry::nb_components_traits<T>::value>, std::integral_constant<uint32, geometry::nb_components_traits<U>::value>>::value, U>::type
+inline auto convert(const T& x) -> typename std::enable_if<!std::is_arithmetic<T>::value && std::is_same< std::integral_constant<uint32, geometry::vector_traits<T>::SIZE>, std::integral_constant<uint32, geometry::vector_traits<U>::SIZE>>::value, U>::type
 {
 	U res;
-	for(uint32 i = 0u; i < geometry::nb_components_traits<T>::value ; ++i)
+	for (uint32 i = 0u; i < geometry::vector_traits<T>::SIZE ; ++i)
 		res[i] = typename geometry::vector_traits<U>::Scalar(x[i]);
 	return res;
 }

--- a/cgogn/io/map_export.cpp
+++ b/cgogn/io/map_export.cpp
@@ -33,6 +33,7 @@ namespace io
 
 template CGOGN_IO_API void export_surface(CMap2& , const ExportOptions&);
 template CGOGN_IO_API void export_volume(CMap3& , const ExportOptions&);
+template CGOGN_IO_API void export_graph(UndirectedGraph& , const ExportOptions&);
 
 } // namespace io
 

--- a/cgogn/io/map_export.cpp
+++ b/cgogn/io/map_export.cpp
@@ -31,9 +31,9 @@ namespace cgogn
 namespace io
 {
 
+template CGOGN_IO_API void export_graph(UndirectedGraph& , const ExportOptions&);
 template CGOGN_IO_API void export_surface(CMap2& , const ExportOptions&);
 template CGOGN_IO_API void export_volume(CMap3& , const ExportOptions&);
-template CGOGN_IO_API void export_graph(UndirectedGraph& , const ExportOptions&);
 
 } // namespace io
 

--- a/cgogn/io/map_export.h
+++ b/cgogn/io/map_export.h
@@ -53,12 +53,6 @@ template <typename MAP>
 inline std::unique_ptr<VolumeExport<MAP>> new_volume_export(const std::string& filename);
 
 template <class MAP>
-inline void export_surface(MAP& map2, const ExportOptions& options);
-
-template <class MAP>
-inline void export_volume(MAP& map3, const ExportOptions& options);
-
-template <class MAP>
 inline void export_surface(MAP& map2, const ExportOptions& options)
 {
 	static_assert(MAP::DIMENSION == 2, "export_surface is designed for 2D maps.");

--- a/cgogn/io/map_export.h
+++ b/cgogn/io/map_export.h
@@ -35,6 +35,9 @@
 #include <cgogn/io/formats/obj.h>
 #include <cgogn/io/formats/stl.h>
 #include <cgogn/io/formats/ply.h>
+#include <cgogn/io/formats/cg.h>
+#include <cgogn/io/formats/cskel.h>
+#include <cgogn/io/formats/skel.h>
 #include <cgogn/io/formats/tet.h>
 #include <cgogn/io/formats/msh.h>
 #include <cgogn/io/formats/nastran.h>
@@ -45,36 +48,6 @@ namespace cgogn
 
 namespace io
 {
-
-template <typename MAP>
-inline std::unique_ptr<SurfaceExport<MAP>> new_surface_export(const std::string& filename);
-
-template <typename MAP>
-inline std::unique_ptr<VolumeExport<MAP>> new_volume_export(const std::string& filename);
-
-template <class MAP>
-inline void export_surface(MAP& map2, const ExportOptions& options);
-
-template <class MAP>
-inline void export_volume(MAP& map3, const ExportOptions& options);
-
-template <class MAP>
-inline void export_surface(MAP& map2, const ExportOptions& options)
-{
-	static_assert(MAP::DIMENSION == 2, "export_surface is designed for 2D maps.");
-	auto se = new_surface_export<MAP>(options.filename_);
-	if (se)
-		se->export_file(map2,options);
-}
-
-template <class MAP>
-inline void export_volume(MAP& map3, const ExportOptions& options)
-{
-	static_assert(MAP::DIMENSION == 3, "export_volume is designed for 3D maps.");
-	auto ve = new_volume_export<MAP>(options.filename_);
-	if (ve)
-		ve->export_file(map3,options);
-}
 
 template <typename MAP>
 inline std::unique_ptr<SurfaceExport<MAP>> new_surface_export(const std::string& filename)
@@ -113,9 +86,52 @@ inline std::unique_ptr<VolumeExport<MAP>> new_volume_export(const std::string& f
 	}
 }
 
+template <typename MAP>
+inline std::unique_ptr<GraphExport<MAP>> new_graph_export(const std::string& filename)
+{
+	const FileType ft = file_type(filename);
+	switch(ft) {
+		case FileType::FileType_SKEL:		return make_unique<SkelGraphExport<MAP>>();
+		case FileType::FileType_VTK_LEGACY:	return make_unique<VtkGraphExport<MAP>>();
+		case FileType::FileType_CG:			return make_unique<CgGraphExport<MAP>>();
+		case FileType::FileType_CSKEL:		return make_unique<CskelGraphExport<MAP>>();
+		case FileType::FileType_OBJ:		return make_unique<ObjGraphExport<MAP>>();
+		default:
+			cgogn_log_warning("new_graph_export") << "GraphExport does not handle files with extension \"" << extension(filename) << "\".";
+			return std::unique_ptr<GraphExport<MAP>>();
+	}
+}
+
+template <class MAP>
+inline void export_surface(MAP& map2, const ExportOptions& options)
+{
+	static_assert(MAP::DIMENSION == 2, "export_surface is designed for 2D maps.");
+	auto se = new_surface_export<MAP>(options.filename_);
+	if (se)
+		se->export_file(map2, options);
+}
+
+template <class MAP>
+inline void export_volume(MAP& map3, const ExportOptions& options)
+{
+	static_assert(MAP::DIMENSION == 3, "export_volume is designed for 3D maps.");
+	auto ve = new_volume_export<MAP>(options.filename_);
+	if (ve)
+		ve->export_file(map3, options);
+}
+
+template <typename MAP>
+inline void export_graph(MAP& map, const ExportOptions& options)
+{
+	auto se = new_graph_export<MAP>(options.filename_);
+	if (se)
+		se->export_file(map, options);
+}
+
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_MAP_EXPORT_CPP_))
 extern template CGOGN_IO_API void export_surface(CMap2& , const ExportOptions&);
 extern template CGOGN_IO_API void export_volume(CMap3& , const ExportOptions&);
+extern template CGOGN_IO_API void export_graph(UndirectedGraph& , const ExportOptions&);
 #endif // defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_MAP_EXPORT_CPP_))
 
 } // namespace io

--- a/cgogn/io/map_export.h
+++ b/cgogn/io/map_export.h
@@ -50,6 +50,22 @@ namespace io
 {
 
 template <typename MAP>
+inline std::unique_ptr<GraphExport<MAP>> new_graph_export(const std::string& filename)
+{
+	const FileType ft = file_type(filename);
+	switch(ft) {
+		case FileType::FileType_SKEL:		return make_unique<SkelGraphExport<MAP>>();
+		case FileType::FileType_VTK_LEGACY:	return make_unique<VtkGraphExport<MAP>>();
+		case FileType::FileType_CG:			return make_unique<CgGraphExport<MAP>>();
+		case FileType::FileType_CSKEL:		return make_unique<CskelGraphExport<MAP>>();
+		case FileType::FileType_OBJ:		return make_unique<ObjGraphExport<MAP>>();
+		default:
+			cgogn_log_warning("new_graph_export") << "GraphExport does not handle files with extension \"" << extension(filename) << "\".";
+			return std::unique_ptr<GraphExport<MAP>>();
+	}
+}
+
+template <typename MAP>
 inline std::unique_ptr<SurfaceExport<MAP>> new_surface_export(const std::string& filename)
 {
 	const FileType ft = file_type(filename);
@@ -87,19 +103,11 @@ inline std::unique_ptr<VolumeExport<MAP>> new_volume_export(const std::string& f
 }
 
 template <typename MAP>
-inline std::unique_ptr<GraphExport<MAP>> new_graph_export(const std::string& filename)
+inline void export_graph(MAP& map, const ExportOptions& options)
 {
-	const FileType ft = file_type(filename);
-	switch(ft) {
-		case FileType::FileType_SKEL:		return make_unique<SkelGraphExport<MAP>>();
-		case FileType::FileType_VTK_LEGACY:	return make_unique<VtkGraphExport<MAP>>();
-		case FileType::FileType_CG:			return make_unique<CgGraphExport<MAP>>();
-		case FileType::FileType_CSKEL:		return make_unique<CskelGraphExport<MAP>>();
-		case FileType::FileType_OBJ:		return make_unique<ObjGraphExport<MAP>>();
-		default:
-			cgogn_log_warning("new_graph_export") << "GraphExport does not handle files with extension \"" << extension(filename) << "\".";
-			return std::unique_ptr<GraphExport<MAP>>();
-	}
+	auto se = new_graph_export<MAP>(options.filename_);
+	if (se)
+		se->export_file(map, options);
 }
 
 template <class MAP>
@@ -120,18 +128,10 @@ inline void export_volume(MAP& map3, const ExportOptions& options)
 		ve->export_file(map3, options);
 }
 
-template <typename MAP>
-inline void export_graph(MAP& map, const ExportOptions& options)
-{
-	auto se = new_graph_export<MAP>(options.filename_);
-	if (se)
-		se->export_file(map, options);
-}
-
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_MAP_EXPORT_CPP_))
+extern template CGOGN_IO_API void export_graph(UndirectedGraph& , const ExportOptions&);
 extern template CGOGN_IO_API void export_surface(CMap2& , const ExportOptions&);
 extern template CGOGN_IO_API void export_volume(CMap3& , const ExportOptions&);
-extern template CGOGN_IO_API void export_graph(UndirectedGraph& , const ExportOptions&);
 #endif // defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_MAP_EXPORT_CPP_))
 
 } // namespace io

--- a/cgogn/io/map_import.cpp
+++ b/cgogn/io/map_import.cpp
@@ -30,13 +30,12 @@ namespace cgogn
 
 namespace io
 {
-
+template CGOGN_IO_API void import_graph<Eigen::Vector3f>(UndirectedGraph&, const std::string&);
+template CGOGN_IO_API void import_graph<Eigen::Vector3d>(UndirectedGraph&, const std::string&);
 template CGOGN_IO_API void import_surface<Eigen::Vector3f>(CMap2&, const std::string&);
 template CGOGN_IO_API void import_surface<Eigen::Vector3d>(CMap2&, const std::string&);
 template CGOGN_IO_API void import_volume<Eigen::Vector3f>(CMap3&, const std::string&);
 template CGOGN_IO_API void import_volume<Eigen::Vector3d>(CMap3&, const std::string&);
-template CGOGN_IO_API void import_graph<Eigen::Vector3f>(UndirectedGraph&, const std::string&);
-template CGOGN_IO_API void import_graph<Eigen::Vector3d>(UndirectedGraph&, const std::string&);
 } // namespace io
 
 } // namespace cgogn

--- a/cgogn/io/map_import.cpp
+++ b/cgogn/io/map_import.cpp
@@ -35,7 +35,8 @@ template CGOGN_IO_API void import_surface<Eigen::Vector3f>(CMap2&, const std::st
 template CGOGN_IO_API void import_surface<Eigen::Vector3d>(CMap2&, const std::string&);
 template CGOGN_IO_API void import_volume<Eigen::Vector3f>(CMap3&, const std::string&);
 template CGOGN_IO_API void import_volume<Eigen::Vector3d>(CMap3&, const std::string&);
-
+template CGOGN_IO_API void import_graph<Eigen::Vector3f>(UndirectedGraph&, const std::string&);
+template CGOGN_IO_API void import_graph<Eigen::Vector3d>(UndirectedGraph&, const std::string&);
 } // namespace io
 
 } // namespace cgogn

--- a/cgogn/io/map_import.h
+++ b/cgogn/io/map_import.h
@@ -30,10 +30,15 @@
 #include <cgogn/core/utils/logger.h>
 #include <cgogn/core/cmap/cmap2.h>
 #include <cgogn/core/cmap/cmap3.h>
+#include <cgogn/core/graph/undirected_graph.h>
 
 #include <cgogn/io/surface_import.h>
 #include <cgogn/io/volume_import.h>
-#include <cgogn/io/formats/vtk.h>
+#include <cgogn/io/graph_import.h>
+
+#include <cgogn/io/formats/cg.h>
+#include <cgogn/io/formats/cskel.h>
+#include <cgogn/io/formats/dot.h>
 #include <cgogn/io/formats/off.h>
 #include <cgogn/io/formats/obj.h>
 #include <cgogn/io/formats/2dm.h>
@@ -43,8 +48,10 @@
 #include <cgogn/io/formats/tetgen.h>
 #include <cgogn/io/formats/nastran.h>
 #include <cgogn/io/formats/tet.h>
+#include <cgogn/io/formats/skel.h>
 #include <cgogn/io/formats/stl.h>
 #include <cgogn/io/formats/tetmesh.h>
+#include <cgogn/io/formats/vtk.h>
 
 namespace cgogn
 {
@@ -94,6 +101,23 @@ inline std::unique_ptr<VolumeFileImport<MAP>> newVolumeImport(MAP& map, const st
 	}
 }
 
+template <typename VEC3>
+inline std::unique_ptr<GraphFileImport> newGraphImport(const std::string& filename)
+{
+	const FileType ft = file_type(filename);
+	switch (ft) {
+		case FileType::FileType_SKEL:		return make_unique<SkelGraphImport<VEC3>>();
+		case FileType::FileType_VTK_LEGACY:	return make_unique<VtkGraphImport<VEC3>>();
+		case FileType::FileType_CG:			return make_unique<CgGraphImport<VEC3>>();
+		case FileType::FileType_CSKEL:		return make_unique<CskelGraphImport<VEC3>>();
+		case FileType::FileType_DOT:		return make_unique<DotGraphImport<VEC3>>();
+		case FileType::FileType_OBJ:		return make_unique<ObjGraphImport<VEC3>>();
+		default:
+			cgogn_log_warning("GraphImport") << "GraphImport does not handle files with extension \"" << extension(filename) << "\".";
+			return std::unique_ptr<GraphFileImport> ();
+	}
+}
+
 template <typename VEC3, typename MAP>
 inline void import_surface(MAP& map, const std::string& filename)
 {
@@ -116,11 +140,26 @@ inline void import_volume(MAP& map, const std::string& filename)
 	}
 }
 
+template <typename VEC3, typename MAP>
+inline void import_graph(MAP& map, const std::string& filename)
+{
+	auto si = newGraphImport<VEC3>(filename);
+
+	if(si)
+	{
+		if(si->import_file(filename))
+			si->create(map);
+	}
+}
+
+
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_MAP_IMPORT_CPP_))
 extern template CGOGN_IO_API void import_surface<Eigen::Vector3f>(CMap2&, const std::string&);
 extern template CGOGN_IO_API void import_surface<Eigen::Vector3d>(CMap2&, const std::string&);
 extern template CGOGN_IO_API void import_volume<Eigen::Vector3f>(CMap3&, const std::string&);
 extern template CGOGN_IO_API void import_volume<Eigen::Vector3d>(CMap3&, const std::string&);
+extern template CGOGN_IO_API void import_graph<Eigen::Vector3f>(UndirectedGraph&, const std::string&);
+extern template CGOGN_IO_API void import_graph<Eigen::Vector3d>(UndirectedGraph&, const std::string&);
 #endif // defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_IO_MAP_IMPORT_CPP_))
 
 } // namespace io

--- a/cgogn/io/map_import.h
+++ b/cgogn/io/map_import.h
@@ -60,7 +60,7 @@ namespace io
 {
 
 template <typename VEC3, typename MAP>
-inline std::unique_ptr<SurfaceFileImport<MAP>> newSurfaceImport(MAP& map, const std::string& filename)
+inline std::unique_ptr<SurfaceFileImport<MAP>> new_surface_import(MAP& map, const std::string& filename)
 {
 	const FileType ft = file_type(filename);
 	switch (ft)
@@ -76,13 +76,13 @@ inline std::unique_ptr<SurfaceFileImport<MAP>> newSurfaceImport(MAP& map, const 
 		case FileType::FileType_MSH: return make_unique<MshSurfaceImport<MAP, VEC3>>(map);
 		case FileType::FileType_MESHB: return make_unique<LM6SurfaceImport<MAP, VEC3>>(map);
 		default:
-			cgogn_log_warning("newSurfaceImport") << "SurfaceImport does not handle files with extension \"" << extension(filename) << "\".";
+			cgogn_log_warning("SurfaceImport") << "SurfaceImport does not handle files with extension \"" << extension(filename) << "\".";
 			return std::unique_ptr<SurfaceFileImport<MAP>>();
 	}
 }
 
 template <typename VEC3, typename MAP>
-inline std::unique_ptr<VolumeFileImport<MAP>> newVolumeImport(MAP& map, const std::string& filename)
+inline std::unique_ptr<VolumeFileImport<MAP>> new_volume_import(MAP& map, const std::string& filename)
 {
 	const FileType ft = file_type(filename);
 	switch (ft)
@@ -102,10 +102,11 @@ inline std::unique_ptr<VolumeFileImport<MAP>> newVolumeImport(MAP& map, const st
 }
 
 template <typename VEC3>
-inline std::unique_ptr<GraphFileImport> newGraphImport(const std::string& filename)
+inline std::unique_ptr<GraphFileImport> new_graph_import(const std::string& filename)
 {
 	const FileType ft = file_type(filename);
-	switch (ft) {
+	switch (ft)
+	{
 		case FileType::FileType_SKEL:		return make_unique<SkelGraphImport<VEC3>>();
 		case FileType::FileType_VTK_LEGACY:	return make_unique<VtkGraphImport<VEC3>>();
 		case FileType::FileType_CG:			return make_unique<CgGraphImport<VEC3>>();
@@ -121,35 +122,29 @@ inline std::unique_ptr<GraphFileImport> newGraphImport(const std::string& filena
 template <typename VEC3, typename MAP>
 inline void import_surface(MAP& map, const std::string& filename)
 {
-	auto si = newSurfaceImport<VEC3>(map, filename);
+	auto si = new_surface_import<VEC3>(map, filename);
 	if (si)
-	{
 		if (si->import_file(filename))
 			si->create_map();
-	}
 }
 
 template <typename VEC3, typename MAP>
 inline void import_volume(MAP& map, const std::string& filename)
 {
-	auto si = newVolumeImport<VEC3>(map, filename);
+	auto si = new_volume_import<VEC3>(map, filename);
 	if (si)
-	{
 		if (si->import_file(filename))
 			si->create_map();
-	}
 }
 
 template <typename VEC3, typename MAP>
 inline void import_graph(MAP& map, const std::string& filename)
 {
-	auto si = newGraphImport<VEC3>(filename);
+	auto si = new_graph_import<VEC3>(filename);
 
 	if(si)
-	{
 		if(si->import_file(filename))
 			si->create(map);
-	}
 }
 
 

--- a/cgogn/io/tests/obj_import_test.cpp
+++ b/cgogn/io/tests/obj_import_test.cpp
@@ -61,12 +61,10 @@ TEST(ImportTest, obj_normal_surface_import)
 	const std::string expected_empty_error_output = testing::internal::GetCapturedStderr();
 
 	auto pos = map2.get_attribute<Vec3, Map2::Vertex>("position");
-	auto normal = map2.get_attribute<Vec3, Map2::Vertex>("normal");
 	const uint32 nbv = map2.nb_cells<Map2::Vertex::ORBIT>();
 	const uint32 nbf = map2.nb_cells<Map2::Face::ORBIT>();
 
 	EXPECT_TRUE(pos.is_valid());
-	EXPECT_TRUE(normal.is_valid());
 	EXPECT_TRUE(map2.check_map_integrity());
 	EXPECT_EQ(nbv, 706u);
 	EXPECT_EQ(nbf, 1408u);

--- a/cgogn/modeling/CMakeLists.txt
+++ b/cgogn/modeling/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(HEADER_ALGOS
 	algos/catmull_clark.h
 	algos/curves.h
+        algos/doo_sabin.h
 	algos/loop.h
 	algos/refinements.h
 	algos/pliant_remeshing.h
@@ -34,6 +35,7 @@ set(HEADER_FILES dll.h ${HEADER_ALGOS} ${HEADER_TILING} ${HEADER_DECIMATION})
 
 set(SOURCE_ALGOS
 	algos/catmull_clark.cpp
+        algos/doo_sabin.cpp
 	algos/loop.cpp
 	algos/refinements.cpp
 	algos/pliant_remeshing.cpp

--- a/cgogn/modeling/algos/doo_sabin.cpp
+++ b/cgogn/modeling/algos/doo_sabin.cpp
@@ -1,0 +1,39 @@
+/*******************************************************************************
+* CGoGN: Combinatorial and Geometric modeling with Generic N-dimensional Maps  *
+* Copyright (C) 2015, IGG Group, ICube, University of Strasbourg, France       *
+*                                                                              *
+* This library is free software; you can redistribute it and/or modify it      *
+* under the terms of the GNU Lesser General Public License as published by the *
+* Free Software Foundation; either version 2.1 of the License, or (at your     *
+* option) any later version.                                                   *
+*                                                                              *
+* This library is distributed in the hope that it will be useful, but WITHOUT  *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *
+* for more details.                                                            *
+*                                                                              *
+* You should have received a copy of the GNU Lesser General Public License     *
+* along with this library; if not, write to the Free Software Foundation,      *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.           *
+*                                                                              *
+* Web site: http://cgogn.unistra.fr/                                           *
+* Contact information: cgogn@unistra.fr                                        *
+*                                                                              *
+*******************************************************************************/
+
+#define CGOGN_MODELING_ALGOS_DOO_SABIN_CPP_
+
+#include <cgogn/modeling/algos/doo_sabin.h>
+
+namespace cgogn
+{
+
+namespace modeling
+{
+
+template CGOGN_MODELING_API void doo_sabin<Eigen::Vector3f, CMap2>(CMap2&, CMap2::VertexAttribute<Eigen::Vector3f>&);
+template CGOGN_MODELING_API void doo_sabin<Eigen::Vector3d, CMap2>(CMap2&, CMap2::VertexAttribute<Eigen::Vector3d>&);
+
+} // namespace modeling
+
+} // namespace cgogn

--- a/cgogn/modeling/algos/doo_sabin.h
+++ b/cgogn/modeling/algos/doo_sabin.h
@@ -38,7 +38,6 @@ namespace cgogn
 namespace modeling
 {
 
-///
 /// \brief Subdivides a surface mesh with the Doo Sabin algorithm
 /// \param[in, out] map the surface to be subdivded
 /// \param[in, out] position the geometric position of the surface
@@ -51,13 +50,14 @@ void doo_sabin(MAP& map, typename MAP::template VertexAttribute<VEC3>& position)
 	using Edge = typename MAP::Edge;
 	using Face = typename MAP::Face;
 	using Builder = typename MAP::Builder;
+	using CellCache = typename MAP::CellCache;
 
 	// storage of boundary of hole (missing vertex faces)
 	std::vector<Dart>* fp = cgogn::dart_buffers()->buffer();
 
 	Builder mbuild(map);
 
-	CellCache<MAP> initial_cache(map);
+	CellCache initial_cache(map);
 	initial_cache.template build<Edge>();
 	initial_cache.template build<Face>();
 

--- a/cgogn/modeling/algos/doo_sabin.h
+++ b/cgogn/modeling/algos/doo_sabin.h
@@ -1,0 +1,173 @@
+/*******************************************************************************
+* CGoGN: Combinatorial and Geometric modeling with Generic N-dimensional Maps  *
+* Copyright (C) 2015, IGG Group, ICube, University of Strasbourg, France       *
+*                                                                              *
+* This library is free software; you can redistribute it and/or modify it      *
+* under the terms of the GNU Lesser General Public License as published by the *
+* Free Software Foundation; either version 2.1 of the License, or (at your     *
+* option) any later version.                                                   *
+*                                                                              *
+* This library is distributed in the hope that it will be useful, but WITHOUT  *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or        *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License  *
+* for more details.                                                            *
+*                                                                              *
+* You should have received a copy of the GNU Lesser General Public License     *
+* along with this library; if not, write to the Free Software Foundation,      *
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA.           *
+*                                                                              *
+* Web site: http://cgogn.unistra.fr/                                           *
+* Contact information: cgogn@unistra.fr                                        *
+*                                                                              *
+*******************************************************************************/
+
+#ifndef CGOGN_MODELING_ALGOS_DOO_SABIN_H_
+#define CGOGN_MODELING_ALGOS_DOO_SABIN_H_
+
+#include <vector>
+
+#include <cgogn/modeling/dll.h>
+#include <cgogn/core/basic/dart_marker.h>
+#include <cgogn/core/utils/masks.h>
+#include <cgogn/core/cmap/cmap3.h>
+#include <cgogn/geometry/types/geometry_traits.h>
+
+namespace cgogn
+{
+
+namespace modeling
+{
+
+///
+/// \brief Subdivides a surface mesh with the Doo Sabin algorithm
+/// \param[in, out] map the surface to be subdivded
+/// \param[in, out] position the geometric position of the surface
+/// \todo handle objects with open boundaries
+template <typename VEC3, typename MAP>
+void doo_sabin(MAP& map, typename MAP::template VertexAttribute<VEC3>& position)
+{
+	using Scalar = typename VEC3::Scalar;
+	using Vertex = typename MAP::Vertex;
+	using Edge = typename MAP::Edge;
+	using Face = typename MAP::Face;
+	using Builder = typename MAP::Builder;
+
+	// storage of boundary of hole (missing vertex faces)
+	std::vector<Dart>* fp = cgogn::dart_buffers()->buffer();
+
+	Builder mbuild(map);
+
+	CellCache<MAP> initial_cache(map);
+	initial_cache.template build<Edge>();
+	initial_cache.template build<Face>();
+
+	// create the edge faces
+	map.foreach_cell([&] (Edge e)
+	{
+		Dart e2 = map.phi2(e.dart);
+		mbuild.phi2_unsew(e.dart);
+		Dart nf = mbuild.add_face_topo_fp(4);
+		mbuild.phi2_sew(e.dart, nf);
+		mbuild.phi2_sew(e2, map.phi1(map.phi1(nf)));
+
+		///todo take care of the edge embedding
+		fp->push_back(map.phi1(nf));
+		fp->push_back(map.phi_1(nf));
+		if(map.template is_embedded<Edge>())
+		{
+			mbuild.template set_orbit_embedding<Edge>(Edge(e), map.embedding(Edge(e)));
+			mbuild.new_orbit_embedding(Edge(e2));
+		}
+
+		if(map.template is_embedded<Face>())
+			mbuild.new_orbit_embedding(Face(nf));
+	}
+	, initial_cache);
+
+	// create the new vertex faces (by filling the holes)
+	for(uint32 i = 0; i < fp->size(); ++i)
+	{
+		const Dart e = (*fp)[i];
+
+		if (map.phi2(e) == e)
+		{
+			Dart h = mbuild.close_hole_topo(e);
+			if(map.codegree(Face(h)) == 2)
+			{
+				//handle degree 2 vertices that turns
+				//into edges (degenerated two sided faces)
+				Dart h2 = map.phi2(h);
+				Dart h12 = map.phi2(map.phi1(h));
+				mbuild.phi2_unsew(h2);
+				mbuild.phi2_unsew(h12);
+				mbuild.remove_face_topo_fp(h);
+				mbuild.phi2_sew(h2, h12);
+
+				if(map.template is_embedded<Edge>())
+					mbuild.new_orbit_embedding(Edge(h2));
+			}
+			else
+			{
+				if(map.template is_embedded<Edge>())
+				{
+					map.foreach_incident_edge(Face(h), [&](Edge e)
+					{
+						mbuild.new_orbit_embedding(e);
+					});
+				}
+
+				if(map.template is_embedded<Face>())
+					mbuild.new_orbit_embedding(Face(h));
+			}
+		}
+	}
+	cgogn::dart_buffers()->release_buffer(fp);
+
+	std::vector<VEC3> buffer;
+	buffer.reserve(8);
+	map.foreach_cell([&] (Face f) {
+		Dart e = f.dart;
+
+		do
+		{
+			buffer.push_back(position[Vertex(e)]);
+			e = map.phi1(e);
+		}while (e != f.dart);
+
+		int N = buffer.size();
+		for (int i = 0; i < N; ++i)
+		{
+			VEC3 P;
+			P.setZero();
+			for (int j = 0; j < N; ++j)
+			{
+				if (j==i)
+				{
+					Scalar c1 = Scalar(N+5)/Scalar(4*N);
+					P += buffer[j]*c1;
+				}
+				else
+				{
+					Scalar c2 = (3.0+2.0*std::cos(2.0*M_PI*(Scalar(i-j))/Scalar(N))) /(4.0*N);
+					P += c2*buffer[j];
+				}
+			}
+			mbuild.new_orbit_embedding(Vertex(e));
+			position[Vertex(e)] = P;
+			e = map.phi1(e);
+		}
+		buffer.clear();
+	},
+	initial_cache);
+}
+
+#if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_MODELING_ALGOS_DOO_SABIN_CPP_))
+extern template CGOGN_MODELING_API void doo_sabin<Eigen::Vector3f, CMap2>(CMap2&, CMap2::VertexAttribute<Eigen::Vector3f>&);
+extern template CGOGN_MODELING_API void doo_sabin<Eigen::Vector3d, CMap2>(CMap2&, CMap2::VertexAttribute<Eigen::Vector3d>&);
+#endif // defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_MODELING_ALGOS_DOO_SABIN_CPP_))
+
+} // namespace modeling
+
+} // namespace cgogn
+
+#endif // CGOGN_MODELING_ALGOS_DOO_SABIN_H_

--- a/cgogn/modeling/algos/doo_sabin.h
+++ b/cgogn/modeling/algos/doo_sabin.h
@@ -42,7 +42,7 @@ namespace modeling
 /// \param[in, out] map the surface to be subdivded
 /// \param[in, out] position the geometric position of the surface
 /// \todo handle objects with open boundaries
-template <typename VEC3, typename MAP, typename MASK>
+template <typename VEC3, typename MAP>
 void doo_sabin(MAP& map,
 			   typename MAP::template VertexAttribute<VEC3>& position)
 {

--- a/cgogn/modeling/algos/doo_sabin.h
+++ b/cgogn/modeling/algos/doo_sabin.h
@@ -40,10 +40,13 @@ namespace modeling
 
 /// \brief Subdivides a surface mesh with the Doo Sabin algorithm
 /// \param[in, out] map the surface to be subdivded
+/// \param[in] mask personalized cell filtering function
 /// \param[in, out] position the geometric position of the surface
 /// \todo handle objects with open boundaries
-template <typename VEC3, typename MAP>
-void doo_sabin(MAP& map, typename MAP::template VertexAttribute<VEC3>& position)
+template <typename VEC3, typename MAP, typename MASK>
+void doo_sabin(MAP& map,
+			   const MASK& mask,
+			   typename MAP::template VertexAttribute<VEC3>& position)
 {
 	using Scalar = typename VEC3::Scalar;
 	using Vertex = typename MAP::Vertex;
@@ -58,8 +61,8 @@ void doo_sabin(MAP& map, typename MAP::template VertexAttribute<VEC3>& position)
 	Builder mbuild(map);
 
 	CellCache initial_cache(map);
-	initial_cache.template build<Edge>();
-	initial_cache.template build<Face>();
+	initial_cache.template build<Edge>(mask);
+	initial_cache.template build<Face>(mask);
 
 	// create the edge faces
 	map.foreach_cell([&] (Edge e)
@@ -159,6 +162,18 @@ void doo_sabin(MAP& map, typename MAP::template VertexAttribute<VEC3>& position)
 		buffer.clear();
 	},
 	initial_cache);
+}
+
+
+/// \brief Subdivides a surface mesh with the Doo Sabin algorithm
+/// \param[in, out] map the surface to be subdivded
+/// \param[in, out] position the geometric position of the surface
+/// \todo handle objects with open boundaries
+template <typename VEC3, typename MAP>
+void doo_sabin(MAP& map,
+			   typename MAP::template VertexAttribute<VEC3>& position)
+{
+	doo_sabin<VEC3>(map, AllCellsFilter(), position);
 }
 
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_MODELING_ALGOS_DOO_SABIN_CPP_))

--- a/cgogn/modeling/algos/doo_sabin.h
+++ b/cgogn/modeling/algos/doo_sabin.h
@@ -40,12 +40,10 @@ namespace modeling
 
 /// \brief Subdivides a surface mesh with the Doo Sabin algorithm
 /// \param[in, out] map the surface to be subdivded
-/// \param[in] mask personalized cell filtering function
 /// \param[in, out] position the geometric position of the surface
 /// \todo handle objects with open boundaries
 template <typename VEC3, typename MAP, typename MASK>
 void doo_sabin(MAP& map,
-			   const MASK& mask,
 			   typename MAP::template VertexAttribute<VEC3>& position)
 {
 	using Scalar = typename VEC3::Scalar;
@@ -61,8 +59,8 @@ void doo_sabin(MAP& map,
 	Builder mbuild(map);
 
 	CellCache initial_cache(map);
-	initial_cache.template build<Edge>(mask);
-	initial_cache.template build<Face>(mask);
+	initial_cache.template build<Edge>();
+	initial_cache.template build<Face>();
 
 	// create the edge faces
 	map.foreach_cell([&] (Edge e)
@@ -162,18 +160,6 @@ void doo_sabin(MAP& map,
 		buffer.clear();
 	},
 	initial_cache);
-}
-
-
-/// \brief Subdivides a surface mesh with the Doo Sabin algorithm
-/// \param[in, out] map the surface to be subdivded
-/// \param[in, out] position the geometric position of the surface
-/// \todo handle objects with open boundaries
-template <typename VEC3, typename MAP>
-void doo_sabin(MAP& map,
-			   typename MAP::template VertexAttribute<VEC3>& position)
-{
-	doo_sabin<VEC3>(map, AllCellsFilter(), position);
 }
 
 #if defined(CGOGN_USE_EXTERNAL_TEMPLATES) && (!defined(CGOGN_MODELING_ALGOS_DOO_SABIN_CPP_))

--- a/cgogn/modeling/examples/subdivision.cpp
+++ b/cgogn/modeling/examples/subdivision.cpp
@@ -43,6 +43,7 @@
 
 #include <cgogn/modeling/algos/loop.h>
 #include <cgogn/modeling/algos/catmull_clark.h>
+#include <cgogn/modeling/algos/doo_sabin.h>
 #include <cgogn/geometry/algos/length.h>
 
 #define DEFAULT_MESH_PATH CGOGN_STR(CGOGN_TEST_MESHES_PATH)
@@ -167,6 +168,20 @@ public:
 			}
 			case Qt::Key_C: {
 				cgogn::modeling::catmull_clark<Vec3>(map_, vertex_position_);
+
+				Scalar mel = cgogn::geometry::mean_edge_length<Vec3>(map_, vertex_position_);
+				param_point_sprite_->size_ = mel / 6.0;
+
+				cgogn::rendering::update_vbo(vertex_position_, vbo_pos_.get());
+
+				render_->init_primitives(map_, cgogn::rendering::POINTS);
+				render_->init_primitives(map_, cgogn::rendering::LINES);
+				render_->init_primitives<Vec3>(map_, cgogn::rendering::TRIANGLES, &vertex_position_);
+
+				break;
+			}
+			case Qt::Key_D: {
+				cgogn::modeling::doo_sabin<Vec3>(map_, vertex_position_);
 
 				Scalar mel = cgogn::geometry::mean_edge_length<Vec3>(map_, vertex_position_);
 				param_point_sprite_->size_ = mel / 6.0;

--- a/cgogn/modeling/tiling/triangular_cylinder.h
+++ b/cgogn/modeling/tiling/triangular_cylinder.h
@@ -80,6 +80,9 @@ public:
 				c->vertex_table_[pos + (nb_x-1)] = Vertex();
 			}
 
+			//mark last vertex
+			c->vertex_table_[(z*nb_x) + (nb_x-1)] = Vertex();
+
 			//suppress the last n vertex (in y direction) from the vertex_table_
 			c->vertex_table_.erase(
 				std::remove_if(

--- a/cgogn/rendering/shaders/vbo.h
+++ b/cgogn/rendering/shaders/vbo.h
@@ -167,7 +167,7 @@ void update_vbo(const std::vector<VEC>& vector, VBO* vbo)
 	using Scalar = typename geometry::vector_traits<VEC>::Scalar;
 	static_assert(std::is_same<Scalar, float32>::value || std::is_same<Scalar, float64>::value, "only float or double allowed for vbo");
 
-	const uint32 vec_dim = geometry::nb_components_traits<VEC>::value;
+	const uint32 vec_dim = geometry::vector_traits<VEC>::SIZE;
 	uint32 vec_sz = uint32(vector.size());
 	vbo->allocate(vec_sz, vec_dim);
 	const uint32 vbo_bytes =  vec_dim * vec_sz * uint32(sizeof(float32));
@@ -238,7 +238,7 @@ void update_vbo(const ATTR& attr, VBO* vbo)
 	std::vector<const void*> chunk_addr = ca->chunks_pointers(byte_chunk_size);
 	const uint32 nb_chunks = uint32(chunk_addr.size());
 
-	const uint32 vec_dim = geometry::nb_components_traits<typename ATTR::value_type>::value;
+	const uint32 vec_dim = geometry::vector_traits<typename ATTR::value_type>::SIZE;
 
 	vbo->allocate(nb_chunks * ATTR::CHUNK_SIZE, vec_dim);
 

--- a/cgogn/rendering/transparency_drawer.h
+++ b/cgogn/rendering/transparency_drawer.h
@@ -48,14 +48,14 @@ class CGOGN_RENDERING_API SurfaceTransparencyDrawer
 	int max_nb_layers_;
 
 	/// rendering shader
-	std::unique_ptr<cgogn::rendering::ShaderFlatTransp::Param> param_flat_;
+	std::unique_ptr<ShaderFlatTransp::Param> param_flat_;
 
-	std::unique_ptr<cgogn::rendering::ShaderPhongTransp::Param> param_phong_;
+	std::unique_ptr<ShaderPhongTransp::Param> param_phong_;
 
-	/// shader for quad blending  with opaque scene
-	std::unique_ptr<cgogn::rendering::ShaderTranspQuad::Param> param_trq_;
+	/// shader for quad blending with opaque scene
+	std::unique_ptr<ShaderTranspQuad::Param> param_trq_;
 
-	std::unique_ptr<cgogn::rendering::ShaderCopyDepth::Param> param_copy_depth_;
+	std::unique_ptr<ShaderCopyDepth::Param> param_copy_depth_;
 
 	/// FBO
 	std::unique_ptr<QOpenGLFramebufferObject> fbo_layer_;
@@ -100,14 +100,12 @@ public:
 	//template<typename PARAM, typename TFUNC>
 	//void draw(PARAM& param, const QMatrix4x4& proj, const QMatrix4x4& view, const TFUNC& draw_func);
 
-
 	/**
 	 * @brief draw the transparent objects (can draw several meshes)
 	 * @param draw_func the func/lambda that draw transparent objects (must bind/unbind ShaderFlatTransp::Param or ShaderPhongTransp::Param)
 	 */
 	template<typename TFUNC>
 	void draw(const TFUNC& draw_func);
-
 
 	/**
 	 * @brief draw the transparent object with local ShaderFlatTransp::Param (can draw only one mesh)
@@ -145,7 +143,6 @@ public:
 		});
 
 	}
-
 
 	/**
 	 * @brief set the max number of layers (eq drawing passes)
@@ -191,7 +188,6 @@ public:
 		param_phong_->set_normal_vbo(vbo_norm);
 	}
 
-
 	inline void set_back_face_culling(bool cull)
 	{
 		param_flat_->bf_culling_ = cull;
@@ -202,11 +198,7 @@ public:
 	{
 		param_flat_->lighted_=lighted;
 	}
-
 };
-
-
-
 
 template<typename TFUNC>
 void SurfaceTransparencyDrawer::draw(const TFUNC& draw_func)
@@ -225,10 +217,10 @@ void SurfaceTransparencyDrawer::draw(const TFUNC& draw_func)
 	ogl33_->glEnable(GL_TEXTURE_2D);
 	ogl33_->glBindTexture(GL_TEXTURE_2D, depthTexture_);
 	ogl33_->glReadBuffer(GL_BACK);
-	ogl33_->glCopyTexSubImage2D(GL_TEXTURE_2D,0,0,0,0,0, width_, height_);
+	ogl33_->glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, width_, height_);
 
 	QVector<GLuint> textures = fbo_layer_->textures();
-	GLenum buffs[2] = {GL_COLOR_ATTACHMENT0,GL_COLOR_ATTACHMENT2};
+	GLenum buffs[2] = { GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT2 };
 
 	sh_flat->bind();
 	sh_flat->set_rgba_sampler(0);
@@ -245,17 +237,17 @@ void SurfaceTransparencyDrawer::draw(const TFUNC& draw_func)
 
 	fbo_layer_->bind();
 
-	GLenum clear_buff[1] = {GL_COLOR_ATTACHMENT3};
-	ogl33_->glDrawBuffers(1,clear_buff);
-	ogl33_->glClearColor(0.0f,0.0f,0.0f,1.0f);
+	GLenum clear_buff[1] = { GL_COLOR_ATTACHMENT3 };
+	ogl33_->glDrawBuffers(1, clear_buff);
+	ogl33_->glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 	ogl33_->glClear(GL_COLOR_BUFFER_BIT);
 
-	ogl33_->glDrawBuffers(1,buffs);
+	ogl33_->glDrawBuffers(1, buffs);
 	ogl33_->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	GLenum opaq_buff[1] = { GL_COLOR_ATTACHMENT5 };
 
-	for (int p=0;p<max_nb_layers_;++p)
+	for (int p = 0; p < max_nb_layers_; ++p)
 	{
 		ogl33_->glClear(GL_DEPTH_BUFFER_BIT);
 
@@ -270,7 +262,7 @@ void SurfaceTransparencyDrawer::draw(const TFUNC& draw_func)
 			param_copy_depth_->release();
 		}
 
-		ogl33_->glDrawBuffers(2,buffs);
+		ogl33_->glDrawBuffers(2, buffs);
 		sh_flat->bind();
 		sh_flat->set_layer(p);
 		sh_flat->release();
@@ -281,11 +273,10 @@ void SurfaceTransparencyDrawer::draw(const TFUNC& draw_func)
 		sh_vol->set_layer(p);
 		sh_vol->release();
 
-
 		ogl33_->glActiveTexture(GL_TEXTURE0);
-		ogl33_->glBindTexture(GL_TEXTURE_2D,textures[3]);
+		ogl33_->glBindTexture(GL_TEXTURE_2D, textures[3]);
 		ogl33_->glActiveTexture(GL_TEXTURE1);
-		ogl33_->glBindTexture(GL_TEXTURE_2D,textures[1]);
+		ogl33_->glBindTexture(GL_TEXTURE_2D, textures[1]);
 
 		ogl33_->glBeginQuery(GL_SAMPLES_PASSED, oq_transp_);
 		draw_func();
@@ -294,23 +285,23 @@ void SurfaceTransparencyDrawer::draw(const TFUNC& draw_func)
 		GLuint nb_samples;
 		ogl33_->glGetQueryObjectuiv(oq_transp_, GL_QUERY_RESULT, &nb_samples);
 
-		if (nb_samples==0) // finished ?
+		if (nb_samples == 0) // finished ?
 			p = max_nb_layers_;
 		else
 		{
 			ogl33_->glReadBuffer(GL_COLOR_ATTACHMENT2);
 			ogl33_->glBindTexture(GL_TEXTURE_2D,textures[1]);
-			ogl33_->glCopyTexImage2D(GL_TEXTURE_2D,0,GL_R32F,0,0,width_,height_,0);
+			ogl33_->glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, 0, 0, width_, height_, 0);
 
-			if (p==0)
+			if (p == 0)
 			{
 				ogl33_->glBindTexture(GL_TEXTURE_2D,textures[4]);
-				ogl33_->glCopyTexImage2D(GL_TEXTURE_2D,0,GL_R32F,0,0,width_,height_,0);
+				ogl33_->glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, 0, 0, width_, height_, 0);
 			}
 
 			ogl33_->glReadBuffer(GL_COLOR_ATTACHMENT0);
 			ogl33_->glBindTexture(GL_TEXTURE_2D,textures[3]);
-			ogl33_->glCopyTexImage2D(GL_TEXTURE_2D,0, GL_RGBA32F,0,0,width_,height_,0);
+			ogl33_->glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, 0, 0, width_, height_, 0);
 		}
 	}
 
@@ -322,23 +313,20 @@ void SurfaceTransparencyDrawer::draw(const TFUNC& draw_func)
 	param_trq_->depth_texture_sampler_ = 1;
 
 	ogl33_->glActiveTexture(GL_TEXTURE0);
-	ogl33_->glBindTexture(GL_TEXTURE_2D,textures[3]);
+	ogl33_->glBindTexture(GL_TEXTURE_2D, textures[3]);
 
 	ogl33_->glActiveTexture(GL_TEXTURE1);
-	ogl33_->glBindTexture(GL_TEXTURE_2D,textures[4]);
+	ogl33_->glBindTexture(GL_TEXTURE_2D, textures[4]);
 
 	ogl33_->glEnable(GL_BLEND);
 	ogl33_->glBlendFunc(GL_ONE,GL_SRC_ALPHA);
-	param_trq_->bind(fake_mat,fake_mat);
+	param_trq_->bind(fake_mat, fake_mat);
 	ogl33_->glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 	param_trq_->release();
 	ogl33_->glDisable(GL_BLEND);
 
-	ogl33_->glClearColor(bkColor[0],bkColor[1],bkColor[2],bkColor[3]);
-
+	ogl33_->glClearColor(bkColor[0], bkColor[1], bkColor[2], bkColor[3]);
 }
-
-
 
 } // namespace rendering
 

--- a/cgogn/rendering/transparency_shaders/shader_copy_depth.cpp
+++ b/cgogn/rendering/transparency_shaders/shader_copy_depth.cpp
@@ -23,11 +23,9 @@
 
 #define CGOGN_RENDER_FLAT_TR_DR_CPP_
 
-
 #include <iostream>
 
 #include <cgogn/rendering/transparency_shaders/shader_copy_depth.h>
-
 
 namespace cgogn
 {
@@ -81,20 +79,17 @@ std::unique_ptr< ShaderCopyDepth::Param> ShaderCopyDepth::generate_param()
 	return cgogn::make_unique<Param>(instance_);
 }
 
-
-
 ShaderParamCopyDepth::ShaderParamCopyDepth(ShaderCopyDepth* sh) :
 	ShaderParam(sh),
 	texture_(nullptr)
 {}
-
 
 void ShaderParamCopyDepth::set_uniforms()
 {
 	ShaderCopyDepth* sh = static_cast<ShaderCopyDepth*>(this->shader_);
 	sh->set_depth_sampler(0);
 	QOpenGLContext::currentContext()->functions()->glActiveTexture(GL_TEXTURE0);
-	if (texture_!=nullptr)
+	if (texture_ != nullptr)
 		texture_->bind();
 }
 

--- a/cgogn/rendering/transparency_shaders/shader_copy_depth.h
+++ b/cgogn/rendering/transparency_shaders/shader_copy_depth.h
@@ -40,19 +40,19 @@ namespace rendering
 // forward
 class ShaderCopyDepth;
 
-
-
 class CGOGN_RENDERING_API ShaderParamCopyDepth : public ShaderParam
 {
 protected:
+
 	void set_uniforms() override;
+
 public:
+
 	using ShaderType = ShaderCopyDepth;
 	QOpenGLTexture* texture_;
 	GLuint depth_texture_sampler_;
 	ShaderParamCopyDepth(ShaderCopyDepth* sh);
 };
-
 
 class CGOGN_RENDERING_API ShaderCopyDepth : public ShaderProgram
 {
@@ -81,7 +81,6 @@ private:
 
 	ShaderCopyDepth();
 	static ShaderCopyDepth* instance_;
-
 };
 
 } // namespace rendering

--- a/thirdparty/OpenNL/OpenNL_psm.c
+++ b/thirdparty/OpenNL/OpenNL_psm.c
@@ -15,7 +15,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -37,9 +37,9 @@
  *     levy@loria.fr
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -88,61 +88,61 @@
 #if defined(__clang__) || defined(__GNUC__)
 #define NL_NORETURN __attribute__((noreturn))
 #else
-#define NL_NORETURN 
+#define NL_NORETURN
 #endif
 
 #if defined(_MSC_VER)
-#define NL_NORETURN_DECL __declspec(noreturn) 
+#define NL_NORETURN_DECL __declspec(noreturn)
 #else
-#define NL_NORETURN_DECL 
+#define NL_NORETURN_DECL
 #endif
 
 NL_NORETURN_DECL void nl_assertion_failed(
-    const char* cond, const char* file, int line
+	const char* cond, const char* file, int line
 ) NL_NORETURN;
 
 NL_NORETURN_DECL void nl_range_assertion_failed(
-    double x, double min_val, double max_val, const char* file, int line
+	double x, double min_val, double max_val, const char* file, int line
 ) NL_NORETURN;
 
 NL_NORETURN_DECL void nl_should_not_have_reached(
-    const char* file, int line
+	const char* file, int line
 ) NL_NORETURN;
 
 #define nl_assert(x) {                                          \
-    if(!(x)) {                                                  \
-        nl_assertion_failed(#x,__FILE__, __LINE__) ;            \
-    }                                                           \
-} 
+	if(!(x)) {                                                  \
+		nl_assertion_failed(#x,__FILE__, __LINE__) ;            \
+	}                                                           \
+}
 
 #define nl_range_assert(x,min_val,max_val) {                    \
-    if(((x) < (min_val)) || ((x) > (max_val))) {                \
-        nl_range_assertion_failed(x, min_val, max_val,          \
-            __FILE__, __LINE__                                  \
-        ) ;                                                     \
-    }                                                           \
+	if(((x) < (min_val)) || ((x) > (max_val))) {                \
+		nl_range_assertion_failed(x, min_val, max_val,          \
+			__FILE__, __LINE__                                  \
+		) ;                                                     \
+	}                                                           \
 }
 
 #define nl_assert_not_reached {                                 \
-    nl_should_not_have_reached(__FILE__, __LINE__) ;            \
+	nl_should_not_have_reached(__FILE__, __LINE__) ;            \
 }
 
 #ifdef NL_DEBUG
-    #define nl_debug_assert(x) nl_assert(x)
-    #define nl_debug_range_assert(x,min_val,max_val)            \
-                               nl_range_assert(x,min_val,max_val)
+	#define nl_debug_assert(x) nl_assert(x)
+	#define nl_debug_range_assert(x,min_val,max_val)            \
+							   nl_range_assert(x,min_val,max_val)
 #else
-    #define nl_debug_assert(x) 
-    #define nl_debug_range_assert(x,min_val,max_val) 
+	#define nl_debug_assert(x)
+	#define nl_debug_range_assert(x,min_val,max_val)
 #endif
 
 #ifdef NL_PARANOID
-    #define nl_parano_assert(x) nl_assert(x)
-    #define nl_parano_range_assert(x,min_val,max_val)           \
-                               nl_range_assert(x,min_val,max_val)
+	#define nl_parano_assert(x) nl_assert(x)
+	#define nl_parano_range_assert(x,min_val,max_val)           \
+							   nl_range_assert(x,min_val,max_val)
 #else
-    #define nl_parano_assert(x) 
-    #define nl_parano_range_assert(x,min_val,max_val) 
+	#define nl_parano_assert(x)
+	#define nl_parano_range_assert(x,min_val,max_val)
 #endif
 
 
@@ -165,28 +165,28 @@ NLfunc nlFindFunction(NLdll handle, const char* funcname);
 /* classic macros */
 
 #ifndef MIN
-#define MIN(x,y) (((x) < (y)) ? (x) : (y)) 
+#define MIN(x,y) (((x) < (y)) ? (x) : (y))
 #endif
 
 #ifndef MAX
-#define MAX(x,y) (((x) > (y)) ? (x) : (y)) 
+#define MAX(x,y) (((x) > (y)) ? (x) : (y))
 #endif
 
 
 
-#define NL_NEW(T)                (T*)(calloc(1, sizeof(T))) 
+#define NL_NEW(T)                (T*)(calloc(1, sizeof(T)))
 
 #define NL_NEW_ARRAY(T,NB)       (T*)(calloc((size_t)(NB),sizeof(T)))
 
-#define NL_RENEW_ARRAY(T,x,NB)   (T*)(realloc(x,(size_t)(NB)*sizeof(T))) 
+#define NL_RENEW_ARRAY(T,x,NB)   (T*)(realloc(x,(size_t)(NB)*sizeof(T)))
 
-#define NL_DELETE(x)             free(x); x = NULL 
+#define NL_DELETE(x)             free(x); x = NULL
 
 #define NL_DELETE_ARRAY(x)       free(x); x = NULL
 
-#define NL_CLEAR(T, x)           memset(x, 0, sizeof(T)) 
+#define NL_CLEAR(T, x)           memset(x, 0, sizeof(T))
 
-#define NL_CLEAR_ARRAY(T,x,NB)   memset(x, 0, (size_t)(NB)*sizeof(T)) 
+#define NL_CLEAR_ARRAY(T,x,NB)   memset(x, 0, (size_t)(NB)*sizeof(T))
 
 
 
@@ -214,50 +214,50 @@ extern "C" {
 struct NLMatrixStruct;
 typedef struct NLMatrixStruct* NLMatrix;
 
-typedef void(*NLDestroyMatrixFunc)(NLMatrix M);    
+typedef void(*NLDestroyMatrixFunc)(NLMatrix M);
 
 typedef void(*NLMultMatrixVectorFunc)(NLMatrix M, const double* x, double* y);
 
 #define NL_MATRIX_SPARSE_DYNAMIC 0x1001
 #define NL_MATRIX_CRS            0x1002
-#define NL_MATRIX_SUPERLU_EXT    0x1003    
-#define NL_MATRIX_CHOLMOD_EXT    0x1004    
+#define NL_MATRIX_SUPERLU_EXT    0x1003
+#define NL_MATRIX_CHOLMOD_EXT    0x1004
 #define NL_MATRIX_FUNCTION       0x1005
 #define NL_MATRIX_OTHER          0x1006
-    
+
 struct NLMatrixStruct {
-    NLuint m;
+	NLuint m;
 
-    NLuint n;
+	NLuint n;
 
-    NLenum type;
+	NLenum type;
 
-    NLDestroyMatrixFunc destroy_func;
+	NLDestroyMatrixFunc destroy_func;
 
-    NLMultMatrixVectorFunc mult_func;
+	NLMultMatrixVectorFunc mult_func;
 };
 
 NLAPI void NLAPIENTRY nlDeleteMatrix(NLMatrix M);
 
 NLAPI void NLAPIENTRY nlMultMatrixVector(
-    NLMatrix M, const double* x, double* y
+	NLMatrix M, const double* x, double* y
 );
-    
+
 
 /* Dynamic arrays for sparse row/columns */
 
 typedef struct  {
-    NLuint index;
+	NLuint index;
 
-    NLdouble value; 
+	NLdouble value;
 } NLCoeff;
 
 typedef struct {
-    NLuint size;
-    
-    NLuint capacity;
+	NLuint size;
 
-    NLCoeff* coeff;  
+	NLuint capacity;
+
+	NLCoeff* coeff;
 } NLRowColumn;
 
 NLAPI void NLAPIENTRY nlRowColumnConstruct(NLRowColumn* c);
@@ -267,11 +267,11 @@ NLAPI void NLAPIENTRY nlRowColumnDestroy(NLRowColumn* c);
 NLAPI void NLAPIENTRY nlRowColumnGrow(NLRowColumn* c);
 
 NLAPI void NLAPIENTRY nlRowColumnAdd(
-    NLRowColumn* c, NLuint index, NLdouble value
+	NLRowColumn* c, NLuint index, NLdouble value
 );
 
 NLAPI void NLAPIENTRY nlRowColumnAppend(
-    NLRowColumn* c, NLuint index, NLdouble value
+	NLRowColumn* c, NLuint index, NLdouble value
 );
 
 NLAPI void NLAPIENTRY nlRowColumnZero(NLRowColumn* c);
@@ -284,47 +284,47 @@ NLAPI void NLAPIENTRY nlRowColumnSort(NLRowColumn* c);
 /* Compressed Row Storage */
 
 typedef struct {
-    NLuint m;
-    
-    NLuint n;
+	NLuint m;
 
-    NLenum type;
-    
-    NLDestroyMatrixFunc destroy_func;
+	NLuint n;
 
-    NLMultMatrixVectorFunc mult_func;
-    
-    NLdouble* val;    
+	NLenum type;
 
-    NLuint* rowptr;
+	NLDestroyMatrixFunc destroy_func;
 
-    NLuint* colind;
+	NLMultMatrixVectorFunc mult_func;
 
-    NLuint nslices;
+	NLdouble* val;
 
-    NLuint* sliceptr;
+	NLuint* rowptr;
 
-    NLboolean symmetric_storage;
+	NLuint* colind;
+
+	NLuint nslices;
+
+	NLuint* sliceptr;
+
+	NLboolean symmetric_storage;
 } NLCRSMatrix;
 
 NLAPI void NLAPIENTRY nlCRSMatrixConstruct(
-    NLCRSMatrix* M, NLuint m, NLuint n, NLuint nnz, NLuint nslices
+	NLCRSMatrix* M, NLuint m, NLuint n, NLuint nnz, NLuint nslices
 );
 
 NLAPI void NLAPIENTRY nlCRSMatrixConstructSymmetric(
-    NLCRSMatrix* M, NLuint n, NLuint nnz
+	NLCRSMatrix* M, NLuint n, NLuint nnz
 );
-    
+
 NLAPI NLboolean NLAPIENTRY nlCRSMatrixLoad(
-    NLCRSMatrix* M, const char* filename
+	NLCRSMatrix* M, const char* filename
 );
 
 NLAPI NLboolean NLAPIENTRY nlCRSMatrixSave(
-    NLCRSMatrix* M, const char* filename
+	NLCRSMatrix* M, const char* filename
 );
 
 NLAPI NLuint NLAPIENTRY nlCRSMatrixNNZ(NLCRSMatrix* M);
-    
+
 
 /* SparseMatrix data structure */
 
@@ -333,46 +333,46 @@ NLAPI NLuint NLAPIENTRY nlCRSMatrixNNZ(NLCRSMatrix* M);
 #define NL_MATRIX_STORE_COLUMNS       2
 
 #define NL_MATRIX_STORE_SYMMETRIC     4
-    
+
 typedef struct {
-    NLuint m;
-    
-    NLuint n;
+	NLuint m;
 
-    NLenum type;
-    
-    NLDestroyMatrixFunc destroy_func;
+	NLuint n;
 
-    NLMultMatrixVectorFunc mult_func;
+	NLenum type;
 
-    
-    NLuint diag_size;
+	NLDestroyMatrixFunc destroy_func;
 
-    NLenum storage;
+	NLMultMatrixVectorFunc mult_func;
 
-    NLRowColumn* row;
 
-    NLRowColumn* column;
+	NLuint diag_size;
 
-    NLdouble*    diag;
+	NLenum storage;
+
+	NLRowColumn* row;
+
+	NLRowColumn* column;
+
+	NLdouble*    diag;
 
 } NLSparseMatrix;
 
 
 NLAPI void NLAPIENTRY nlSparseMatrixConstruct(
-    NLSparseMatrix* M, NLuint m, NLuint n, NLenum storage
+	NLSparseMatrix* M, NLuint m, NLuint n, NLenum storage
 );
 
 NLAPI void nlSparseMatrixDestroy(NLSparseMatrix* M);
-    
+
 NLAPI void NLAPIENTRY nlSparseMatrixAdd(
-    NLSparseMatrix* M, NLuint i, NLuint j, NLdouble value
+	NLSparseMatrix* M, NLuint i, NLuint j, NLdouble value
 );
 
 NLAPI void NLAPIENTRY nlSparseMatrixAddMatrix(
-    NLSparseMatrix* M, double mul, const NLMatrix N
-);	
-    
+	NLSparseMatrix* M, double mul, const NLMatrix N
+);
+
 NLAPI void NLAPIENTRY nlSparseMatrixZero( NLSparseMatrix* M);
 
 NLAPI void NLAPIENTRY nlSparseMatrixClear( NLSparseMatrix* M);
@@ -383,38 +383,38 @@ NLAPI void NLAPIENTRY nlSparseMatrixSort( NLSparseMatrix* M);
 
 
 
-NLAPI NLMatrix NLAPIENTRY nlCRSMatrixNewFromSparseMatrix(NLSparseMatrix* M);    
+NLAPI NLMatrix NLAPIENTRY nlCRSMatrixNewFromSparseMatrix(NLSparseMatrix* M);
 
 NLAPI NLMatrix NLAPIENTRY nlCRSMatrixNewFromSparseMatrixSymmetric(
-    NLSparseMatrix* M
-);    
+	NLSparseMatrix* M
+);
 
-    
+
 NLAPI void NLAPIENTRY nlMatrixCompress(NLMatrix* M);
 
 NLAPI NLuint NLAPIENTRY nlMatrixNNZ(NLMatrix M);
 
 NLAPI NLMatrix NLAPIENTRY nlMatrixFactorize(NLMatrix M, NLenum solver);
-    
 
 
-    typedef void(*NLMatrixFunc)(const double* x, double* y);
+
+	typedef void(*NLMatrixFunc)(const double* x, double* y);
 
 NLAPI NLMatrix NLAPIENTRY nlMatrixNewFromFunction(
-    NLuint m, NLuint n, NLMatrixFunc func
-);	     
+	NLuint m, NLuint n, NLMatrixFunc func
+);
 
 NLAPI NLMatrixFunc NLAPIENTRY nlMatrixGetFunction(NLMatrix M);
 
 
 
 NLAPI NLMatrix NLAPIENTRY nlMatrixNewFromProduct(
-    NLMatrix M, NLboolean product_owns_M,
-    NLMatrix N, NLboolean product_owns_N
+	NLMatrix M, NLboolean product_owns_M,
+	NLMatrix N, NLboolean product_owns_N
 );
 
 
-    
+
 #ifdef __cplusplus
 }
 #endif
@@ -435,7 +435,7 @@ NLAPI NLMatrix NLAPIENTRY nlMatrixNewFromProduct(
 typedef NLboolean(*NLSolverFunc)();
 
 typedef void(*NLProgressFunc)(
-    NLuint cur_iter, NLuint max_iter, double cur_err, double max_err
+	NLuint cur_iter, NLuint max_iter, double cur_err, double max_err
 );
 
 #define NL_STATE_INITIAL                0
@@ -447,107 +447,107 @@ typedef void(*NLProgressFunc)(
 #define NL_STATE_SOLVED                 6
 
 typedef struct {
-    void* base_address;
-    NLuint stride;
+	void* base_address;
+	NLuint stride;
 } NLBufferBinding;
 
 #define NL_BUFFER_ITEM(B,i) \
-    *(double*)((void*)((char*)((B).base_address)+((i)*(B).stride)))
+	*(double*)((void*)((char*)((B).base_address)+((i)*(B).stride)))
 
 
 typedef struct {
-    NLenum           state;
+	NLenum           state;
 
-    NLboolean        user_variable_buffers;
-    
-    NLBufferBinding* variable_buffer;
-    
-    NLdouble*        variable_value;
+	NLboolean        user_variable_buffers;
 
-    NLboolean*       variable_is_locked;
+	NLBufferBinding* variable_buffer;
 
-    NLuint*          variable_index;
-    
-    NLuint           n;
+	NLdouble*        variable_value;
 
+	NLboolean*       variable_is_locked;
 
-    NLenum           matrix_mode;
+	NLuint*          variable_index;
 
-    NLMatrix         M;
-
-    NLMatrix         P;
-
-    NLMatrix         B;
-    
-    NLRowColumn      af;
-
-    NLRowColumn      al;
-
-    NLdouble*        x;
-
-    NLdouble*        b;
-
-    NLdouble*        right_hand_side;
-
-    NLdouble         row_scaling;
-
-    NLenum           solver;
-
-    NLenum           preconditioner;
-
-    NLboolean        preconditioner_defined;
-    
-    NLuint           nb_variables;
-
-    NLuint           nb_systems;
-
-    NLboolean        ij_coefficient_called;
-    
-    NLuint           current_row;
-
-    NLboolean        least_squares;
-
-    NLboolean        symmetric;
-
-    NLuint           max_iterations;
+	NLuint           n;
 
 
-    NLboolean        max_iterations_defined;
-    
-    NLuint           inner_iterations;
+	NLenum           matrix_mode;
 
-    NLdouble         threshold;
+	NLMatrix         M;
 
-    NLboolean        threshold_defined;
-    
-    NLdouble         omega;
+	NLMatrix         P;
 
-    NLboolean        normalize_rows;
-    
-    NLuint           used_iterations;
+	NLMatrix         B;
 
-    NLdouble         error;
+	NLRowColumn      af;
 
-    NLdouble         elapsed_time;
+	NLRowColumn      al;
 
-    NLSolverFunc     solver_func;
+	NLdouble*        x;
 
-    NLProgressFunc   progress_func;
+	NLdouble*        b;
 
-    NLboolean        verbose;
+	NLdouble*        right_hand_side;
 
-    NLulong          flops;
+	NLdouble         row_scaling;
 
-    NLenum           eigen_solver;
+	NLenum           solver;
 
-    NLdouble         eigen_shift;
+	NLenum           preconditioner;
 
-    NLboolean        eigen_shift_invert;
+	NLboolean        preconditioner_defined;
 
-    NLdouble*        eigen_value;
+	NLuint           nb_variables;
 
-    NLdouble*        temp_eigen_value;
-    
+	NLuint           nb_systems;
+
+	NLboolean        ij_coefficient_called;
+
+	NLuint           current_row;
+
+	NLboolean        least_squares;
+
+	NLboolean        symmetric;
+
+	NLuint           max_iterations;
+
+
+	NLboolean        max_iterations_defined;
+
+	NLuint           inner_iterations;
+
+	NLdouble         threshold;
+
+	NLboolean        threshold_defined;
+
+	NLdouble         omega;
+
+	NLboolean        normalize_rows;
+
+	NLuint           used_iterations;
+
+	NLdouble         error;
+
+	NLdouble         elapsed_time;
+
+	NLSolverFunc     solver_func;
+
+	NLProgressFunc   progress_func;
+
+	NLboolean        verbose;
+
+	NLulong          flops;
+
+	NLenum           eigen_solver;
+
+	NLdouble         eigen_shift;
+
+	NLboolean        eigen_shift_invert;
+
+	NLdouble*        eigen_value;
+
+	NLdouble*        temp_eigen_value;
+
 } NLContextStruct;
 
 extern NLContextStruct* nlCurrentContext;
@@ -577,45 +577,45 @@ NLboolean nlDefaultSolver(void);
 
 void dscal( int n, double a, double *x, int incx ) ;
 
-void dcopy( 
-    int n, const double *x, int incx, double *y, int incy 
+void dcopy(
+	int n, const double *x, int incx, double *y, int incy
 ) ;
 
-void daxpy( 
-    int n, double a, const double *x, int incx, double *y,
-    int incy 
+void daxpy(
+	int n, double a, const double *x, int incx, double *y,
+	int incy
 ) ;
 
-double ddot( 
-    int n, const double *x, int incx, const double *y, int incy 
+double ddot(
+	int n, const double *x, int incx, const double *y, int incy
 ) ;
 
 double dnrm2( int n, const double *x, int incx ) ;
 
 typedef enum {
-    NoTranspose=0, Transpose=1, ConjugateTranspose=2
+	NoTranspose=0, Transpose=1, ConjugateTranspose=2
 } MatrixTranspose ;
 
 typedef enum {
-    UpperTriangle=0, LowerTriangle=1
+	UpperTriangle=0, LowerTriangle=1
 } MatrixTriangle ;
 
 
 typedef enum {
-    UnitTriangular=0, NotUnitTriangular=1
+	UnitTriangular=0, NotUnitTriangular=1
 } MatrixUnitTriangular ;
 
 
-void dtpsv( 
-    MatrixTriangle uplo, MatrixTranspose trans,
-    MatrixUnitTriangular diag, int n, const double *AP,
-    double *x, int incx 
+void dtpsv(
+	MatrixTriangle uplo, MatrixTranspose trans,
+	MatrixUnitTriangular diag, int n, const double *AP,
+	double *x, int incx
 ) ;
 
-void dgemv( 
-    MatrixTranspose trans, int m, int n, double alpha,
-    const double *A, int ldA, const double *x, int incx,
-    double beta, double *y, int incy 
+void dgemv(
+	MatrixTranspose trans, int m, int n, double alpha,
+	const double *A, int ldA, const double *x, int incx,
+	double beta, double *y, int incy
 ) ;
 
 #endif
@@ -629,9 +629,9 @@ void dgemv(
 
 
 NLAPI NLuint NLAPIENTRY nlSolveSystemIterative(
-    NLMatrix M, NLMatrix P, NLdouble* b, NLdouble* x,
-    NLenum solver,
-    double eps, NLuint max_iter, NLuint inner_iter
+	NLMatrix M, NLMatrix P, NLdouble* b, NLdouble* x,
+	NLenum solver,
+	double eps, NLuint max_iter, NLuint inner_iter
 );
 
 #endif
@@ -661,7 +661,7 @@ NLMatrix nlNewSSORPreconditioner(NLMatrix M, double omega);
 
 
 NLAPI NLMatrix NLAPIENTRY nlMatrixFactorize_SUPERLU(
-    NLMatrix M, NLenum solver
+	NLMatrix M, NLenum solver
 );
 
 NLboolean nlInitExtension_SUPERLU(void);
@@ -676,7 +676,7 @@ NLboolean nlInitExtension_SUPERLU(void);
 
 
 NLAPI NLMatrix NLAPIENTRY nlMatrixFactorize_CHOLMOD(
-    NLMatrix M, NLenum solver
+	NLMatrix M, NLenum solver
 );
 
 NLboolean nlInitExtension_CHOLMOD(void);
@@ -707,7 +707,7 @@ extern "C" {
 #endif
 
 
-    
+
 NLboolean nlSolverIsCNC(NLint solver) ;
 
 NLuint nlSolve_CNC(void) ;
@@ -725,7 +725,7 @@ NLuint nlSolve_CNC(void) ;
 #include <windows.h>
 #else
 #include <sys/types.h>
-#include <sys/times.h> 
+#include <sys/times.h>
 #endif
 
 #if defined(GEO_DYNAMIC_LIBS) && defined(NL_OS_UNIX)
@@ -737,33 +737,33 @@ NLuint nlSolve_CNC(void) ;
 
 
 void nl_assertion_failed(const char* cond, const char* file, int line) {
-    fprintf(
-        stderr, 
-        "OpenNL assertion failed: %s, file:%s, line:%d\n",
-        cond,file,line
-    ) ;
-    abort() ;
+	fprintf(
+		stderr,
+		"OpenNL assertion failed: %s, file:%s, line:%d\n",
+		cond,file,line
+	) ;
+	abort() ;
 }
 
 void nl_range_assertion_failed(
-    double x, double min_val, double max_val, const char* file, int line
+	double x, double min_val, double max_val, const char* file, int line
 ) {
-    fprintf(
-        stderr, 
-        "OpenNL range assertion failed: "
+	fprintf(
+		stderr,
+		"OpenNL range assertion failed: "
 	"%f in [ %f ... %f ], file:%s, line:%d\n",
-        x, min_val, max_val, file,line
-    ) ;
-    abort() ;
+		x, min_val, max_val, file,line
+	) ;
+	abort() ;
 }
 
 void nl_should_not_have_reached(const char* file, int line) {
-    fprintf(
-        stderr, 
-        "OpenNL should not have reached this point: file:%s, line:%d\n",
-        file,line
-    ) ;
-    abort() ;
+	fprintf(
+		stderr,
+		"OpenNL should not have reached this point: file:%s, line:%d\n",
+		file,line
+	) ;
+	abort() ;
 }
 
 
@@ -772,73 +772,73 @@ void nl_should_not_have_reached(const char* file, int line) {
 
 #ifdef WIN32
 NLdouble nlCurrentTime() {
-    return (NLdouble)GetTickCount() / 1000.0 ;
+	return (NLdouble)GetTickCount() / 1000.0 ;
 }
 #else
 double nlCurrentTime() {
-    clock_t user_clock ;
-    struct tms user_tms ;
-    user_clock = times(&user_tms) ;
-    return (NLdouble)user_clock / 100.0 ;
+	clock_t user_clock ;
+	struct tms user_tms ;
+	user_clock = times(&user_tms) ;
+	return (NLdouble)user_clock / 100.0 ;
 }
 #endif
 
 
 /* DLLs/shared objects/dylibs */
 
-#if defined(GEO_DYNAMIC_LIBS) 
+#if defined(GEO_DYNAMIC_LIBS)
 
 #  if defined(NL_OS_UNIX)
 
 NLdll nlOpenDLL(const char* name) {
-    void* result = dlopen(name, RTLD_NOW);  
-    if(result == NULL) {
-        fprintf(stderr,"Did not find %s,\n", name);
-        fprintf(stderr,"Retrying with libgeogram_num_3rdparty.so\n");
-        result=dlopen("libgeogram_num_3rdparty.so", RTLD_NOW);
-        if(result == NULL) {
-            nlError("nlOpenDLL/dlopen",dlerror());
-        }
-    }
-    return result;
+	void* result = dlopen(name, RTLD_NOW);
+	if(result == NULL) {
+		fprintf(stderr,"Did not find %s,\n", name);
+		fprintf(stderr,"Retrying with libgeogram_num_3rdparty.so\n");
+		result=dlopen("libgeogram_num_3rdparty.so", RTLD_NOW);
+		if(result == NULL) {
+			nlError("nlOpenDLL/dlopen",dlerror());
+		}
+	}
+	return result;
 }
 
 void nlCloseDLL(void* handle) {
-    dlclose(handle);
+	dlclose(handle);
 }
 
 NLfunc nlFindFunction(void* handle, const char* name) {
-    /*
-     * It is not legal in modern C to cast a void*
-     *  pointer into a function pointer, thus requiring this
-     *  (quite dirty) function that uses a union.    
-     */
-    union {
-        void* ptr;
-        NLfunc fptr;
-    } u;
-    u.ptr = dlsym(handle, name);
-    return u.fptr;
+	/*
+	 * It is not legal in modern C to cast a void*
+	 *  pointer into a function pointer, thus requiring this
+	 *  (quite dirty) function that uses a union.
+	 */
+	union {
+		void* ptr;
+		NLfunc fptr;
+	} u;
+	u.ptr = dlsym(handle, name);
+	return u.fptr;
 }
 
 #  elif defined(NL_OS_WINDOWS)
 
 NLdll nlOpenDLL(const char* name) {
-    void* result = LoadLibrary(name);
-    if(result == NULL) {
-        fprintf(stderr,"Did not find %s,\n", name);
-        fprintf(stderr,"Retrying with geogram_num_3rdparty\n");
-        result=LoadLibrary("geogram_num_3rdparty.dll");
-    }
-    return result;
+	void* result = LoadLibrary(name);
+	if(result == NULL) {
+		fprintf(stderr,"Did not find %s,\n", name);
+		fprintf(stderr,"Retrying with geogram_num_3rdparty\n");
+		result=LoadLibrary("geogram_num_3rdparty.dll");
+	}
+	return result;
 }
 
 void nlCloseDLL(void* handle) {
-    FreeLibrary((HMODULE)handle);
+	FreeLibrary((HMODULE)handle);
 }
 
 NLfunc nlFindFunction(void* handle, const char* name) {
-    return (NLfunc)GetProcAddress((HMODULE)handle, name);
+	return (NLfunc)GetProcAddress((HMODULE)handle, name);
 }
 
 #  endif
@@ -846,26 +846,26 @@ NLfunc nlFindFunction(void* handle, const char* name) {
 #else
 
 NLdll nlOpenDLL(const char* name) {
-    nl_arg_used(name);
+	nl_arg_used(name);
 #ifdef NL_OS_UNIX
-    nlError("nlOpenDLL","Was not compiled with dynamic linking enabled");
-    nlError("nlOpenDLL","(see VORPALINE_BUILD_DYNAMIC in CMakeLists.txt)");        
-#else    
-    nlError("nlOpenDLL","Not implemented");
-#endif    
-    return NULL;
+	nlError("nlOpenDLL","Was not compiled with dynamic linking enabled");
+	nlError("nlOpenDLL","(see VORPALINE_BUILD_DYNAMIC in CMakeLists.txt)");
+#else
+	nlError("nlOpenDLL","Not implemented");
+#endif
+	return NULL;
 }
 
 void nlCloseDLL(void* handle) {
-    nl_arg_used(handle);
-    nlError("nlCloseDLL","Not implemented");        
+	nl_arg_used(handle);
+	nlError("nlCloseDLL","Not implemented");
 }
 
 NLfunc nlFindFunction(void* handle, const char* name) {
-    nl_arg_used(handle);
-    nl_arg_used(name);
-    nlError("nlFindFunction","Not implemented");            
-    return NULL;
+	nl_arg_used(handle);
+	nl_arg_used(name);
+	nlError("nlFindFunction","Not implemented");
+	return NULL;
 }
 
 #endif
@@ -874,11 +874,11 @@ NLfunc nlFindFunction(void* handle, const char* name) {
 /* Error-reporting functions */
 
 void nlError(const char* function, const char* message) {
-    fprintf(stderr, "OpenNL error in %s(): %s\n", function, message) ; 
+	fprintf(stderr, "OpenNL error in %s(): %s\n", function, message) ;
 }
 
 void nlWarning(const char* function, const char* message) {
-    fprintf(stderr, "OpenNL warning in %s(): %s\n", function, message) ; 
+	fprintf(stderr, "OpenNL warning in %s(): %s\n", function, message) ;
 }
 
 
@@ -901,260 +901,260 @@ void nlWarning(const char* function, const char* message) {
 
 
 void nlDeleteMatrix(NLMatrix M) {
-    if(M == NULL) {
-        return;
-    }
-    M->destroy_func(M);
-    NL_DELETE(M);
+	if(M == NULL) {
+		return;
+	}
+	M->destroy_func(M);
+	NL_DELETE(M);
 }
 
 void nlMultMatrixVector(
-    NLMatrix M, const double* x, double* y
+	NLMatrix M, const double* x, double* y
 ) {
-    M->mult_func(M,x,y);
-    if(nlCurrentContext != NULL) {
+	M->mult_func(M,x,y);
+	if(nlCurrentContext != NULL) {
 	if(M->type == NL_MATRIX_SPARSE_DYNAMIC) {
-	    nlCurrentContext->flops +=
+		nlCurrentContext->flops +=
 		(NLulong)(nlSparseMatrixNNZ((NLSparseMatrix*)M)*2);
 	} else if(M->type == NL_MATRIX_CRS) {
-	    nlCurrentContext->flops +=
+		nlCurrentContext->flops +=
 		(NLulong)(nlCRSMatrixNNZ((NLCRSMatrix*)M)*2);
 	}
-    }
+	}
 }
 
 
 
 void nlRowColumnConstruct(NLRowColumn* c) {
-    c->size     = 0;
-    c->capacity = 0;
-    c->coeff    = NULL;
+	c->size     = 0;
+	c->capacity = 0;
+	c->coeff    = NULL;
 }
 
 void nlRowColumnDestroy(NLRowColumn* c) {
-    NL_DELETE_ARRAY(c->coeff);
-    c->size = 0;
-    c->capacity = 0;
+	NL_DELETE_ARRAY(c->coeff);
+	c->size = 0;
+	c->capacity = 0;
 }
 
 void nlRowColumnGrow(NLRowColumn* c) {
-    if(c->capacity != 0) {
-        c->capacity = 2 * c->capacity;
-        c->coeff = NL_RENEW_ARRAY(NLCoeff, c->coeff, c->capacity);
-    } else {
-        c->capacity = 4;
-        c->coeff = NL_NEW_ARRAY(NLCoeff, c->capacity);
-    }
+	if(c->capacity != 0) {
+		c->capacity = 2 * c->capacity;
+		c->coeff = NL_RENEW_ARRAY(NLCoeff, c->coeff, c->capacity);
+	} else {
+		c->capacity = 4;
+		c->coeff = NL_NEW_ARRAY(NLCoeff, c->capacity);
+	}
 }
 
 void nlRowColumnAdd(NLRowColumn* c, NLuint index, NLdouble value) {
-    NLuint i;
-    for(i=0; i<c->size; i++) {
-        if(c->coeff[i].index == index) {
-            c->coeff[i].value += value;
-            return;
-        }
-    }
-    if(c->size == c->capacity) {
-        nlRowColumnGrow(c);
-    }
-    c->coeff[c->size].index = index;
-    c->coeff[c->size].value = value;
-    c->size++;
+	NLuint i;
+	for(i=0; i<c->size; i++) {
+		if(c->coeff[i].index == index) {
+			c->coeff[i].value += value;
+			return;
+		}
+	}
+	if(c->size == c->capacity) {
+		nlRowColumnGrow(c);
+	}
+	c->coeff[c->size].index = index;
+	c->coeff[c->size].value = value;
+	c->size++;
 }
 
 /* Does not check whether the index already exists */
 void nlRowColumnAppend(NLRowColumn* c, NLuint index, NLdouble value) {
-    if(c->size == c->capacity) {
-        nlRowColumnGrow(c);
-    }
-    c->coeff[c->size].index = index;
-    c->coeff[c->size].value = value;
-    c->size++;
+	if(c->size == c->capacity) {
+		nlRowColumnGrow(c);
+	}
+	c->coeff[c->size].index = index;
+	c->coeff[c->size].value = value;
+	c->size++;
 }
 
 void nlRowColumnZero(NLRowColumn* c) {
-    c->size = 0;
+	c->size = 0;
 }
 
 void nlRowColumnClear(NLRowColumn* c) {
-    c->size     = 0;
-    c->capacity = 0;
-    NL_DELETE_ARRAY(c->coeff);
+	c->size     = 0;
+	c->capacity = 0;
+	NL_DELETE_ARRAY(c->coeff);
 }
 
 static int nlCoeffCompare(const void* p1, const void* p2) {
-    return (((NLCoeff*)(p2))->index < ((NLCoeff*)(p1))->index);
+	return (((NLCoeff*)(p2))->index < ((NLCoeff*)(p1))->index);
 }
 
 void nlRowColumnSort(NLRowColumn* c) {
-    qsort(c->coeff, c->size, sizeof(NLCoeff), nlCoeffCompare);
+	qsort(c->coeff, c->size, sizeof(NLCoeff), nlCoeffCompare);
 }
 
 
 /* CRSMatrix data structure */
 
 static void nlCRSMatrixDestroy(NLCRSMatrix* M) {
-    NL_DELETE_ARRAY(M->val);
-    NL_DELETE_ARRAY(M->rowptr);
-    NL_DELETE_ARRAY(M->colind);
-    NL_DELETE_ARRAY(M->sliceptr);
-    M->m = 0;
-    M->n = 0;
-    M->nslices = 0;
+	NL_DELETE_ARRAY(M->val);
+	NL_DELETE_ARRAY(M->rowptr);
+	NL_DELETE_ARRAY(M->colind);
+	NL_DELETE_ARRAY(M->sliceptr);
+	M->m = 0;
+	M->n = 0;
+	M->nslices = 0;
 }
 
 
 NLboolean nlCRSMatrixSave(NLCRSMatrix* M, const char* filename) {
-    NLuint nnz = M->rowptr[M->m];
-    FILE* f = fopen(filename, "rb");
-    if(f == NULL) {
-        nlError("nlCRSMatrixSave", "Could not open file");
-        return NL_FALSE;
-    }
+	NLuint nnz = M->rowptr[M->m];
+	FILE* f = fopen(filename, "rb");
+	if(f == NULL) {
+		nlError("nlCRSMatrixSave", "Could not open file");
+		return NL_FALSE;
+	}
 
-    fwrite(&M->m, sizeof(NLuint), 1, f);
-    fwrite(&M->n, sizeof(NLuint), 1, f);
-    fwrite(&nnz, sizeof(NLuint), 1, f);
+	fwrite(&M->m, sizeof(NLuint), 1, f);
+	fwrite(&M->n, sizeof(NLuint), 1, f);
+	fwrite(&nnz, sizeof(NLuint), 1, f);
 
-    fwrite(M->rowptr, sizeof(NLuint), M->m+1, f);
-    fwrite(M->colind, sizeof(NLuint), nnz, f);
-    fwrite(M->val, sizeof(double), nnz, f);
-    
-    return NL_TRUE;
+	fwrite(M->rowptr, sizeof(NLuint), M->m+1, f);
+	fwrite(M->colind, sizeof(NLuint), nnz, f);
+	fwrite(M->val, sizeof(double), nnz, f);
+
+	return NL_TRUE;
 }
 
 NLboolean nlCRSMatrixLoad(NLCRSMatrix* M, const char* filename) {
-    NLuint nnz = 0;
-    FILE* f = fopen(filename, "rb");
-    NLboolean truncated = NL_FALSE;
-    
-    if(f == NULL) {
-        nlError("nlCRSMatrixLoad", "Could not open file");
-        return NL_FALSE;
-    }
-    
-    truncated = truncated || (
-        fread(&M->m, sizeof(NLuint), 1, f) != 1 ||
-        fread(&M->n, sizeof(NLuint), 1, f) != 1 ||
-        fread(&nnz, sizeof(NLuint), 1, f) != 1
-    );
+	NLuint nnz = 0;
+	FILE* f = fopen(filename, "rb");
+	NLboolean truncated = NL_FALSE;
 
-    if(truncated) {
-        M->rowptr = NULL;
-        M->colind = NULL;
-        M->val = NULL;
-    } else {
-        M->rowptr = NL_NEW_ARRAY(NLuint, M->m+1);
-        M->colind = NL_NEW_ARRAY(NLuint, nnz);
-        M->val = NL_NEW_ARRAY(double, nnz);
-        truncated = truncated || (
-            fread(M->rowptr, sizeof(NLuint), M->m+1, f) != M->m+1 ||
-            fread(M->colind, sizeof(NLuint), nnz, f) != nnz ||
-            fread(M->val, sizeof(double), nnz, f) != nnz
-        );
-    }
+	if(f == NULL) {
+		nlError("nlCRSMatrixLoad", "Could not open file");
+		return NL_FALSE;
+	}
 
-    if(truncated) {
-        nlError("nlCRSMatrixSave", "File appears to be truncated");
-        NL_DELETE_ARRAY(M->rowptr);
-        NL_DELETE_ARRAY(M->colind);
-        NL_DELETE_ARRAY(M->val);
-        return NL_FALSE;
-    } else {
-        M->nslices = 1;    
-        M->sliceptr = NL_NEW_ARRAY(NLuint, M->nslices+1);
-        M->sliceptr[0] = 0;
-        M->sliceptr[1] = M->m;
-    }
+	truncated = truncated || (
+		fread(&M->m, sizeof(NLuint), 1, f) != 1 ||
+		fread(&M->n, sizeof(NLuint), 1, f) != 1 ||
+		fread(&nnz, sizeof(NLuint), 1, f) != 1
+	);
 
-    fclose(f);
-    return NL_TRUE;
+	if(truncated) {
+		M->rowptr = NULL;
+		M->colind = NULL;
+		M->val = NULL;
+	} else {
+		M->rowptr = NL_NEW_ARRAY(NLuint, M->m+1);
+		M->colind = NL_NEW_ARRAY(NLuint, nnz);
+		M->val = NL_NEW_ARRAY(double, nnz);
+		truncated = truncated || (
+			fread(M->rowptr, sizeof(NLuint), M->m+1, f) != M->m+1 ||
+			fread(M->colind, sizeof(NLuint), nnz, f) != nnz ||
+			fread(M->val, sizeof(double), nnz, f) != nnz
+		);
+	}
+
+	if(truncated) {
+		nlError("nlCRSMatrixSave", "File appears to be truncated");
+		NL_DELETE_ARRAY(M->rowptr);
+		NL_DELETE_ARRAY(M->colind);
+		NL_DELETE_ARRAY(M->val);
+		return NL_FALSE;
+	} else {
+		M->nslices = 1;
+		M->sliceptr = NL_NEW_ARRAY(NLuint, M->nslices+1);
+		M->sliceptr[0] = 0;
+		M->sliceptr[1] = M->m;
+	}
+
+	fclose(f);
+	return NL_TRUE;
 }
 
 NLuint nlCRSMatrixNNZ(NLCRSMatrix* M) {
-    return M->rowptr[M->m];
+	return M->rowptr[M->m];
 }
 
 static void nlCRSMatrixMultSlice(
-    NLCRSMatrix* M, const double* x, double* y, NLuint Ibegin, NLuint Iend
+	NLCRSMatrix* M, const double* x, double* y, NLuint Ibegin, NLuint Iend
 ) {
-    NLuint i,j;
-    for(i=Ibegin; i<Iend; ++i) {
-        double sum=0.0;
-        for(j=M->rowptr[i]; j<M->rowptr[i+1]; ++j) {
-            sum += M->val[j] * x[M->colind[j]];
-        }
-        y[i] = sum; 
-    }
+	NLuint i,j;
+	for(i=Ibegin; i<Iend; ++i) {
+		double sum=0.0;
+		for(j=M->rowptr[i]; j<M->rowptr[i+1]; ++j) {
+			sum += M->val[j] * x[M->colind[j]];
+		}
+		y[i] = sum;
+	}
 }
 
 static void nlCRSMatrixMult(
-    NLCRSMatrix* M, const double* x, double* y
+	NLCRSMatrix* M, const double* x, double* y
 ) {
-    int slice;
-    int nslices = (int)(M->nslices);
-    NLuint i,j,jj;
-    NLdouble a;
-    
-    if(M->symmetric_storage) {
-        for(i=0; i<M->m; ++i) {
-            y[i] = 0.0;
-        }
-        for(i=0; i<M->m; ++i) {
-            for(jj=M->rowptr[i]; jj<M->rowptr[i]; ++jj) {
-                a = M->val[jj];
-                j = M->colind[jj];
-                y[i] += a * x[j];
-                if(j != i) {
-                    y[j] += a * x[i];
-                }
-            }
-        }
-    }
+	int slice;
+	int nslices = (int)(M->nslices);
+	NLuint i,j,jj;
+	NLdouble a;
 
-    
+	if(M->symmetric_storage) {
+		for(i=0; i<M->m; ++i) {
+			y[i] = 0.0;
+		}
+		for(i=0; i<M->m; ++i) {
+			for(jj=M->rowptr[i]; jj<M->rowptr[i]; ++jj) {
+				a = M->val[jj];
+				j = M->colind[jj];
+				y[i] += a * x[j];
+				if(j != i) {
+					y[j] += a * x[i];
+				}
+			}
+		}
+	}
+
+
 #if defined(_OPENMP)
 #pragma omp parallel for private(slice)
 #endif
-    
-    for(slice=0; slice<nslices; ++slice) {
-        nlCRSMatrixMultSlice(
-            M,x,y,M->sliceptr[slice],M->sliceptr[slice+1]
-        );
-    }
+
+	for(slice=0; slice<nslices; ++slice) {
+		nlCRSMatrixMultSlice(
+			M,x,y,M->sliceptr[slice],M->sliceptr[slice+1]
+		);
+	}
 }
 
 void nlCRSMatrixConstruct(
-    NLCRSMatrix* M, NLuint m, NLuint n, NLuint nnz, NLuint nslices
+	NLCRSMatrix* M, NLuint m, NLuint n, NLuint nnz, NLuint nslices
 ) {
-    M->m = m;
-    M->n = n;
-    M->type = NL_MATRIX_CRS;
-    M->destroy_func = (NLDestroyMatrixFunc)nlCRSMatrixDestroy;
-    M->mult_func = (NLMultMatrixVectorFunc)nlCRSMatrixMult;
-    M->nslices = nslices;
-    M->val = NL_NEW_ARRAY(double, nnz);
-    M->rowptr = NL_NEW_ARRAY(NLuint, m+1);
-    M->colind = NL_NEW_ARRAY(NLuint, nnz);
-    M->sliceptr = NL_NEW_ARRAY(NLuint, nslices+1);
-    M->symmetric_storage = NL_FALSE;
+	M->m = m;
+	M->n = n;
+	M->type = NL_MATRIX_CRS;
+	M->destroy_func = (NLDestroyMatrixFunc)nlCRSMatrixDestroy;
+	M->mult_func = (NLMultMatrixVectorFunc)nlCRSMatrixMult;
+	M->nslices = nslices;
+	M->val = NL_NEW_ARRAY(double, nnz);
+	M->rowptr = NL_NEW_ARRAY(NLuint, m+1);
+	M->colind = NL_NEW_ARRAY(NLuint, nnz);
+	M->sliceptr = NL_NEW_ARRAY(NLuint, nslices+1);
+	M->symmetric_storage = NL_FALSE;
 }
 
 void nlCRSMatrixConstructSymmetric(
-    NLCRSMatrix* M, NLuint n, NLuint nnz
+	NLCRSMatrix* M, NLuint n, NLuint nnz
 ) {
-    M->m = n;
-    M->n = n;
-    M->type = NL_MATRIX_CRS;
-    M->destroy_func = (NLDestroyMatrixFunc)nlCRSMatrixDestroy;
-    M->mult_func = (NLMultMatrixVectorFunc)nlCRSMatrixMult;
-    M->nslices = 0;
-    M->val = NL_NEW_ARRAY(double, nnz);
-    M->rowptr = NL_NEW_ARRAY(NLuint, n+1);
-    M->colind = NL_NEW_ARRAY(NLuint, nnz);
-    M->sliceptr = NULL;
-    M->symmetric_storage = NL_TRUE;
+	M->m = n;
+	M->n = n;
+	M->type = NL_MATRIX_CRS;
+	M->destroy_func = (NLDestroyMatrixFunc)nlCRSMatrixDestroy;
+	M->mult_func = (NLMultMatrixVectorFunc)nlCRSMatrixMult;
+	M->nslices = 0;
+	M->val = NL_NEW_ARRAY(double, nnz);
+	M->rowptr = NL_NEW_ARRAY(NLuint, n+1);
+	M->colind = NL_NEW_ARRAY(NLuint, nnz);
+	M->sliceptr = NULL;
+	M->symmetric_storage = NL_TRUE;
 }
 
 
@@ -1162,567 +1162,567 @@ void nlCRSMatrixConstructSymmetric(
 
 
 static void nlSparseMatrixDestroyRowColumns(NLSparseMatrix* M) {
-    NLuint i;
-    if(M->storage & NL_MATRIX_STORE_ROWS) {
-        for(i=0; i<M->m; i++) {
-            nlRowColumnDestroy(&(M->row[i]));
-        }
-        NL_DELETE_ARRAY(M->row);
-    }
-    M->storage = (NLenum)((int)(M->storage) & ~NL_MATRIX_STORE_ROWS);
-    
-    if(M->storage & NL_MATRIX_STORE_COLUMNS) {
-        for(i=0; i<M->n; i++) {
-            nlRowColumnDestroy(&(M->column[i]));
-        }
-        NL_DELETE_ARRAY(M->column);
-    }
-    M->storage = (NLenum)((int)(M->storage) & ~NL_MATRIX_STORE_COLUMNS);    
+	NLuint i;
+	if(M->storage & NL_MATRIX_STORE_ROWS) {
+		for(i=0; i<M->m; i++) {
+			nlRowColumnDestroy(&(M->row[i]));
+		}
+		NL_DELETE_ARRAY(M->row);
+	}
+	M->storage = (NLenum)((int)(M->storage) & ~NL_MATRIX_STORE_ROWS);
+
+	if(M->storage & NL_MATRIX_STORE_COLUMNS) {
+		for(i=0; i<M->n; i++) {
+			nlRowColumnDestroy(&(M->column[i]));
+		}
+		NL_DELETE_ARRAY(M->column);
+	}
+	M->storage = (NLenum)((int)(M->storage) & ~NL_MATRIX_STORE_COLUMNS);
 }
 
 void nlSparseMatrixDestroy(NLSparseMatrix* M) {
-    nl_assert(M->type == NL_MATRIX_SPARSE_DYNAMIC);
-    nlSparseMatrixDestroyRowColumns(M);
-    NL_DELETE_ARRAY(M->diag);
+	nl_assert(M->type == NL_MATRIX_SPARSE_DYNAMIC);
+	nlSparseMatrixDestroyRowColumns(M);
+	NL_DELETE_ARRAY(M->diag);
 #ifdef NL_PARANOID
-    NL_CLEAR(NLSparseMatrix,M);
+	NL_CLEAR(NLSparseMatrix,M);
 #endif
 }
 
 void nlSparseMatrixAdd(NLSparseMatrix* M, NLuint i, NLuint j, NLdouble value) {
-    nl_parano_range_assert(i, 0, M->m - 1);
-    nl_parano_range_assert(j, 0, M->n - 1);
-    if((M->storage & NL_MATRIX_STORE_SYMMETRIC) && (j > i)) {
-        return;
-    }
-    if(i == j) {
-        M->diag[i] += value;
-    }
-    if(M->storage & NL_MATRIX_STORE_ROWS) {
-        nlRowColumnAdd(&(M->row[i]), j, value);
-    }
-    if(M->storage & NL_MATRIX_STORE_COLUMNS) {
-        nlRowColumnAdd(&(M->column[j]), i, value);
-    }
+	nl_parano_range_assert(i, 0, M->m - 1);
+	nl_parano_range_assert(j, 0, M->n - 1);
+	if((M->storage & NL_MATRIX_STORE_SYMMETRIC) && (j > i)) {
+		return;
+	}
+	if(i == j) {
+		M->diag[i] += value;
+	}
+	if(M->storage & NL_MATRIX_STORE_ROWS) {
+		nlRowColumnAdd(&(M->row[i]), j, value);
+	}
+	if(M->storage & NL_MATRIX_STORE_COLUMNS) {
+		nlRowColumnAdd(&(M->column[j]), i, value);
+	}
 }
 
 static void nlSparseMatrixAddSparseMatrix(
-    NLSparseMatrix* M, double mul, const NLSparseMatrix* N    
+	NLSparseMatrix* M, double mul, const NLSparseMatrix* N
 ) {
-    NLuint i,j,ii,jj;
-    nl_assert(M->m == N->m);
-    nl_assert(M->n == N->n);
-    if(N->storage & NL_MATRIX_STORE_SYMMETRIC) {
+	NLuint i,j,ii,jj;
+	nl_assert(M->m == N->m);
+	nl_assert(M->n == N->n);
+	if(N->storage & NL_MATRIX_STORE_SYMMETRIC) {
 	nl_assert(M->storage & NL_MATRIX_STORE_SYMMETRIC);
-    }
-    if(N->storage & NL_MATRIX_STORE_ROWS) {
+	}
+	if(N->storage & NL_MATRIX_STORE_ROWS) {
 	for(i=0; i<N->m; ++i) {
-	    for(jj=0; jj<N->row[i].size; ++jj) {
+		for(jj=0; jj<N->row[i].size; ++jj) {
 		nlSparseMatrixAdd(
-		    M,
-		    i, N->row[i].coeff[jj].index,
-		    mul*N->row[i].coeff[jj].value
+			M,
+			i, N->row[i].coeff[jj].index,
+			mul*N->row[i].coeff[jj].value
 		);
-	    }
+		}
 	}
-    } else {
-	nl_assert(N->storage & NL_MATRIX_STORE_COLUMNS);	
+	} else {
+	nl_assert(N->storage & NL_MATRIX_STORE_COLUMNS);
 	for(j=0; j<N->n; ++j) {
-	    for(ii=0; ii<N->column[j].size; ++ii) {
+		for(ii=0; ii<N->column[j].size; ++ii) {
 		nlSparseMatrixAdd(
-		    M,
-		    N->column[j].coeff[ii].index, j,
-		    mul*N->column[j].coeff[ii].value
+			M,
+			N->column[j].coeff[ii].index, j,
+			mul*N->column[j].coeff[ii].value
 		);
-	    }
+		}
 	}
-    }
+	}
 }
 
 static void nlSparseMatrixAddCRSMatrix(
-    NLSparseMatrix* M, double mul, const NLCRSMatrix* N    
+	NLSparseMatrix* M, double mul, const NLCRSMatrix* N
 ) {
-    NLuint i,jj;
-    nl_assert(M->m == N->m);
-    nl_assert(M->n == N->n);
-    for(i=0; i<M->m; ++i) {
+	NLuint i,jj;
+	nl_assert(M->m == N->m);
+	nl_assert(M->n == N->n);
+	for(i=0; i<M->m; ++i) {
 	for(jj=N->rowptr[i]; jj<N->rowptr[i+1]; ++jj) {
-	    nlSparseMatrixAdd(
+		nlSparseMatrixAdd(
 		M,
 		i,
 		N->colind[jj],
 		mul*N->val[jj]
-	    );
+		);
 	}
-    }
+	}
 }
 
 void nlSparseMatrixAddMatrix(
-    NLSparseMatrix* M, double mul, const NLMatrix N
+	NLSparseMatrix* M, double mul, const NLMatrix N
 ) {
-    nl_assert(M->m == N->m);
-    nl_assert(M->n == N->n);
-    if(N->type == NL_MATRIX_SPARSE_DYNAMIC) {
+	nl_assert(M->m == N->m);
+	nl_assert(M->n == N->n);
+	if(N->type == NL_MATRIX_SPARSE_DYNAMIC) {
 	nlSparseMatrixAddSparseMatrix(M, mul, (const NLSparseMatrix*)N);
-    } else if(N->type == NL_MATRIX_CRS) {
-	nlSparseMatrixAddCRSMatrix(M, mul, (const NLCRSMatrix*)N);	
-    } else {
+	} else if(N->type == NL_MATRIX_CRS) {
+	nlSparseMatrixAddCRSMatrix(M, mul, (const NLCRSMatrix*)N);
+	} else {
 	nl_assert_not_reached;
-    }
+	}
 }
-    
+
 
 
 void nlSparseMatrixZero( NLSparseMatrix* M) {
-    NLuint i;
-    if(M->storage & NL_MATRIX_STORE_ROWS) {
-        for(i=0; i<M->m; i++) {
-            nlRowColumnZero(&(M->row[i]));
-        }
-    }
-    if(M->storage & NL_MATRIX_STORE_COLUMNS) {
-        for(i=0; i<M->n; i++) {
-            nlRowColumnZero(&(M->column[i]));
-        }
-    }
-    NL_CLEAR_ARRAY(NLdouble, M->diag, M->diag_size);
+	NLuint i;
+	if(M->storage & NL_MATRIX_STORE_ROWS) {
+		for(i=0; i<M->m; i++) {
+			nlRowColumnZero(&(M->row[i]));
+		}
+	}
+	if(M->storage & NL_MATRIX_STORE_COLUMNS) {
+		for(i=0; i<M->n; i++) {
+			nlRowColumnZero(&(M->column[i]));
+		}
+	}
+	NL_CLEAR_ARRAY(NLdouble, M->diag, M->diag_size);
 }
 
 void nlSparseMatrixClear( NLSparseMatrix* M) {
-    NLuint i;
-    if(M->storage & NL_MATRIX_STORE_ROWS) {
-        for(i=0; i<M->m; i++) {
-            nlRowColumnClear(&(M->row[i]));
-        }
-    }
-    if(M->storage & NL_MATRIX_STORE_COLUMNS) {
-        for(i=0; i<M->n; i++) {
-            nlRowColumnClear(&(M->column[i]));
-        }
-    }
-    NL_CLEAR_ARRAY(NLdouble, M->diag, M->diag_size);
+	NLuint i;
+	if(M->storage & NL_MATRIX_STORE_ROWS) {
+		for(i=0; i<M->m; i++) {
+			nlRowColumnClear(&(M->row[i]));
+		}
+	}
+	if(M->storage & NL_MATRIX_STORE_COLUMNS) {
+		for(i=0; i<M->n; i++) {
+			nlRowColumnClear(&(M->column[i]));
+		}
+	}
+	NL_CLEAR_ARRAY(NLdouble, M->diag, M->diag_size);
 }
 
 /* Returns the number of non-zero coefficients */
 NLuint nlSparseMatrixNNZ( NLSparseMatrix* M) {
-    NLuint nnz = 0;
-    NLuint i;
-    if(M->storage & NL_MATRIX_STORE_ROWS) {
-        for(i = 0; i<M->m; i++) {
-            nnz += M->row[i].size;
-        }
-    } else if (M->storage & NL_MATRIX_STORE_COLUMNS) {
-        for(i = 0; i<M->n; i++) {
-            nnz += M->column[i].size;
-        }
-    } else {
-        nl_assert_not_reached;
-    }
-    return nnz;
+	NLuint nnz = 0;
+	NLuint i;
+	if(M->storage & NL_MATRIX_STORE_ROWS) {
+		for(i = 0; i<M->m; i++) {
+			nnz += M->row[i].size;
+		}
+	} else if (M->storage & NL_MATRIX_STORE_COLUMNS) {
+		for(i = 0; i<M->n; i++) {
+			nnz += M->column[i].size;
+		}
+	} else {
+		nl_assert_not_reached;
+	}
+	return nnz;
 }
 
 void nlSparseMatrixSort( NLSparseMatrix* M) {
-    NLuint i;
-    if(M->storage & NL_MATRIX_STORE_ROWS) {
-        for(i = 0; i<M->m; i++) {
-            nlRowColumnSort(&(M->row[i]));                
-        }
-    } 
-    if (M->storage & NL_MATRIX_STORE_COLUMNS) {
-        for(i = 0; i<M->n; i++) {
-            nlRowColumnSort(&(M->column[i]));
-        }
-    } 
+	NLuint i;
+	if(M->storage & NL_MATRIX_STORE_ROWS) {
+		for(i = 0; i<M->m; i++) {
+			nlRowColumnSort(&(M->row[i]));
+		}
+	}
+	if (M->storage & NL_MATRIX_STORE_COLUMNS) {
+		for(i = 0; i<M->n; i++) {
+			nlRowColumnSort(&(M->column[i]));
+		}
+	}
 }
 
 
 /* SparseMatrix x Vector routines, internal helper routines */
 
 static void nlSparseMatrix_mult_rows_symmetric(
-    NLSparseMatrix* A,
-    const NLdouble* x,
-    NLdouble* y
+	NLSparseMatrix* A,
+	const NLdouble* x,
+	NLdouble* y
 ) {
-    NLuint m = A->m;
-    NLuint i,ij;
-    NLCoeff* c = NULL;
-    for(i=0; i<m; i++) {
-        NLRowColumn* Ri = &(A->row[i]);
-        y[i] = 0;
-        for(ij=0; ij<Ri->size; ij++) {
-            c = &(Ri->coeff[ij]);
-            y[i] += c->value * x[c->index];
-            if(i != c->index) {
-                y[c->index] += c->value * x[i];
-            }
-        }
-    }
+	NLuint m = A->m;
+	NLuint i,ij;
+	NLCoeff* c = NULL;
+	for(i=0; i<m; i++) {
+		NLRowColumn* Ri = &(A->row[i]);
+		y[i] = 0;
+		for(ij=0; ij<Ri->size; ij++) {
+			c = &(Ri->coeff[ij]);
+			y[i] += c->value * x[c->index];
+			if(i != c->index) {
+				y[c->index] += c->value * x[i];
+			}
+		}
+	}
 }
 
 static void nlSparseMatrix_mult_rows(
-        NLSparseMatrix* A,
-        const NLdouble* x,
-        NLdouble* y
+		NLSparseMatrix* A,
+		const NLdouble* x,
+		NLdouble* y
 ) {
-    /* 
-     * Note: OpenMP does not like unsigned ints
-     * (causes some floating point exceptions),
-     * therefore I use here signed ints for all
-     * indices.
-     */
-    
-    int m = (int)(A->m);
-    int i,ij;
-    NLCoeff* c = NULL;
-    NLRowColumn* Ri = NULL;
+	/*
+	 * Note: OpenMP does not like unsigned ints
+	 * (causes some floating point exceptions),
+	 * therefore I use here signed ints for all
+	 * indices.
+	 */
 
-#if defined(_OPENMP)    
+	int m = (int)(A->m);
+	int i,ij;
+	NLCoeff* c = NULL;
+	NLRowColumn* Ri = NULL;
+
+#if defined(_OPENMP)
 #pragma omp parallel for private(i,ij,c,Ri)
 #endif
-    
-    for(i=0; i<m; i++) {
-        Ri = &(A->row[i]);       
-        y[i] = 0;
-        for(ij=0; ij<(int)(Ri->size); ij++) {
-            c = &(Ri->coeff[ij]);
-            y[i] += c->value * x[c->index];
-        }
-    }
+
+	for(i=0; i<m; i++) {
+		Ri = &(A->row[i]);
+		y[i] = 0;
+		for(ij=0; ij<(int)(Ri->size); ij++) {
+			c = &(Ri->coeff[ij]);
+			y[i] += c->value * x[c->index];
+		}
+	}
 }
 
 static void nlSparseMatrix_mult_cols_symmetric(
-        NLSparseMatrix* A,
-        const NLdouble* x,
-        NLdouble* y
+		NLSparseMatrix* A,
+		const NLdouble* x,
+		NLdouble* y
 ) {
-    NLuint n = A->n;
-    NLuint j,ii;
-    NLCoeff* c = NULL;
-    for(j=0; j<n; j++) {
-        NLRowColumn* Cj = &(A->column[j]);       
-        y[j] = 0;
-        for(ii=0; ii<Cj->size; ii++) {
-            c = &(Cj->coeff[ii]);
-            y[c->index] += c->value * x[j];
-            if(j != c->index) {
-                y[j] += c->value * x[c->index];
-            }
-        }
-    }
+	NLuint n = A->n;
+	NLuint j,ii;
+	NLCoeff* c = NULL;
+	for(j=0; j<n; j++) {
+		NLRowColumn* Cj = &(A->column[j]);
+		y[j] = 0;
+		for(ii=0; ii<Cj->size; ii++) {
+			c = &(Cj->coeff[ii]);
+			y[c->index] += c->value * x[j];
+			if(j != c->index) {
+				y[j] += c->value * x[c->index];
+			}
+		}
+	}
 }
 
 static void nlSparseMatrix_mult_cols(
-        NLSparseMatrix* A,
-        const NLdouble* x,
-        NLdouble* y
+		NLSparseMatrix* A,
+		const NLdouble* x,
+		NLdouble* y
 ) {
-    NLuint n = A->n;
-    NLuint j,ii; 
-    NLCoeff* c = NULL;
-    NL_CLEAR_ARRAY(NLdouble, y, A->m);
-    for(j=0; j<n; j++) {
-        NLRowColumn* Cj = &(A->column[j]);
-        for(ii=0; ii<Cj->size; ii++) {
-            c = &(Cj->coeff[ii]);
-            y[c->index] += c->value * x[j];
-        }
-    }
+	NLuint n = A->n;
+	NLuint j,ii;
+	NLCoeff* c = NULL;
+	NL_CLEAR_ARRAY(NLdouble, y, A->m);
+	for(j=0; j<n; j++) {
+		NLRowColumn* Cj = &(A->column[j]);
+		for(ii=0; ii<Cj->size; ii++) {
+			c = &(Cj->coeff[ii]);
+			y[c->index] += c->value * x[j];
+		}
+	}
 }
 
 static void nlSparseMatrixMult(
-    NLSparseMatrix* A, const NLdouble* x, NLdouble* y
+	NLSparseMatrix* A, const NLdouble* x, NLdouble* y
 ) {
-    nl_assert(A->type == NL_MATRIX_SPARSE_DYNAMIC);
-    if(A->storage & NL_MATRIX_STORE_ROWS) {
-        if(A->storage & NL_MATRIX_STORE_SYMMETRIC) {
-            nlSparseMatrix_mult_rows_symmetric(A, x, y);
-        } else {
-            nlSparseMatrix_mult_rows(A, x, y);
-        }
-    } else {
-        if(A->storage & NL_MATRIX_STORE_SYMMETRIC) {
-            nlSparseMatrix_mult_cols_symmetric(A, x, y);
-        } else {
-            nlSparseMatrix_mult_cols(A, x, y);
-        }
-    }
+	nl_assert(A->type == NL_MATRIX_SPARSE_DYNAMIC);
+	if(A->storage & NL_MATRIX_STORE_ROWS) {
+		if(A->storage & NL_MATRIX_STORE_SYMMETRIC) {
+			nlSparseMatrix_mult_rows_symmetric(A, x, y);
+		} else {
+			nlSparseMatrix_mult_rows(A, x, y);
+		}
+	} else {
+		if(A->storage & NL_MATRIX_STORE_SYMMETRIC) {
+			nlSparseMatrix_mult_cols_symmetric(A, x, y);
+		} else {
+			nlSparseMatrix_mult_cols(A, x, y);
+		}
+	}
 }
 
 void nlSparseMatrixConstruct(
-    NLSparseMatrix* M, NLuint m, NLuint n, NLenum storage
+	NLSparseMatrix* M, NLuint m, NLuint n, NLenum storage
 ) {
-    NLuint i;
-    M->m = m;
-    M->n = n;
-    M->type = NL_MATRIX_SPARSE_DYNAMIC;
-    M->destroy_func = (NLDestroyMatrixFunc)nlSparseMatrixDestroy;
-    M->mult_func = (NLMultMatrixVectorFunc)nlSparseMatrixMult;
-    M->storage = storage;
-    if(storage & NL_MATRIX_STORE_ROWS) {
-        M->row = NL_NEW_ARRAY(NLRowColumn, m);
-        for(i=0; i<n; i++) {
-            nlRowColumnConstruct(&(M->row[i]));
-        }
-    } else {
-        M->row = NULL;
-    }
+	NLuint i;
+	M->m = m;
+	M->n = n;
+	M->type = NL_MATRIX_SPARSE_DYNAMIC;
+	M->destroy_func = (NLDestroyMatrixFunc)nlSparseMatrixDestroy;
+	M->mult_func = (NLMultMatrixVectorFunc)nlSparseMatrixMult;
+	M->storage = storage;
+	if(storage & NL_MATRIX_STORE_ROWS) {
+		M->row = NL_NEW_ARRAY(NLRowColumn, m);
+		for(i=0; i<n; i++) {
+			nlRowColumnConstruct(&(M->row[i]));
+		}
+	} else {
+		M->row = NULL;
+	}
 
-    if(storage & NL_MATRIX_STORE_COLUMNS) {
-        M->column = NL_NEW_ARRAY(NLRowColumn, n);
-        for(i=0; i<n; i++) {
-            nlRowColumnConstruct(&(M->column[i]));
-        }
-    } else {
-        M->column = NULL;
-    }
+	if(storage & NL_MATRIX_STORE_COLUMNS) {
+		M->column = NL_NEW_ARRAY(NLRowColumn, n);
+		for(i=0; i<n; i++) {
+			nlRowColumnConstruct(&(M->column[i]));
+		}
+	} else {
+		M->column = NULL;
+	}
 
-    M->diag_size = MIN(m,n);
-    M->diag = NL_NEW_ARRAY(NLdouble, M->diag_size);
+	M->diag_size = MIN(m,n);
+	M->diag = NL_NEW_ARRAY(NLdouble, M->diag_size);
 }
 
 
 
 NLMatrix nlCRSMatrixNewFromSparseMatrix(NLSparseMatrix* M) {
-    NLuint nnz = nlSparseMatrixNNZ(M);
-    NLuint nslices = 8; /* TODO: get number of cores */
-    NLuint slice, cur_bound, cur_NNZ, cur_row;
-    NLuint i,ij,k; 
-    NLuint slice_size = nnz / nslices;
-    NLCRSMatrix* CRS = NL_NEW(NLCRSMatrix);
+	NLuint nnz = nlSparseMatrixNNZ(M);
+	NLuint nslices = 8; /* TODO: get number of cores */
+	NLuint slice, cur_bound, cur_NNZ, cur_row;
+	NLuint i,ij,k;
+	NLuint slice_size = nnz / nslices;
+	NLCRSMatrix* CRS = NL_NEW(NLCRSMatrix);
 
-    nl_assert(M->storage & NL_MATRIX_STORE_ROWS);
+	nl_assert(M->storage & NL_MATRIX_STORE_ROWS);
 
-    if(M->storage & NL_MATRIX_STORE_SYMMETRIC) {
-        nl_assert(M->m == M->n);
-        nlCRSMatrixConstructSymmetric(CRS, M->n, nnz);        
-    } else {
-        nlCRSMatrixConstruct(CRS, M->m, M->n, nnz, nslices);
-    }
-    
-    nlSparseMatrixSort(M);
-    /* Convert matrix to CRS format */
-    k=0;
-    for(i=0; i<M->m; ++i) {
-        NLRowColumn* Ri = &(M->row[i]);
-        CRS->rowptr[i] = k;
-        for(ij=0; ij<Ri->size; ij++) {
-            NLCoeff* c = &(Ri->coeff[ij]);
-            CRS->val[k] = c->value;
-            CRS->colind[k] = c->index;
-            ++k;
-        }
-    }
-    CRS->rowptr[M->m] = k;
-        
-    /* Create "slices" to be used by parallel sparse matrix vector product */
-    if(CRS->sliceptr != NULL) {
+	if(M->storage & NL_MATRIX_STORE_SYMMETRIC) {
+		nl_assert(M->m == M->n);
+		nlCRSMatrixConstructSymmetric(CRS, M->n, nnz);
+	} else {
+		nlCRSMatrixConstruct(CRS, M->m, M->n, nnz, nslices);
+	}
+
+	nlSparseMatrixSort(M);
+	/* Convert matrix to CRS format */
+	k=0;
+	for(i=0; i<M->m; ++i) {
+		NLRowColumn* Ri = &(M->row[i]);
+		CRS->rowptr[i] = k;
+		for(ij=0; ij<Ri->size; ij++) {
+			NLCoeff* c = &(Ri->coeff[ij]);
+			CRS->val[k] = c->value;
+			CRS->colind[k] = c->index;
+			++k;
+		}
+	}
+	CRS->rowptr[M->m] = k;
+
+	/* Create "slices" to be used by parallel sparse matrix vector product */
+	if(CRS->sliceptr != NULL) {
 	cur_bound = slice_size;
 	cur_NNZ = 0;
 	cur_row = 0;
 	CRS->sliceptr[0]=0;
 	for(slice=1; slice<nslices; ++slice) {
-	    while(cur_NNZ < cur_bound && cur_row < M->m) {
+		while(cur_NNZ < cur_bound && cur_row < M->m) {
 		++cur_row;
 		cur_NNZ += CRS->rowptr[cur_row+1] - CRS->rowptr[cur_row];
-	    }
-	    CRS->sliceptr[slice] = cur_row;
-	    cur_bound += slice_size;
+		}
+		CRS->sliceptr[slice] = cur_row;
+		cur_bound += slice_size;
 	}
 	CRS->sliceptr[nslices]=M->m;
-    }
-    return (NLMatrix)CRS;
+	}
+	return (NLMatrix)CRS;
 }
 
 NLMatrix nlCRSMatrixNewFromSparseMatrixSymmetric(NLSparseMatrix* M) {
-    NLuint nnz;
-    NLuint i,j,jj,k;
-    NLCRSMatrix* CRS = NL_NEW(NLCRSMatrix);
-    
-    nl_assert(M->storage & NL_MATRIX_STORE_ROWS);
-    nl_assert(M->m == M->n);
+	NLuint nnz;
+	NLuint i,j,jj,k;
+	NLCRSMatrix* CRS = NL_NEW(NLCRSMatrix);
 
-    nlSparseMatrixSort(M);
-    
-    if(M->storage & NL_MATRIX_STORE_SYMMETRIC) {
-        nnz = nlSparseMatrixNNZ(M);
-    } else {
-        nnz = 0;
-        for(i=0; i<M->n; ++i) {
-            NLRowColumn* Ri = &M->row[i];
-            for(jj=0; jj<Ri->size; ++jj) {
-                j = Ri->coeff[jj].index;
-                if(j <= i) {
-                    ++nnz;
-                }
-            }
-        }
-    }
+	nl_assert(M->storage & NL_MATRIX_STORE_ROWS);
+	nl_assert(M->m == M->n);
 
-    nlCRSMatrixConstructSymmetric(CRS, M->n, nnz);        
+	nlSparseMatrixSort(M);
 
-    k=0;
-    for(i=0; i<M->m; ++i) {
-        NLRowColumn* Ri = &(M->row[i]);
-        CRS->rowptr[i] = k;
-        for(jj=0; jj<Ri->size; ++jj) {
-            j = Ri->coeff[jj].index;
-            if((M->storage & NL_MATRIX_STORE_SYMMETRIC)) {
-                nl_debug_assert(j <= i);
-            }
-            if(j <= i) {
-                CRS->val[k] = Ri->coeff[jj].value;
-                CRS->colind[k] = j;
-                ++k;
-            }
-        }
-    }
-    CRS->rowptr[M->m] = k;
+	if(M->storage & NL_MATRIX_STORE_SYMMETRIC) {
+		nnz = nlSparseMatrixNNZ(M);
+	} else {
+		nnz = 0;
+		for(i=0; i<M->n; ++i) {
+			NLRowColumn* Ri = &M->row[i];
+			for(jj=0; jj<Ri->size; ++jj) {
+				j = Ri->coeff[jj].index;
+				if(j <= i) {
+					++nnz;
+				}
+			}
+		}
+	}
 
-    return (NLMatrix)CRS;
+	nlCRSMatrixConstructSymmetric(CRS, M->n, nnz);
+
+	k=0;
+	for(i=0; i<M->m; ++i) {
+		NLRowColumn* Ri = &(M->row[i]);
+		CRS->rowptr[i] = k;
+		for(jj=0; jj<Ri->size; ++jj) {
+			j = Ri->coeff[jj].index;
+			if((M->storage & NL_MATRIX_STORE_SYMMETRIC)) {
+				nl_debug_assert(j <= i);
+			}
+			if(j <= i) {
+				CRS->val[k] = Ri->coeff[jj].value;
+				CRS->colind[k] = j;
+				++k;
+			}
+		}
+	}
+	CRS->rowptr[M->m] = k;
+
+	return (NLMatrix)CRS;
 }
 
 
 void nlMatrixCompress(NLMatrix* M) {
-    NLMatrix CRS = NULL;
-    if((*M)->type != NL_MATRIX_SPARSE_DYNAMIC) {
-        return;
-    }
-    CRS = nlCRSMatrixNewFromSparseMatrix((NLSparseMatrix*)*M);
-    nlDeleteMatrix(*M);
-    *M = CRS;
+	NLMatrix CRS = NULL;
+	if((*M)->type != NL_MATRIX_SPARSE_DYNAMIC) {
+		return;
+	}
+	CRS = nlCRSMatrixNewFromSparseMatrix((NLSparseMatrix*)*M);
+	nlDeleteMatrix(*M);
+	*M = CRS;
 }
 
 NLuint nlMatrixNNZ(NLMatrix M) {
-    if(M->type == NL_MATRIX_SPARSE_DYNAMIC) {
+	if(M->type == NL_MATRIX_SPARSE_DYNAMIC) {
 	return nlSparseMatrixNNZ((NLSparseMatrix*)M);
-    } else if(M->type == NL_MATRIX_CRS) {
-	return nlCRSMatrixNNZ((NLCRSMatrix*)M);	
-    }
-    return M->m * M->n;
+	} else if(M->type == NL_MATRIX_CRS) {
+	return nlCRSMatrixNNZ((NLCRSMatrix*)M);
+	}
+	return M->m * M->n;
 }
 
 NLMatrix nlMatrixFactorize(NLMatrix M, NLenum solver) {
-    NLMatrix result = NULL;
-    switch(solver) {
+	NLMatrix result = NULL;
+	switch(solver) {
 	case NL_SUPERLU_EXT:
-	case NL_PERM_SUPERLU_EXT:      
+	case NL_PERM_SUPERLU_EXT:
 	case NL_SYMMETRIC_SUPERLU_EXT:
-	    result = nlMatrixFactorize_SUPERLU(M,solver);
-	    break;
+		result = nlMatrixFactorize_SUPERLU(M,solver);
+		break;
 	case NL_CHOLMOD_EXT:
-	    result = nlMatrixFactorize_CHOLMOD(M,solver);	    
-	    break;
+		result = nlMatrixFactorize_CHOLMOD(M,solver);
+		break;
 	default:
-	    nlError("nlMatrixFactorize","unknown solver");
-    }
-    return result;
+		nlError("nlMatrixFactorize","unknown solver");
+	}
+	return result;
 }
 
 
 
 typedef struct {
-    NLuint m;
+	NLuint m;
 
-    NLuint n;
+	NLuint n;
 
-    NLenum type;
+	NLenum type;
 
-    NLDestroyMatrixFunc destroy_func;
+	NLDestroyMatrixFunc destroy_func;
 
-    NLMultMatrixVectorFunc mult_func;
+	NLMultMatrixVectorFunc mult_func;
 
-    NLMatrixFunc matrix_func;
+	NLMatrixFunc matrix_func;
 } NLFunctionMatrix;
 
 static void nlFunctionMatrixDestroy(NLFunctionMatrix* M) {
-    (void)M; /* to avoid 'unused parameter' warning */
-    /* 
-     * Nothing special to do, 
-     * there is no dynamic allocated mem.
-     */
+	(void)M; /* to avoid 'unused parameter' warning */
+	/*
+	 * Nothing special to do,
+	 * there is no dynamic allocated mem.
+	 */
 }
 
 static void nlFunctionMatrixMult(NLFunctionMatrix* M, const NLdouble* x, NLdouble* y) {
-    M->matrix_func(x,y);
+	M->matrix_func(x,y);
 }
 
 NLMatrix nlMatrixNewFromFunction(NLuint m, NLuint n, NLMatrixFunc func) {
-    NLFunctionMatrix* result = NL_NEW(NLFunctionMatrix);
-    result->m = m;
-    result->n = n;
-    result->type = NL_MATRIX_FUNCTION;
-    result->destroy_func = (NLDestroyMatrixFunc)nlFunctionMatrixDestroy;
-    result->mult_func = (NLMultMatrixVectorFunc)nlFunctionMatrixMult;
-    result->matrix_func = func;
-    return (NLMatrix)result;
+	NLFunctionMatrix* result = NL_NEW(NLFunctionMatrix);
+	result->m = m;
+	result->n = n;
+	result->type = NL_MATRIX_FUNCTION;
+	result->destroy_func = (NLDestroyMatrixFunc)nlFunctionMatrixDestroy;
+	result->mult_func = (NLMultMatrixVectorFunc)nlFunctionMatrixMult;
+	result->matrix_func = func;
+	return (NLMatrix)result;
 }
 
 NLMatrixFunc nlMatrixGetFunction(NLMatrix M) {
-    if(M == NULL) {
+	if(M == NULL) {
 	return NULL;
-    }
-    if(M->type != NL_MATRIX_FUNCTION) {
+	}
+	if(M->type != NL_MATRIX_FUNCTION) {
 	return NULL;
-    }
-    return ((NLFunctionMatrix*)M)->matrix_func;
+	}
+	return ((NLFunctionMatrix*)M)->matrix_func;
 }
 
 
 
 typedef struct {
-    NLuint m;
+	NLuint m;
 
-    NLuint n;
+	NLuint n;
 
-    NLenum type;
+	NLenum type;
 
-    NLDestroyMatrixFunc destroy_func;
+	NLDestroyMatrixFunc destroy_func;
 
-    NLMultMatrixVectorFunc mult_func;
+	NLMultMatrixVectorFunc mult_func;
 
-    NLMatrixFunc matrix_func;
+	NLMatrixFunc matrix_func;
 
-    NLMatrix M;
+	NLMatrix M;
 
-    NLboolean owns_M;
-    
-    NLMatrix N;
+	NLboolean owns_M;
 
-    NLboolean owns_N;
-    
-    NLdouble* work;
+	NLMatrix N;
+
+	NLboolean owns_N;
+
+	NLdouble* work;
 } NLMatrixProduct;
 
 
 static void nlMatrixProductDestroy(NLMatrixProduct* P) {
-    NL_DELETE_ARRAY(P->work);
-    if(P->owns_M) {
+	NL_DELETE_ARRAY(P->work);
+	if(P->owns_M) {
 	nlDeleteMatrix(P->M); P->M = NULL;
-    }
-    if(P->owns_N) {
+	}
+	if(P->owns_N) {
 	nlDeleteMatrix(P->N); P->N = NULL;
-    }
+	}
 }
 
 static void nlMatrixProductMult(NLMatrixProduct* P, const NLdouble* x, NLdouble* y) {
-    nlMultMatrixVector(P->N, x, P->work);
-    nlMultMatrixVector(P->M, P->work, y);
+	nlMultMatrixVector(P->N, x, P->work);
+	nlMultMatrixVector(P->M, P->work, y);
 }
 
 NLMatrix nlMatrixNewFromProduct(NLMatrix M, NLboolean owns_M, NLMatrix N, NLboolean owns_N) {
-    NLMatrixProduct* result = NL_NEW(NLMatrixProduct);
-    nl_assert(M->n == N->m);
-    result->m = M->m;
-    result->n = N->n;
-    result->type = NL_MATRIX_OTHER;
-    result->work = NL_NEW_ARRAY(NLdouble,N->m);
-    result->destroy_func = (NLDestroyMatrixFunc)nlMatrixProductDestroy;
-    result->mult_func = (NLMultMatrixVectorFunc)nlMatrixProductMult;
-    result->M = M;
-    result->owns_M = owns_M;
-    result->N = N;
-    result->owns_N = owns_N;
-    return (NLMatrix)result;
+	NLMatrixProduct* result = NL_NEW(NLMatrixProduct);
+	nl_assert(M->n == N->m);
+	result->m = M->m;
+	result->n = N->n;
+	result->type = NL_MATRIX_OTHER;
+	result->work = NL_NEW_ARRAY(NLdouble,N->m);
+	result->destroy_func = (NLDestroyMatrixFunc)nlMatrixProductDestroy;
+	result->mult_func = (NLMultMatrixVectorFunc)nlMatrixProductMult;
+	result->M = M;
+	result->owns_M = owns_M;
+	result->N = N;
+	result->owns_N = owns_N;
+	return (NLMatrix)result;
 }
 
 
@@ -1733,213 +1733,213 @@ NLMatrix nlMatrixNewFromProduct(NLMatrix M, NLboolean owns_M, NLMatrix N, NLbool
 NLContextStruct* nlCurrentContext = NULL;
 
 NLContext nlNewContext() {
-    NLContextStruct* result     = NL_NEW(NLContextStruct);
-    result->state               = NL_STATE_INITIAL;
-    result->solver              = NL_SOLVER_DEFAULT;
-    result->max_iterations      = 100;
-    result->threshold           = 1e-6;
-    result->omega               = 1.5;
-    result->row_scaling         = 1.0;
-    result->inner_iterations    = 5;
-    result->solver_func         = nlDefaultSolver;
-    result->progress_func       = NULL;
-    result->verbose             = NL_FALSE;
-    result->nb_systems          = 1;
-    result->matrix_mode         = NL_STIFFNESS_MATRIX;
-    nlMakeCurrent(result);
-    return result;
+	NLContextStruct* result     = NL_NEW(NLContextStruct);
+	result->state               = NL_STATE_INITIAL;
+	result->solver              = NL_SOLVER_DEFAULT;
+	result->max_iterations      = 100;
+	result->threshold           = 1e-6;
+	result->omega               = 1.5;
+	result->row_scaling         = 1.0;
+	result->inner_iterations    = 5;
+	result->solver_func         = nlDefaultSolver;
+	result->progress_func       = NULL;
+	result->verbose             = NL_FALSE;
+	result->nb_systems          = 1;
+	result->matrix_mode         = NL_STIFFNESS_MATRIX;
+	nlMakeCurrent(result);
+	return result;
 }
 
 void nlDeleteContext(NLContext context_in) {
-    NLContextStruct* context = (NLContextStruct*)(context_in);
-    if(nlCurrentContext == context) {
-        nlCurrentContext = NULL;
-    }
+	NLContextStruct* context = (NLContextStruct*)(context_in);
+	if(nlCurrentContext == context) {
+		nlCurrentContext = NULL;
+	}
 
-    nlDeleteMatrix(context->M);
-    context->M = NULL;
+	nlDeleteMatrix(context->M);
+	context->M = NULL;
 
-    nlDeleteMatrix(context->P);
-    context->P = NULL;
+	nlDeleteMatrix(context->P);
+	context->P = NULL;
 
-    nlDeleteMatrix(context->B);
-    context->B = NULL;
-    
-    nlRowColumnDestroy(&context->af);
-    nlRowColumnDestroy(&context->al);
+	nlDeleteMatrix(context->B);
+	context->B = NULL;
 
-    NL_DELETE_ARRAY(context->variable_value);
-    NL_DELETE_ARRAY(context->variable_buffer);
-    NL_DELETE_ARRAY(context->variable_is_locked);
-    NL_DELETE_ARRAY(context->variable_index);
-    
-    NL_DELETE_ARRAY(context->x);
-    NL_DELETE_ARRAY(context->b);
-    NL_DELETE_ARRAY(context->right_hand_side);
+	nlRowColumnDestroy(&context->af);
+	nlRowColumnDestroy(&context->al);
 
-    NL_DELETE_ARRAY(context->eigen_value);
-    
+	NL_DELETE_ARRAY(context->variable_value);
+	NL_DELETE_ARRAY(context->variable_buffer);
+	NL_DELETE_ARRAY(context->variable_is_locked);
+	NL_DELETE_ARRAY(context->variable_index);
+
+	NL_DELETE_ARRAY(context->x);
+	NL_DELETE_ARRAY(context->b);
+	NL_DELETE_ARRAY(context->right_hand_side);
+
+	NL_DELETE_ARRAY(context->eigen_value);
+
 #ifdef NL_PARANOID
-    NL_CLEAR(NLContextStruct, context);
+	NL_CLEAR(NLContextStruct, context);
 #endif
-    NL_DELETE(context);
+	NL_DELETE(context);
 }
 
 void nlMakeCurrent(NLContext context) {
-    nlCurrentContext = (NLContextStruct*)(context);
+	nlCurrentContext = (NLContextStruct*)(context);
 }
 
 NLContext nlGetCurrent() {
-    return nlCurrentContext;
+	return nlCurrentContext;
 }
 
 
 /* Finite state automaton   */
 
 void nlCheckState(NLenum state) {
-    nl_assert(nlCurrentContext->state == state);
+	nl_assert(nlCurrentContext->state == state);
 }
 
 void nlTransition(NLenum from_state, NLenum to_state) {
-    nlCheckState(from_state);
-    nlCurrentContext->state = to_state;
+	nlCheckState(from_state);
+	nlCurrentContext->state = to_state;
 }
 
 
 /* Preconditioner setup and default solver */
 
 static void nlSetupPreconditioner() {
-    /* Check compatibility between solver and preconditioner */
-    if(
-        nlCurrentContext->solver == NL_BICGSTAB && 
-        nlCurrentContext->preconditioner == NL_PRECOND_SSOR
-    ) {
-        nlWarning(
-            "nlSolve", 
-            "cannot use SSOR preconditioner with non-symmetric matrix, "
-	    "switching to Jacobi"
-        );
-        nlCurrentContext->preconditioner = NL_PRECOND_JACOBI;        
-    }
-    if(
-        nlCurrentContext->solver == NL_GMRES && 
-        nlCurrentContext->preconditioner != NL_PRECOND_NONE
-    ) {
-        nlWarning("nlSolve", "Preconditioner not implemented yet for GMRES");
-        nlCurrentContext->preconditioner = NL_PRECOND_NONE;        
-    }
-    if(
-        nlCurrentContext->solver == NL_SUPERLU_EXT && 
-        nlCurrentContext->preconditioner != NL_PRECOND_NONE
-    ) {
-        nlWarning("nlSolve", "Preconditioner not implemented yet for SUPERLU");
-        nlCurrentContext->preconditioner = NL_PRECOND_NONE;        
-    }
-    if(
-        nlCurrentContext->solver == NL_CHOLMOD_EXT && 
-        nlCurrentContext->preconditioner != NL_PRECOND_NONE
-    ) {
-        nlWarning("nlSolve", "Preconditioner not implemented yet for CHOLMOD");
-        nlCurrentContext->preconditioner = NL_PRECOND_NONE;        
-    }
-    if(
-        nlCurrentContext->solver == NL_PERM_SUPERLU_EXT && 
-        nlCurrentContext->preconditioner != NL_PRECOND_NONE
-    ) {
-        nlWarning(
-	    "nlSolve", "Preconditioner not implemented yet for PERMSUPERLU"
+	/* Check compatibility between solver and preconditioner */
+	if(
+		nlCurrentContext->solver == NL_BICGSTAB &&
+		nlCurrentContext->preconditioner == NL_PRECOND_SSOR
+	) {
+		nlWarning(
+			"nlSolve",
+			"cannot use SSOR preconditioner with non-symmetric matrix, "
+		"switching to Jacobi"
+		);
+		nlCurrentContext->preconditioner = NL_PRECOND_JACOBI;
+	}
+	if(
+		nlCurrentContext->solver == NL_GMRES &&
+		nlCurrentContext->preconditioner != NL_PRECOND_NONE
+	) {
+		nlWarning("nlSolve", "Preconditioner not implemented yet for GMRES");
+		nlCurrentContext->preconditioner = NL_PRECOND_NONE;
+	}
+	if(
+		nlCurrentContext->solver == NL_SUPERLU_EXT &&
+		nlCurrentContext->preconditioner != NL_PRECOND_NONE
+	) {
+		nlWarning("nlSolve", "Preconditioner not implemented yet for SUPERLU");
+		nlCurrentContext->preconditioner = NL_PRECOND_NONE;
+	}
+	if(
+		nlCurrentContext->solver == NL_CHOLMOD_EXT &&
+		nlCurrentContext->preconditioner != NL_PRECOND_NONE
+	) {
+		nlWarning("nlSolve", "Preconditioner not implemented yet for CHOLMOD");
+		nlCurrentContext->preconditioner = NL_PRECOND_NONE;
+	}
+	if(
+		nlCurrentContext->solver == NL_PERM_SUPERLU_EXT &&
+		nlCurrentContext->preconditioner != NL_PRECOND_NONE
+	) {
+		nlWarning(
+		"nlSolve", "Preconditioner not implemented yet for PERMSUPERLU"
 	);
-        nlCurrentContext->preconditioner = NL_PRECOND_NONE;        
-    }
-    if(
-        nlCurrentContext->solver == NL_SYMMETRIC_SUPERLU_EXT && 
-        nlCurrentContext->preconditioner != NL_PRECOND_NONE
-    ) {
-        nlWarning(
-	    "nlSolve", "Preconditioner not implemented yet for PERMSUPERLU"
+		nlCurrentContext->preconditioner = NL_PRECOND_NONE;
+	}
+	if(
+		nlCurrentContext->solver == NL_SYMMETRIC_SUPERLU_EXT &&
+		nlCurrentContext->preconditioner != NL_PRECOND_NONE
+	) {
+		nlWarning(
+		"nlSolve", "Preconditioner not implemented yet for PERMSUPERLU"
 	);
-        nlCurrentContext->preconditioner = NL_PRECOND_NONE;        
-    }
+		nlCurrentContext->preconditioner = NL_PRECOND_NONE;
+	}
 
-    nlDeleteMatrix(nlCurrentContext->P);
-    nlCurrentContext->P = NULL;
-    
-    switch(nlCurrentContext->preconditioner) {
-    case NL_PRECOND_NONE:
-        break;
-    case NL_PRECOND_JACOBI:
+	nlDeleteMatrix(nlCurrentContext->P);
+	nlCurrentContext->P = NULL;
+
+	switch(nlCurrentContext->preconditioner) {
+	case NL_PRECOND_NONE:
+		break;
+	case NL_PRECOND_JACOBI:
 	nlCurrentContext->P = nlNewJacobiPreconditioner(nlCurrentContext->M);
-        break;
-    case NL_PRECOND_SSOR:
+		break;
+	case NL_PRECOND_SSOR:
 	nlCurrentContext->P = nlNewSSORPreconditioner(
-	    nlCurrentContext->M,nlCurrentContext->omega
-	);	
-        break;
-    case NL_PRECOND_USER:
-        break;
-    default:
-        nl_assert_not_reached;
-    }
+		nlCurrentContext->M,nlCurrentContext->omega
+	);
+		break;
+	case NL_PRECOND_USER:
+		break;
+	default:
+		nl_assert_not_reached;
+	}
 
-    if(nlCurrentContext->preconditioner != NL_PRECOND_SSOR) {
-        if(getenv("NL_LOW_MEM") == NULL) {
-            nlMatrixCompress(&nlCurrentContext->M);
-        }
-    }
+	if(nlCurrentContext->preconditioner != NL_PRECOND_SSOR) {
+		if(getenv("NL_LOW_MEM") == NULL) {
+			nlMatrixCompress(&nlCurrentContext->M);
+		}
+	}
 }
 
 static NLboolean nlSolveDirect() {
-    NLdouble* b = nlCurrentContext->b;
-    NLdouble* x = nlCurrentContext->x;
-    NLuint n = nlCurrentContext->n;
-    NLuint k;
-    
-    NLMatrix F = nlMatrixFactorize(
+	NLdouble* b = nlCurrentContext->b;
+	NLdouble* x = nlCurrentContext->x;
+	NLuint n = nlCurrentContext->n;
+	NLuint k;
+
+	NLMatrix F = nlMatrixFactorize(
 	nlCurrentContext->M, nlCurrentContext->solver
-    );
-    if(F == NULL) {
+	);
+	if(F == NULL) {
 	return NL_FALSE;
-    }
-    for(k=0; k<nlCurrentContext->nb_systems; ++k) {
+	}
+	for(k=0; k<nlCurrentContext->nb_systems; ++k) {
 	nlMultMatrixVector(F, b, x);
 	b += n;
 	x += n;
-    }
-    nlDeleteMatrix(F);
-    return NL_TRUE;
+	}
+	nlDeleteMatrix(F);
+	return NL_TRUE;
 }
 
 static NLboolean nlSolveIterative() {
-    NLdouble* b = nlCurrentContext->b;
-    NLdouble* x = nlCurrentContext->x;
-    NLuint n = nlCurrentContext->n;
-    NLuint k;
-    for(k=0; k<nlCurrentContext->nb_systems; ++k) {
+	NLdouble* b = nlCurrentContext->b;
+	NLdouble* x = nlCurrentContext->x;
+	NLuint n = nlCurrentContext->n;
+	NLuint k;
+	for(k=0; k<nlCurrentContext->nb_systems; ++k) {
 	nlSolveSystemIterative(
-	    nlCurrentContext->M,
-	    nlCurrentContext->P,
-	    b,
-	    x,
-	    nlCurrentContext->solver,
-	    nlCurrentContext->threshold,
-	    nlCurrentContext->max_iterations,
-	    nlCurrentContext->inner_iterations
+		nlCurrentContext->M,
+		nlCurrentContext->P,
+		b,
+		x,
+		nlCurrentContext->solver,
+		nlCurrentContext->threshold,
+		nlCurrentContext->max_iterations,
+		nlCurrentContext->inner_iterations
 	);
 	b += n;
 	x += n;
-    }
-    return NL_TRUE;
+	}
+	return NL_TRUE;
 }
 
 
 NLboolean nlDefaultSolver() {
-    NLboolean result = NL_TRUE;
-    nlSetupPreconditioner();
-    switch(nlCurrentContext->solver) {
+	NLboolean result = NL_TRUE;
+	nlSetupPreconditioner();
+	switch(nlCurrentContext->solver) {
 	case NL_CG:
 	case NL_BICGSTAB:
 	case NL_GMRES: {
-	    result = nlSolveIterative();
+		result = nlSolveIterative();
 	} break;
 	case NL_CNC_FLOAT_CRS_EXT:
 	case NL_CNC_DOUBLE_CRS_EXT:
@@ -1949,19 +1949,19 @@ NLboolean nlDefaultSolver() {
 	case NL_CNC_DOUBLE_ELL_EXT:
 	case NL_CNC_FLOAT_HYB_EXT:
 	case NL_CNC_DOUBLE_HYB_EXT: {
-	    nlSolve_CNC();
-	    result = NL_TRUE;
+		nlSolve_CNC();
+		result = NL_TRUE;
 	} break;
-	case NL_SUPERLU_EXT: 
-	case NL_PERM_SUPERLU_EXT: 
-	case NL_SYMMETRIC_SUPERLU_EXT: 
+	case NL_SUPERLU_EXT:
+	case NL_PERM_SUPERLU_EXT:
+	case NL_SYMMETRIC_SUPERLU_EXT:
 	case NL_CHOLMOD_EXT: {
-	    result = nlSolveDirect();
+		result = nlSolveDirect();
 	} break;
 	default:
-	    nl_assert_not_reached;
-    }
-    return result;
+		nl_assert_not_reached;
+	}
+	return result;
 }
 
 /******* extracted from nl_blas.c *******/
@@ -1979,11 +1979,11 @@ NLboolean nlDefaultSolver() {
 
 #ifdef NL_USE_ATLAS
 int NL_FORTRAN_WRAP(xerbla)(char *srname, int *info) {
-    printf("** On entry to %6s, parameter number %2d had an illegal value\n",
-              srname, *info
-    );
-    return 0;
-} 
+	printf("** On entry to %6s, parameter number %2d had an illegal value\n",
+			  srname, *info
+	);
+	return 0;
+}
 #ifndef NL_USE_BLAS
 #define NL_USE_BLAS
 #endif
@@ -1992,7 +1992,7 @@ int NL_FORTRAN_WRAP(xerbla)(char *srname, int *info) {
 #ifdef NL_USE_SUPERLU
 #ifndef NL_USE_BLAS
 #define NL_USE_BLAS
-/* 
+/*
  * The BLAS included in SuperLU does not have DTPSV,
  * we use the DTPSV embedded in OpenNL.
  */
@@ -2037,379 +2037,379 @@ typedef NLint     ftnlen ;
 
 static int NL_FORTRAN_WRAP(lsame)(const char *ca, const char *cb)
 {
-/*  -- LAPACK auxiliary routine (version 2.0) --   
-       Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
-       Courant Institute, Argonne National Lab, and Rice University   
-       September 30, 1994   
+/*  -- LAPACK auxiliary routine (version 2.0) --
+	   Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,
+	   Courant Institute, Argonne National Lab, and Rice University
+	   September 30, 1994
 
-    Purpose   
-    =======   
+	Purpose
+	=======
 
-    LSAME returns .TRUE. if CA is the same letter as CB regardless of case.   
+	LSAME returns .TRUE. if CA is the same letter as CB regardless of case.
 
-    Arguments   
-    =========   
+	Arguments
+	=========
 
-    CA      (input) CHARACTER*1   
-    CB      (input) CHARACTER*1   
-            CA and CB specify the single characters to be compared.   
+	CA      (input) CHARACTER*1
+	CB      (input) CHARACTER*1
+			CA and CB specify the single characters to be compared.
 
-   ===================================================================== 
-*/  
+   =====================================================================
+*/
 
-    /* System generated locals */
-    int ret_val;
-    
-    /* Local variables */
-    int inta, intb, zcode;
+	/* System generated locals */
+	int ret_val;
 
-    ret_val = *(unsigned char *)ca == *(unsigned char *)cb;
-    if (ret_val) {
-        return ret_val;
-    }
+	/* Local variables */
+	int inta, intb, zcode;
 
-    /* Now test for equivalence if both characters are alphabetic. */
+	ret_val = *(unsigned char *)ca == *(unsigned char *)cb;
+	if (ret_val) {
+		return ret_val;
+	}
 
-    zcode = 'Z';
+	/* Now test for equivalence if both characters are alphabetic. */
 
-    /* Use 'Z' rather than 'A' so that ASCII can be detected on Prime   
-       machines, on which ICHAR returns a value with bit 8 set.   
-       ICHAR('A') on Prime machines returns 193 which is the same as   
-       ICHAR('A') on an EBCDIC machine. */
+	zcode = 'Z';
 
-    inta = *(unsigned char *)ca;
-    intb = *(unsigned char *)cb;
+	/* Use 'Z' rather than 'A' so that ASCII can be detected on Prime
+	   machines, on which ICHAR returns a value with bit 8 set.
+	   ICHAR('A') on Prime machines returns 193 which is the same as
+	   ICHAR('A') on an EBCDIC machine. */
 
-    if (zcode == 90 || zcode == 122) {
-        /* ASCII is assumed - ZCODE is the ASCII code of either lower or   
-          upper case 'Z'. */
-        if (inta >= 97 && inta <= 122) inta += -32;
-        if (intb >= 97 && intb <= 122) intb += -32;
+	inta = *(unsigned char *)ca;
+	intb = *(unsigned char *)cb;
 
-    } else if (zcode == 233 || zcode == 169) {
-        /* EBCDIC is assumed - ZCODE is the EBCDIC code of either lower or   
-          upper case 'Z'. */
-        if ((inta >= 129 && inta <= 137) || 
-            (inta >= 145 && inta <= 153) || 
-            (inta >= 162 && inta <= 169)
-        )
-            inta += 64;
-        if (
-            (intb >= 129 && intb <= 137) || 
-            (intb >= 145 && intb <= 153) || 
-            (intb >= 162 && intb <= 169)
-        )
-            intb += 64;
-    } else if (zcode == 218 || zcode == 250) {
-        /* ASCII is assumed, on Prime machines - ZCODE is the ASCII code   
-          plus 128 of either lower or upper case 'Z'. */
-        if (inta >= 225 && inta <= 250) inta += -32;
-        if (intb >= 225 && intb <= 250) intb += -32;
-    }
-    ret_val = inta == intb;
-    return ret_val;
-    
+	if (zcode == 90 || zcode == 122) {
+		/* ASCII is assumed - ZCODE is the ASCII code of either lower or
+		  upper case 'Z'. */
+		if (inta >= 97 && inta <= 122) inta += -32;
+		if (intb >= 97 && intb <= 122) intb += -32;
+
+	} else if (zcode == 233 || zcode == 169) {
+		/* EBCDIC is assumed - ZCODE is the EBCDIC code of either lower or
+		  upper case 'Z'. */
+		if ((inta >= 129 && inta <= 137) ||
+			(inta >= 145 && inta <= 153) ||
+			(inta >= 162 && inta <= 169)
+		)
+			inta += 64;
+		if (
+			(intb >= 129 && intb <= 137) ||
+			(intb >= 145 && intb <= 153) ||
+			(intb >= 162 && intb <= 169)
+		)
+			intb += 64;
+	} else if (zcode == 218 || zcode == 250) {
+		/* ASCII is assumed, on Prime machines - ZCODE is the ASCII code
+		  plus 128 of either lower or upper case 'Z'. */
+		if (inta >= 225 && inta <= 250) inta += -32;
+		if (intb >= 225 && intb <= 250) intb += -32;
+	}
+	ret_val = inta == intb;
+	return ret_val;
+
 } /* lsame_ */
 
 /* Subroutine */ static int NL_FORTRAN_WRAP(xerbla)(const char *srname, int *info)
 {
-/*  -- LAPACK auxiliary routine (version 2.0) --   
-       Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,   
-       Courant Institute, Argonne National Lab, and Rice University   
-       September 30, 1994   
+/*  -- LAPACK auxiliary routine (version 2.0) --
+	   Univ. of Tennessee, Univ. of California Berkeley, NAG Ltd.,
+	   Courant Institute, Argonne National Lab, and Rice University
+	   September 30, 1994
 
 
-    Purpose   
-    =======   
+	Purpose
+	=======
 
-    XERBLA  is an error handler for the LAPACK routines.   
-    It is called by an LAPACK routine if an input parameter has an   
-    invalid value.  A message is printed and execution stops.   
+	XERBLA  is an error handler for the LAPACK routines.
+	It is called by an LAPACK routine if an input parameter has an
+	invalid value.  A message is printed and execution stops.
 
-    Installers may consider modifying the STOP statement in order to   
-    call system-specific exception-handling facilities.   
+	Installers may consider modifying the STOP statement in order to
+	call system-specific exception-handling facilities.
 
-    Arguments   
-    =========   
+	Arguments
+	=========
 
-    SRNAME  (input) CHARACTER*6   
-            The name of the routine which called XERBLA.   
+	SRNAME  (input) CHARACTER*6
+			The name of the routine which called XERBLA.
 
-    INFO    (input) INT   
-            The position of the invalid parameter in the parameter list   
+	INFO    (input) INT
+			The position of the invalid parameter in the parameter list
 
-            of the calling routine.   
+			of the calling routine.
 
-   ===================================================================== 
+   =====================================================================
 */
 
-    printf("** On entry to %6s, parameter number %2d had an illegal value\n",
-                srname, *info);
+	printf("** On entry to %6s, parameter number %2d had an illegal value\n",
+				srname, *info);
 
 /*     End of XERBLA */
 
-    return 0;
+	return 0;
 } /* xerbla_ */
 
 
-/* Subroutine */ static int NL_FORTRAN_WRAP(daxpy)(integer *n, doublereal *da, doublereal *dx, 
-        integer *incx, doublereal *dy, integer *incy)
+/* Subroutine */ static int NL_FORTRAN_WRAP(daxpy)(integer *n, doublereal *da, doublereal *dx,
+		integer *incx, doublereal *dy, integer *incy)
 {
 
 
-    /* System generated locals */
-    integer i__1;
+	/* System generated locals */
+	integer i__1;
 
-    /* Local variables */
-    static integer i, m, ix, iy, mp1;
-
-
-/*     constant times a vector plus a vector.   
-       uses unrolled loops for increments equal to one.   
-       jack dongarra, linpack, 3/11/78.   
-       modified 12/3/93, array(1) declarations changed to array(*)   
+	/* Local variables */
+	static integer i, m, ix, iy, mp1;
 
 
-    
-   Parameter adjustments   
-       Function Body */
+/*     constant times a vector plus a vector.
+	   uses unrolled loops for increments equal to one.
+	   jack dongarra, linpack, 3/11/78.
+	   modified 12/3/93, array(1) declarations changed to array(*)
+
+
+
+   Parameter adjustments
+	   Function Body */
 #define DY(I) dy[(I)-1]
 #define DX(I) dx[(I)-1]
 
 
-    if (*n <= 0) {
-        return 0;
-    }
-    if (*da == 0.) {
-        return 0;
-    }
-    if (*incx == 1 && *incy == 1) {
-        goto L20;
-    }
+	if (*n <= 0) {
+		return 0;
+	}
+	if (*da == 0.) {
+		return 0;
+	}
+	if (*incx == 1 && *incy == 1) {
+		goto L20;
+	}
 
-/*        code for unequal increments or equal increments   
-            not equal to 1 */
+/*        code for unequal increments or equal increments
+			not equal to 1 */
 
-    ix = 1;
-    iy = 1;
-    if (*incx < 0) {
-        ix = (-(*n) + 1) * *incx + 1;
-    }
-    if (*incy < 0) {
-        iy = (-(*n) + 1) * *incy + 1;
-    }
-    i__1 = *n;
-    for (i = 1; i <= *n; ++i) {
-        DY(iy) += *da * DX(ix);
-        ix += *incx;
-        iy += *incy;
+	ix = 1;
+	iy = 1;
+	if (*incx < 0) {
+		ix = (-(*n) + 1) * *incx + 1;
+	}
+	if (*incy < 0) {
+		iy = (-(*n) + 1) * *incy + 1;
+	}
+	i__1 = *n;
+	for (i = 1; i <= *n; ++i) {
+		DY(iy) += *da * DX(ix);
+		ix += *incx;
+		iy += *incy;
 /* L10: */
-    }
-    return 0;
+	}
+	return 0;
 
-/*        code for both increments equal to 1   
+/*        code for both increments equal to 1
 
 
-          clean-up loop */
+		  clean-up loop */
 
 L20:
-    m = *n % 4;
-    if (m == 0) {
-        goto L40;
-    }
-    i__1 = m;
-    for (i = 1; i <= m; ++i) {
-        DY(i) += *da * DX(i);
+	m = *n % 4;
+	if (m == 0) {
+		goto L40;
+	}
+	i__1 = m;
+	for (i = 1; i <= m; ++i) {
+		DY(i) += *da * DX(i);
 /* L30: */
-    }
-    if (*n < 4) {
-        return 0;
-    }
+	}
+	if (*n < 4) {
+		return 0;
+	}
 L40:
-    mp1 = m + 1;
-    i__1 = *n;
-    for (i = mp1; i <= *n; i += 4) {
-        DY(i) += *da * DX(i);
-        DY(i + 1) += *da * DX(i + 1);
-        DY(i + 2) += *da * DX(i + 2);
-        DY(i + 3) += *da * DX(i + 3);
+	mp1 = m + 1;
+	i__1 = *n;
+	for (i = mp1; i <= *n; i += 4) {
+		DY(i) += *da * DX(i);
+		DY(i + 1) += *da * DX(i + 1);
+		DY(i + 2) += *da * DX(i + 2);
+		DY(i + 3) += *da * DX(i + 3);
 /* L50: */
-    }
-    nl_arg_used(i__1);
-    return 0;
+	}
+	nl_arg_used(i__1);
+	return 0;
 } /* daxpy_ */
 #undef DY
 #undef DX
 
 
-static doublereal NL_FORTRAN_WRAP(ddot)(integer *n, doublereal *dx, integer *incx, doublereal *dy, 
-        integer *incy)
+static doublereal NL_FORTRAN_WRAP(ddot)(integer *n, doublereal *dx, integer *incx, doublereal *dy,
+		integer *incy)
 {
 
-    /* System generated locals */
-    integer i__1;
-    doublereal ret_val;
+	/* System generated locals */
+	integer i__1;
+	doublereal ret_val;
 
-    /* Local variables */
-    static integer i, m;
-    static doublereal dtemp;
-    static integer ix, iy, mp1;
-
-
-/*     forms the dot product of two vectors.   
-       uses unrolled loops for increments equal to one.   
-       jack dongarra, linpack, 3/11/78.   
-       modified 12/3/93, array(1) declarations changed to array(*)   
+	/* Local variables */
+	static integer i, m;
+	static doublereal dtemp;
+	static integer ix, iy, mp1;
 
 
-    
-   Parameter adjustments   
-       Function Body */
+/*     forms the dot product of two vectors.
+	   uses unrolled loops for increments equal to one.
+	   jack dongarra, linpack, 3/11/78.
+	   modified 12/3/93, array(1) declarations changed to array(*)
+
+
+
+   Parameter adjustments
+	   Function Body */
 #define DY(I) dy[(I)-1]
 #define DX(I) dx[(I)-1]
 
-    ret_val = 0.;
-    dtemp = 0.;
-    if (*n <= 0) {
-        return ret_val;
-    }
-    if (*incx == 1 && *incy == 1) {
-        goto L20;
-    }
+	ret_val = 0.;
+	dtemp = 0.;
+	if (*n <= 0) {
+		return ret_val;
+	}
+	if (*incx == 1 && *incy == 1) {
+		goto L20;
+	}
 
-/*        code for unequal increments or equal increments   
-            not equal to 1 */
+/*        code for unequal increments or equal increments
+			not equal to 1 */
 
-    ix = 1;
-    iy = 1;
-    if (*incx < 0) {
-        ix = (-(*n) + 1) * *incx + 1;
-    }
-    if (*incy < 0) {
-        iy = (-(*n) + 1) * *incy + 1;
-    }
-    i__1 = *n;
-    for (i = 1; i <= *n; ++i) {
-        dtemp += DX(ix) * DY(iy);
-        ix += *incx;
-        iy += *incy;
+	ix = 1;
+	iy = 1;
+	if (*incx < 0) {
+		ix = (-(*n) + 1) * *incx + 1;
+	}
+	if (*incy < 0) {
+		iy = (-(*n) + 1) * *incy + 1;
+	}
+	i__1 = *n;
+	for (i = 1; i <= *n; ++i) {
+		dtemp += DX(ix) * DY(iy);
+		ix += *incx;
+		iy += *incy;
 /* L10: */
-    }
-    ret_val = dtemp;
-    return ret_val;
+	}
+	ret_val = dtemp;
+	return ret_val;
 
-/*        code for both increments equal to 1   
+/*        code for both increments equal to 1
 
 
-          clean-up loop */
+		  clean-up loop */
 
 L20:
-    m = *n % 5;
-    if (m == 0) {
-        goto L40;
-    }
-    i__1 = m;
-    for (i = 1; i <= m; ++i) {
-        dtemp += DX(i) * DY(i);
+	m = *n % 5;
+	if (m == 0) {
+		goto L40;
+	}
+	i__1 = m;
+	for (i = 1; i <= m; ++i) {
+		dtemp += DX(i) * DY(i);
 /* L30: */
-    }
-    if (*n < 5) {
-        goto L60;
-    }
+	}
+	if (*n < 5) {
+		goto L60;
+	}
 L40:
-    mp1 = m + 1;
-    i__1 = *n;
-    for (i = mp1; i <= *n; i += 5) {
-        dtemp = dtemp + DX(i) * DY(i) + DX(i + 1) * DY(i + 1) + DX(i + 2) * 
-                DY(i + 2) + DX(i + 3) * DY(i + 3) + DX(i + 4) * DY(i + 4);
+	mp1 = m + 1;
+	i__1 = *n;
+	for (i = mp1; i <= *n; i += 5) {
+		dtemp = dtemp + DX(i) * DY(i) + DX(i + 1) * DY(i + 1) + DX(i + 2) *
+				DY(i + 2) + DX(i + 3) * DY(i + 3) + DX(i + 4) * DY(i + 4);
 /* L50: */
-    }
+	}
 L60:
-    ret_val = dtemp;
-    nl_arg_used(i__1);
-    return ret_val;
+	ret_val = dtemp;
+	nl_arg_used(i__1);
+	return ret_val;
 } /* ddot_ */
 #undef DY
 #undef DX
 
-/* Subroutine */ static int NL_FORTRAN_WRAP(dscal)(integer *n, doublereal *da, doublereal *dx, 
-    integer *incx)
+/* Subroutine */ static int NL_FORTRAN_WRAP(dscal)(integer *n, doublereal *da, doublereal *dx,
+	integer *incx)
 {
 
 
-    /* System generated locals */
-    integer i__1, i__2;
+	/* System generated locals */
+	integer i__1, i__2;
 
-    /* Local variables */
-    static integer i, m, nincx, mp1;
-
-
-/*     scales a vector by a constant.   
-       uses unrolled loops for increment equal to one.   
-       jack dongarra, linpack, 3/11/78.   
-       modified 3/93 to return if incx .le. 0.   
-       modified 12/3/93, array(1) declarations changed to array(*)   
+	/* Local variables */
+	static integer i, m, nincx, mp1;
 
 
-    
-   Parameter adjustments   
-       Function Body */
+/*     scales a vector by a constant.
+	   uses unrolled loops for increment equal to one.
+	   jack dongarra, linpack, 3/11/78.
+	   modified 3/93 to return if incx .le. 0.
+	   modified 12/3/93, array(1) declarations changed to array(*)
+
+
+
+   Parameter adjustments
+	   Function Body */
 #ifdef DX
 #undef DX
 #endif
 #define DX(I) dx[(I)-1]
 
 
-    if (*n <= 0 || *incx <= 0) {
-        return 0;
-    }
-    if (*incx == 1) {
-        goto L20;
-    }
+	if (*n <= 0 || *incx <= 0) {
+		return 0;
+	}
+	if (*incx == 1) {
+		goto L20;
+	}
 
 /*        code for increment not equal to 1 */
 
-    nincx = *n * *incx;
-    i__1 = nincx;
-    i__2 = *incx;
-    for (i = 1; *incx < 0 ? i >= nincx : i <= nincx; i += *incx) {
-        DX(i) = *da * DX(i);
+	nincx = *n * *incx;
+	i__1 = nincx;
+	i__2 = *incx;
+	for (i = 1; *incx < 0 ? i >= nincx : i <= nincx; i += *incx) {
+		DX(i) = *da * DX(i);
 /* L10: */
-    }
-    return 0;
+	}
+	return 0;
 
-/*        code for increment equal to 1   
+/*        code for increment equal to 1
 
 
-          clean-up loop */
+		  clean-up loop */
 
 L20:
-    m = *n % 5;
-    if (m == 0) {
-        goto L40;
-    }
-    i__2 = m;
-    for (i = 1; i <= m; ++i) {
-        DX(i) = *da * DX(i);
+	m = *n % 5;
+	if (m == 0) {
+		goto L40;
+	}
+	i__2 = m;
+	for (i = 1; i <= m; ++i) {
+		DX(i) = *da * DX(i);
 /* L30: */
-    }
-    if (*n < 5) {
-        return 0;
-    }
+	}
+	if (*n < 5) {
+		return 0;
+	}
 L40:
-    mp1 = m + 1;
-    i__2 = *n;
-    for (i = mp1; i <= *n; i += 5) {
-        DX(i) = *da * DX(i);
-        DX(i + 1) = *da * DX(i + 1);
-        DX(i + 2) = *da * DX(i + 2);
-        DX(i + 3) = *da * DX(i + 3);
-        DX(i + 4) = *da * DX(i + 4);
+	mp1 = m + 1;
+	i__2 = *n;
+	for (i = mp1; i <= *n; i += 5) {
+		DX(i) = *da * DX(i);
+		DX(i + 1) = *da * DX(i + 1);
+		DX(i + 2) = *da * DX(i + 2);
+		DX(i + 3) = *da * DX(i + 3);
+		DX(i + 4) = *da * DX(i + 4);
 /* L50: */
-    }
-    nl_arg_used(i__1);
-    nl_arg_used(i__2);
-    return 0;
+	}
+	nl_arg_used(i__1);
+	nl_arg_used(i__2);
+	return 0;
 } /* dscal_ */
 #undef DX
 
@@ -2417,465 +2417,465 @@ static doublereal NL_FORTRAN_WRAP(dnrm2)(integer *n, doublereal *x, integer *inc
 {
 
 
-    /* System generated locals */
-    integer i__1, i__2;
-    doublereal ret_val, d__1;
+	/* System generated locals */
+	integer i__1, i__2;
+	doublereal ret_val, d__1;
 
-    /* Builtin functions */
-    /* BL: already declared in the included <math.h>, 
-       we do not need it here. */
-    /*double sqrt(doublereal); */
+	/* Builtin functions */
+	/* BL: already declared in the included <math.h>,
+	   we do not need it here. */
+	/*double sqrt(doublereal); */
 
-    /* Local variables */
-    static doublereal norm, scale, absxi;
-    static integer ix;
-    static doublereal ssq;
-
-
-/*  DNRM2 returns the euclidean norm of a vector via the function   
-    name, so that   
-
-       DNRM2 := sqrt( x'*x )   
+	/* Local variables */
+	static doublereal norm, scale, absxi;
+	static integer ix;
+	static doublereal ssq;
 
 
+/*  DNRM2 returns the euclidean norm of a vector via the function
+	name, so that
 
-    -- This version written on 25-October-1982.   
-       Modified on 14-October-1993 to inline the call to DLASSQ.   
-       Sven Hammarling, Nag Ltd.   
+	   DNRM2 := sqrt( x'*x )
 
 
-    
-   Parameter adjustments   
-       Function Body */
+
+	-- This version written on 25-October-1982.
+	   Modified on 14-October-1993 to inline the call to DLASSQ.
+	   Sven Hammarling, Nag Ltd.
+
+
+
+   Parameter adjustments
+	   Function Body */
 #ifdef X
 #undef X
 #endif
 #define X(I) x[(I)-1]
 
 
-    if (*n < 1 || *incx < 1) {
-        norm = 0.;
-    } else if (*n == 1) {
-        norm = fabs(X(1));
-    } else {
-        scale = 0.;
-        ssq = 1.;
-/*        The following loop is equivalent to this call to the LAPACK 
-  
-          auxiliary routine:   
-          CALL DLASSQ( N, X, INCX, SCALE, SSQ ) */
+	if (*n < 1 || *incx < 1) {
+		norm = 0.;
+	} else if (*n == 1) {
+		norm = fabs(X(1));
+	} else {
+		scale = 0.;
+		ssq = 1.;
+/*        The following loop is equivalent to this call to the LAPACK
 
-        i__1 = (*n - 1) * *incx + 1;
-        i__2 = *incx;
-        for (ix = 1; *incx < 0 ? ix >= (*n-1)**incx+1 : ix <= (*n-1)**incx+1; ix += *incx) {
-            if (X(ix) != 0.) {
-                absxi = (d__1 = X(ix), fabs(d__1));
-                if (scale < absxi) {
+		  auxiliary routine:
+		  CALL DLASSQ( N, X, INCX, SCALE, SSQ ) */
+
+		i__1 = (*n - 1) * *incx + 1;
+		i__2 = *incx;
+		for (ix = 1; *incx < 0 ? ix >= (*n-1)**incx+1 : ix <= (*n-1)**incx+1; ix += *incx) {
+			if (X(ix) != 0.) {
+				absxi = (d__1 = X(ix), fabs(d__1));
+				if (scale < absxi) {
 /* Computing 2nd power */
-                    d__1 = scale / absxi;
-                    ssq = ssq * (d__1 * d__1) + 1.;
-                    scale = absxi;
-                } else {
+					d__1 = scale / absxi;
+					ssq = ssq * (d__1 * d__1) + 1.;
+					scale = absxi;
+				} else {
 /* Computing 2nd power */
-                    d__1 = absxi / scale;
-                    ssq += d__1 * d__1;
-                }
-            }
+					d__1 = absxi / scale;
+					ssq += d__1 * d__1;
+				}
+			}
 /* L10: */
-        }
-        norm = scale * sqrt(ssq);
-    }
+		}
+		norm = scale * sqrt(ssq);
+	}
 
-    ret_val = norm;
+	ret_val = norm;
 
-    nl_arg_used(i__1);
-    nl_arg_used(i__2);
+	nl_arg_used(i__1);
+	nl_arg_used(i__2);
 
-    return ret_val;
+	return ret_val;
 
 /*     End of DNRM2. */
 
 } /* dnrm2_ */
 #undef X
 
-/* Subroutine */ static int NL_FORTRAN_WRAP(dcopy)(integer *n, doublereal *dx, integer *incx, 
-        doublereal *dy, integer *incy)
+/* Subroutine */ static int NL_FORTRAN_WRAP(dcopy)(integer *n, doublereal *dx, integer *incx,
+		doublereal *dy, integer *incy)
 {
 
-    /* System generated locals */
-    integer i__1;
+	/* System generated locals */
+	integer i__1;
 
-    /* Local variables */
-    static integer i, m, ix, iy, mp1;
-
-
-/*     copies a vector, x, to a vector, y.   
-       uses unrolled loops for increments equal to one.   
-       jack dongarra, linpack, 3/11/78.   
-       modified 12/3/93, array(1) declarations changed to array(*)   
+	/* Local variables */
+	static integer i, m, ix, iy, mp1;
 
 
-    
-   Parameter adjustments   
-       Function Body */
+/*     copies a vector, x, to a vector, y.
+	   uses unrolled loops for increments equal to one.
+	   jack dongarra, linpack, 3/11/78.
+	   modified 12/3/93, array(1) declarations changed to array(*)
+
+
+
+   Parameter adjustments
+	   Function Body */
 #define DY(I) dy[(I)-1]
 #define DX(I) dx[(I)-1]
 
 
-    if (*n <= 0) {
-        return 0;
-    }
-    if (*incx == 1 && *incy == 1) {
-        goto L20;
-    }
+	if (*n <= 0) {
+		return 0;
+	}
+	if (*incx == 1 && *incy == 1) {
+		goto L20;
+	}
 
-/*        code for unequal increments or equal increments   
-            not equal to 1 */
+/*        code for unequal increments or equal increments
+			not equal to 1 */
 
-    ix = 1;
-    iy = 1;
-    if (*incx < 0) {
-        ix = (-(*n) + 1) * *incx + 1;
-    }
-    if (*incy < 0) {
-        iy = (-(*n) + 1) * *incy + 1;
-    }
-    i__1 = *n;
-    for (i = 1; i <= *n; ++i) {
-        DY(iy) = DX(ix);
-        ix += *incx;
-        iy += *incy;
+	ix = 1;
+	iy = 1;
+	if (*incx < 0) {
+		ix = (-(*n) + 1) * *incx + 1;
+	}
+	if (*incy < 0) {
+		iy = (-(*n) + 1) * *incy + 1;
+	}
+	i__1 = *n;
+	for (i = 1; i <= *n; ++i) {
+		DY(iy) = DX(ix);
+		ix += *incx;
+		iy += *incy;
 /* L10: */
-    }
-    return 0;
+	}
+	return 0;
 
-/*        code for both increments equal to 1   
+/*        code for both increments equal to 1
 
 
-          clean-up loop */
+		  clean-up loop */
 
 L20:
-    m = *n % 7;
-    if (m == 0) {
-        goto L40;
-    }
-    i__1 = m;
-    for (i = 1; i <= m; ++i) {
-        DY(i) = DX(i);
+	m = *n % 7;
+	if (m == 0) {
+		goto L40;
+	}
+	i__1 = m;
+	for (i = 1; i <= m; ++i) {
+		DY(i) = DX(i);
 /* L30: */
-    }
-    if (*n < 7) {
-        return 0;
-    }
+	}
+	if (*n < 7) {
+		return 0;
+	}
 L40:
-    mp1 = m + 1;
-    i__1 = *n;
-    for (i = mp1; i <= *n; i += 7) {
-        DY(i) = DX(i);
-        DY(i + 1) = DX(i + 1);
-        DY(i + 2) = DX(i + 2);
-        DY(i + 3) = DX(i + 3);
-        DY(i + 4) = DX(i + 4);
-        DY(i + 5) = DX(i + 5);
-        DY(i + 6) = DX(i + 6);
+	mp1 = m + 1;
+	i__1 = *n;
+	for (i = mp1; i <= *n; i += 7) {
+		DY(i) = DX(i);
+		DY(i + 1) = DX(i + 1);
+		DY(i + 2) = DX(i + 2);
+		DY(i + 3) = DX(i + 3);
+		DY(i + 4) = DX(i + 4);
+		DY(i + 5) = DX(i + 5);
+		DY(i + 6) = DX(i + 6);
 /* L50: */
-    }
-    nl_arg_used(i__1);
-    return 0;
+	}
+	nl_arg_used(i__1);
+	return 0;
 } /* dcopy_ */
 
 #undef DX
 #undef DY
 
 /* Subroutine */ static int NL_FORTRAN_WRAP(dgemv)(const char *trans, integer *m, integer *n, doublereal *
-        alpha, doublereal *a, integer *lda, doublereal *x, integer *incx, 
-        doublereal *beta, doublereal *y, integer *incy)
+		alpha, doublereal *a, integer *lda, doublereal *x, integer *incx,
+		doublereal *beta, doublereal *y, integer *incy)
 {
 
 
-    /* System generated locals */
-    /* integer a_dim1, a_offset ; */
-    integer i__1, i__2; 
+	/* System generated locals */
+	/* integer a_dim1, a_offset ; */
+	integer i__1, i__2;
 
-    /* Local variables */
-    static integer info;
-    static doublereal temp;
-    static integer lenx, leny, i, j;
+	/* Local variables */
+	static integer info;
+	static doublereal temp;
+	static integer lenx, leny, i, j;
 /*    extern logical lsame_(char *, char *); */
-    static integer ix, iy, jx, jy, kx, ky;
+	static integer ix, iy, jx, jy, kx, ky;
 /*    extern int xerbla_(char *, integer *); */
 
 
-/*  Purpose   
-    =======   
+/*  Purpose
+	=======
 
-    DGEMV  performs one of the matrix-vector operations   
+	DGEMV  performs one of the matrix-vector operations
 
-       y := alpha*A*x + beta*y,   or   y := alpha*A'*x + beta*y,   
+	   y := alpha*A*x + beta*y,   or   y := alpha*A'*x + beta*y,
 
-    where alpha and beta are scalars, x and y are vectors and A is an   
-    m by n matrix.   
+	where alpha and beta are scalars, x and y are vectors and A is an
+	m by n matrix.
 
-    Parameters   
-    ==========   
+	Parameters
+	==========
 
-    TRANS  - CHARACTER*1.   
-             On entry, TRANS specifies the operation to be performed as   
-             follows:   
+	TRANS  - CHARACTER*1.
+			 On entry, TRANS specifies the operation to be performed as
+			 follows:
 
-                TRANS = 'N' or 'n'   y := alpha*A*x + beta*y.   
+				TRANS = 'N' or 'n'   y := alpha*A*x + beta*y.
 
-                TRANS = 'T' or 't'   y := alpha*A'*x + beta*y.   
+				TRANS = 'T' or 't'   y := alpha*A'*x + beta*y.
 
-                TRANS = 'C' or 'c'   y := alpha*A'*x + beta*y.   
+				TRANS = 'C' or 'c'   y := alpha*A'*x + beta*y.
 
-             Unchanged on exit.   
+			 Unchanged on exit.
 
-    M      - INTEGER.   
-             On entry, M specifies the number of rows of the matrix A.   
-             M must be at least zero.   
-             Unchanged on exit.   
+	M      - INTEGER.
+			 On entry, M specifies the number of rows of the matrix A.
+			 M must be at least zero.
+			 Unchanged on exit.
 
-    N      - INTEGER.   
-             On entry, N specifies the number of columns of the matrix A. 
-  
-             N must be at least zero.   
-             Unchanged on exit.   
+	N      - INTEGER.
+			 On entry, N specifies the number of columns of the matrix A.
 
-    ALPHA  - DOUBLE PRECISION.   
-             On entry, ALPHA specifies the scalar alpha.   
-             Unchanged on exit.   
+			 N must be at least zero.
+			 Unchanged on exit.
 
-    A      - DOUBLE PRECISION array of DIMENSION ( LDA, n ).   
-             Before entry, the leading m by n part of the array A must   
-             contain the matrix of coefficients.   
-             Unchanged on exit.   
+	ALPHA  - DOUBLE PRECISION.
+			 On entry, ALPHA specifies the scalar alpha.
+			 Unchanged on exit.
 
-    LDA    - INTEGER.   
-             On entry, LDA specifies the first dimension of A as declared 
-  
-             in the calling (sub) program. LDA must be at least   
-             max( 1, m ).   
-             Unchanged on exit.   
+	A      - DOUBLE PRECISION array of DIMENSION ( LDA, n ).
+			 Before entry, the leading m by n part of the array A must
+			 contain the matrix of coefficients.
+			 Unchanged on exit.
 
-    X      - DOUBLE PRECISION array of DIMENSION at least   
-             ( 1 + ( n - 1 )*abs( INCX ) ) when TRANS = 'N' or 'n'   
-             and at least   
-             ( 1 + ( m - 1 )*abs( INCX ) ) otherwise.   
-             Before entry, the incremented array X must contain the   
-             vector x.   
-             Unchanged on exit.   
+	LDA    - INTEGER.
+			 On entry, LDA specifies the first dimension of A as declared
 
-    INCX   - INTEGER.   
-             On entry, INCX specifies the increment for the elements of   
-             X. INCX must not be zero.   
-             Unchanged on exit.   
+			 in the calling (sub) program. LDA must be at least
+			 max( 1, m ).
+			 Unchanged on exit.
 
-    BETA   - DOUBLE PRECISION.   
-             On entry, BETA specifies the scalar beta. When BETA is   
-             supplied as zero then Y need not be set on input.   
-             Unchanged on exit.   
+	X      - DOUBLE PRECISION array of DIMENSION at least
+			 ( 1 + ( n - 1 )*abs( INCX ) ) when TRANS = 'N' or 'n'
+			 and at least
+			 ( 1 + ( m - 1 )*abs( INCX ) ) otherwise.
+			 Before entry, the incremented array X must contain the
+			 vector x.
+			 Unchanged on exit.
 
-    Y      - DOUBLE PRECISION array of DIMENSION at least   
-             ( 1 + ( m - 1 )*abs( INCY ) ) when TRANS = 'N' or 'n'   
-             and at least   
-             ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.   
-             Before entry with BETA non-zero, the incremented array Y   
-             must contain the vector y. On exit, Y is overwritten by the 
-  
-             updated vector y.   
+	INCX   - INTEGER.
+			 On entry, INCX specifies the increment for the elements of
+			 X. INCX must not be zero.
+			 Unchanged on exit.
 
-    INCY   - INTEGER.   
-             On entry, INCY specifies the increment for the elements of   
-             Y. INCY must not be zero.   
-             Unchanged on exit.   
+	BETA   - DOUBLE PRECISION.
+			 On entry, BETA specifies the scalar beta. When BETA is
+			 supplied as zero then Y need not be set on input.
+			 Unchanged on exit.
 
+	Y      - DOUBLE PRECISION array of DIMENSION at least
+			 ( 1 + ( m - 1 )*abs( INCY ) ) when TRANS = 'N' or 'n'
+			 and at least
+			 ( 1 + ( n - 1 )*abs( INCY ) ) otherwise.
+			 Before entry with BETA non-zero, the incremented array Y
+			 must contain the vector y. On exit, Y is overwritten by the
 
-    Level 2 Blas routine.   
+			 updated vector y.
 
-    -- Written on 22-October-1986.   
-       Jack Dongarra, Argonne National Lab.   
-       Jeremy Du Croz, Nag Central Office.   
-       Sven Hammarling, Nag Central Office.   
-       Richard Hanson, Sandia National Labs.   
+	INCY   - INTEGER.
+			 On entry, INCY specifies the increment for the elements of
+			 Y. INCY must not be zero.
+			 Unchanged on exit.
 
 
+	Level 2 Blas routine.
 
-       Test the input parameters.   
+	-- Written on 22-October-1986.
+	   Jack Dongarra, Argonne National Lab.
+	   Jeremy Du Croz, Nag Central Office.
+	   Sven Hammarling, Nag Central Office.
+	   Richard Hanson, Sandia National Labs.
 
-    
-   Parameter adjustments   
-       Function Body */
+
+
+	   Test the input parameters.
+
+
+   Parameter adjustments
+	   Function Body */
 #define X(I) x[(I)-1]
 #define Y(I) y[(I)-1]
 
 #define A(I,J) a[(I)-1 + ((J)-1)* ( *lda)]
 
-    info = 0;
-    if (! NL_FORTRAN_WRAP(lsame)(trans, "N") && ! NL_FORTRAN_WRAP(lsame)(trans, "T") && ! 
-            NL_FORTRAN_WRAP(lsame)(trans, "C")) {
-        info = 1;
-    } else if (*m < 0) {
-        info = 2;
-    } else if (*n < 0) {
-        info = 3;
-    } else if (*lda < max(1,*m)) {
-        info = 6;
-    } else if (*incx == 0) {
-        info = 8;
-    } else if (*incy == 0) {
-        info = 11;
-    }
-    if (info != 0) {
-        NL_FORTRAN_WRAP(xerbla)("DGEMV ", &info);
-        return 0;
-    }
+	info = 0;
+	if (! NL_FORTRAN_WRAP(lsame)(trans, "N") && ! NL_FORTRAN_WRAP(lsame)(trans, "T") && !
+			NL_FORTRAN_WRAP(lsame)(trans, "C")) {
+		info = 1;
+	} else if (*m < 0) {
+		info = 2;
+	} else if (*n < 0) {
+		info = 3;
+	} else if (*lda < max(1,*m)) {
+		info = 6;
+	} else if (*incx == 0) {
+		info = 8;
+	} else if (*incy == 0) {
+		info = 11;
+	}
+	if (info != 0) {
+		NL_FORTRAN_WRAP(xerbla)("DGEMV ", &info);
+		return 0;
+	}
 
 /*     Quick return if possible. */
 
-    if (*m == 0 || *n == 0 || (*alpha == 0. && *beta == 1.)) {
-        return 0;
-    }
+	if (*m == 0 || *n == 0 || (*alpha == 0. && *beta == 1.)) {
+		return 0;
+	}
 
-/*     Set  LENX  and  LENY, the lengths of the vectors x and y, and set 
-  
-       up the start points in  X  and  Y. */
+/*     Set  LENX  and  LENY, the lengths of the vectors x and y, and set
 
-    if (NL_FORTRAN_WRAP(lsame)(trans, "N")) {
-        lenx = *n;
-        leny = *m;
-    } else {
-        lenx = *m;
-        leny = *n;
-    }
-    if (*incx > 0) {
-        kx = 1;
-    } else {
-        kx = 1 - (lenx - 1) * *incx;
-    }
-    if (*incy > 0) {
-        ky = 1;
-    } else {
-        ky = 1 - (leny - 1) * *incy;
-    }
+	   up the start points in  X  and  Y. */
 
-/*     Start the operations. In this version the elements of A are   
-       accessed sequentially with one pass through A.   
+	if (NL_FORTRAN_WRAP(lsame)(trans, "N")) {
+		lenx = *n;
+		leny = *m;
+	} else {
+		lenx = *m;
+		leny = *n;
+	}
+	if (*incx > 0) {
+		kx = 1;
+	} else {
+		kx = 1 - (lenx - 1) * *incx;
+	}
+	if (*incy > 0) {
+		ky = 1;
+	} else {
+		ky = 1 - (leny - 1) * *incy;
+	}
 
-       First form  y := beta*y. */
+/*     Start the operations. In this version the elements of A are
+	   accessed sequentially with one pass through A.
 
-    if (*beta != 1.) {
-        if (*incy == 1) {
-            if (*beta == 0.) {
-                i__1 = leny;
-                for (i = 1; i <= leny; ++i) {
-                    Y(i) = 0.;
+	   First form  y := beta*y. */
+
+	if (*beta != 1.) {
+		if (*incy == 1) {
+			if (*beta == 0.) {
+				i__1 = leny;
+				for (i = 1; i <= leny; ++i) {
+					Y(i) = 0.;
 /* L10: */
-                }
-            } else {
-                i__1 = leny;
-                for (i = 1; i <= leny; ++i) {
-                    Y(i) = *beta * Y(i);
+				}
+			} else {
+				i__1 = leny;
+				for (i = 1; i <= leny; ++i) {
+					Y(i) = *beta * Y(i);
 /* L20: */
-                }
-            }
-        } else {
-            iy = ky;
-            if (*beta == 0.) {
-                i__1 = leny;
-                for (i = 1; i <= leny; ++i) {
-                    Y(iy) = 0.;
-                    iy += *incy;
+				}
+			}
+		} else {
+			iy = ky;
+			if (*beta == 0.) {
+				i__1 = leny;
+				for (i = 1; i <= leny; ++i) {
+					Y(iy) = 0.;
+					iy += *incy;
 /* L30: */
-                }
-            } else {
-                i__1 = leny;
-                for (i = 1; i <= leny; ++i) {
-                    Y(iy) = *beta * Y(iy);
-                    iy += *incy;
+				}
+			} else {
+				i__1 = leny;
+				for (i = 1; i <= leny; ++i) {
+					Y(iy) = *beta * Y(iy);
+					iy += *incy;
 /* L40: */
-                }
-            }
-        }
-    }
-    if (*alpha == 0.) {
-        return 0;
-    }
-    if (NL_FORTRAN_WRAP(lsame)(trans, "N")) {
+				}
+			}
+		}
+	}
+	if (*alpha == 0.) {
+		return 0;
+	}
+	if (NL_FORTRAN_WRAP(lsame)(trans, "N")) {
 
 /*        Form  y := alpha*A*x + y. */
 
-        jx = kx;
-        if (*incy == 1) {
-            i__1 = *n;
-            for (j = 1; j <= *n; ++j) {
-                if (X(jx) != 0.) {
-                    temp = *alpha * X(jx);
-                    i__2 = *m;
-                    for (i = 1; i <= *m; ++i) {
-                        Y(i) += temp * A(i,j);
+		jx = kx;
+		if (*incy == 1) {
+			i__1 = *n;
+			for (j = 1; j <= *n; ++j) {
+				if (X(jx) != 0.) {
+					temp = *alpha * X(jx);
+					i__2 = *m;
+					for (i = 1; i <= *m; ++i) {
+						Y(i) += temp * A(i,j);
 /* L50: */
-                    }
-                }
-                jx += *incx;
+					}
+				}
+				jx += *incx;
 /* L60: */
-            }
-        } else {
-            i__1 = *n;
-            for (j = 1; j <= *n; ++j) {
-                if (X(jx) != 0.) {
-                    temp = *alpha * X(jx);
-                    iy = ky;
-                    i__2 = *m;
-                    for (i = 1; i <= *m; ++i) {
-                        Y(iy) += temp * A(i,j);
-                        iy += *incy;
+			}
+		} else {
+			i__1 = *n;
+			for (j = 1; j <= *n; ++j) {
+				if (X(jx) != 0.) {
+					temp = *alpha * X(jx);
+					iy = ky;
+					i__2 = *m;
+					for (i = 1; i <= *m; ++i) {
+						Y(iy) += temp * A(i,j);
+						iy += *incy;
 /* L70: */
-                    }
-                }
-                jx += *incx;
+					}
+				}
+				jx += *incx;
 /* L80: */
-            }
-        }
-    } else {
+			}
+		}
+	} else {
 
 /*        Form  y := alpha*A'*x + y. */
 
-        jy = ky;
-        if (*incx == 1) {
-            i__1 = *n;
-            for (j = 1; j <= *n; ++j) {
-                temp = 0.;
-                i__2 = *m;
-                for (i = 1; i <= *m; ++i) {
-                    temp += A(i,j) * X(i);
+		jy = ky;
+		if (*incx == 1) {
+			i__1 = *n;
+			for (j = 1; j <= *n; ++j) {
+				temp = 0.;
+				i__2 = *m;
+				for (i = 1; i <= *m; ++i) {
+					temp += A(i,j) * X(i);
 /* L90: */
-                }
-                Y(jy) += *alpha * temp;
-                jy += *incy;
+				}
+				Y(jy) += *alpha * temp;
+				jy += *incy;
 /* L100: */
-            }
-        } else {
-            i__1 = *n;
-            for (j = 1; j <= *n; ++j) {
-                temp = 0.;
-                ix = kx;
-                i__2 = *m;
-                for (i = 1; i <= *m; ++i) {
-                    temp += A(i,j) * X(ix);
-                    ix += *incx;
+			}
+		} else {
+			i__1 = *n;
+			for (j = 1; j <= *n; ++j) {
+				temp = 0.;
+				ix = kx;
+				i__2 = *m;
+				for (i = 1; i <= *m; ++i) {
+					temp += A(i,j) * X(ix);
+					ix += *incx;
 /* L110: */
-                }
-                Y(jy) += *alpha * temp;
-                jy += *incy;
+				}
+				Y(jy) += *alpha * temp;
+				jy += *incy;
 /* L120: */
-            }
-        }
-    }
+			}
+		}
+	}
 
-    nl_arg_used(i__1);
-    nl_arg_used(i__2);
-    return 0;
+	nl_arg_used(i__1);
+	nl_arg_used(i__2);
+	return 0;
 
 /*     End of DGEMV . */
 
@@ -2890,14 +2890,14 @@ L40:
 
 #else
 
-extern void NL_FORTRAN_WRAP(daxpy)( 
-    int *n, double *alpha, double *x,
-    int *incx, double *y, int *incy 
+extern void NL_FORTRAN_WRAP(daxpy)(
+	int *n, double *alpha, double *x,
+	int *incx, double *y, int *incy
 ) ;
 
-extern double NL_FORTRAN_WRAP(ddot)( 
-    int *n, double *x, int *incx, double *y,
-    int *incy 
+extern double NL_FORTRAN_WRAP(ddot)(
+	int *n, double *x, int *incx, double *y,
+	int *incy
 ) ;
 
 extern double NL_FORTRAN_WRAP(dnrm2)( int *n, double *x, int *incx ) ;
@@ -2907,17 +2907,17 @@ extern int NL_FORTRAN_WRAP(dcopy)(int* n, double* dx, int* incx, double* dy, int
 extern void NL_FORTRAN_WRAP(dscal)(int* n, double* alpha, double *x, int* incx) ;
 
 #ifndef NEEDS_DTPSV
-extern void NL_FORTRAN_WRAP(dtpsv)( 
-    char *uplo, char *trans, char *diag,
-    int *n, double *AP, double *x, int *incx 
+extern void NL_FORTRAN_WRAP(dtpsv)(
+	char *uplo, char *trans, char *diag,
+	int *n, double *AP, double *x, int *incx
 ) ;
 #endif
 
-extern void NL_FORTRAN_WRAP(dgemv)( 
-    char *trans, int *m, int *n,
-    double *alpha, double *A, int *ldA,
-    double *x, int *incx,
-    double *beta, double *y, int *incy 
+extern void NL_FORTRAN_WRAP(dgemv)(
+	char *trans, int *m, int *n,
+	double *alpha, double *A, int *ldA,
+	double *x, int *incx,
+	double *beta, double *y, int *incy
 ) ;
 
 #endif
@@ -2925,27 +2925,27 @@ extern void NL_FORTRAN_WRAP(dgemv)(
 #ifdef NEEDS_DTPSV
 
 /* DECK DTPSV */
-/* Subroutine */ 
+/* Subroutine */
 static int NL_FORTRAN_WRAP(dtpsv)(
-   const char* uplo, 
-   const char* trans, 
-   const char* diag, 
-   integer* n, 
-   doublereal* ap, 
-   doublereal* x, 
+   const char* uplo,
+   const char* trans,
+   const char* diag,
+   integer* n,
+   doublereal* ap,
+   doublereal* x,
    integer* incx
 ) {
-    /* System generated locals */
-    integer i__1, i__2;
+	/* System generated locals */
+	integer i__1, i__2;
 
-    /* Local variables */
-    static integer info;
-    static doublereal temp;
-    static integer i__, j, k;
+	/* Local variables */
+	static integer info;
+	static doublereal temp;
+	static integer i__, j, k;
 /*    extern logical lsame_(); */
-    static integer kk, ix, jx, kx;
+	static integer kk, ix, jx, kx;
 /*    extern int xerbla_(); */
-    static logical nounit;
+	static logical nounit;
 
 /* ***BEGIN PROLOGUE  DTPSV */
 /* ***PURPOSE  Solve one of the systems of equations. */
@@ -3057,240 +3057,240 @@ static int NL_FORTRAN_WRAP(dtpsv)(
 
 /*     Test the input parameters. */
 
-    /* Parameter adjustments */
-    --x;
-    --ap;
+	/* Parameter adjustments */
+	--x;
+	--ap;
 
-    /* Function Body */
-    info = 0;
-    if (!NL_FORTRAN_WRAP(lsame)(uplo, "U") && 
-        !NL_FORTRAN_WRAP(lsame)(uplo, "L")
-    ) {
-        info = 1;
-    } else if (
-        !NL_FORTRAN_WRAP(lsame)(trans, "N") && 
-        !NL_FORTRAN_WRAP(lsame)(trans, "T") && 
-        !NL_FORTRAN_WRAP(lsame)(trans, "C")
-    ) {
-        info = 2;
-    } else if (
-        !NL_FORTRAN_WRAP(lsame)(diag, "U") && 
-        !NL_FORTRAN_WRAP(lsame)(diag, "N")
-    ) {
-        info = 3;
-    } else if (*n < 0) {
-        info = 4;
-    } else if (*incx == 0) {
-        info = 7;
-    }
-    if (info != 0) {
-        NL_FORTRAN_WRAP(xerbla)("DTPSV ", &info);
-        return 0;
-    }
+	/* Function Body */
+	info = 0;
+	if (!NL_FORTRAN_WRAP(lsame)(uplo, "U") &&
+		!NL_FORTRAN_WRAP(lsame)(uplo, "L")
+	) {
+		info = 1;
+	} else if (
+		!NL_FORTRAN_WRAP(lsame)(trans, "N") &&
+		!NL_FORTRAN_WRAP(lsame)(trans, "T") &&
+		!NL_FORTRAN_WRAP(lsame)(trans, "C")
+	) {
+		info = 2;
+	} else if (
+		!NL_FORTRAN_WRAP(lsame)(diag, "U") &&
+		!NL_FORTRAN_WRAP(lsame)(diag, "N")
+	) {
+		info = 3;
+	} else if (*n < 0) {
+		info = 4;
+	} else if (*incx == 0) {
+		info = 7;
+	}
+	if (info != 0) {
+		NL_FORTRAN_WRAP(xerbla)("DTPSV ", &info);
+		return 0;
+	}
 
 /*     Quick return if possible. */
 
-    if (*n == 0) {
-        return 0;
-    }
+	if (*n == 0) {
+		return 0;
+	}
 
-    nounit = (logical)(NL_FORTRAN_WRAP(lsame)(diag, "N"));
+	nounit = (logical)(NL_FORTRAN_WRAP(lsame)(diag, "N"));
 
 /*     Set up the start point in X if the increment is not unity. This */
 /*     will be  ( N - 1 )*INCX  too small for descending loops. */
 
-    if (*incx <= 0) {
-        kx = 1 - (*n - 1) * *incx;
-    } else if (*incx != 1) {
-        kx = 1;
-    }
+	if (*incx <= 0) {
+		kx = 1 - (*n - 1) * *incx;
+	} else if (*incx != 1) {
+		kx = 1;
+	}
 
 /*     Start the operations. In this version the elements of AP are */
 /*     accessed sequentially with one pass through AP. */
 
-    if (NL_FORTRAN_WRAP(lsame)(trans, "N")) {
+	if (NL_FORTRAN_WRAP(lsame)(trans, "N")) {
 
 /*        Form  x := inv( A )*x. */
 
-        if (NL_FORTRAN_WRAP(lsame)(uplo, "U")) {
-            kk = *n * (*n + 1) / 2;
-            if (*incx == 1) {
-                for (j = *n; j >= 1; --j) {
-                    if (x[j] != 0.) {
-                        if (nounit) {
-                            x[j] /= ap[kk];
-                        }
-                        temp = x[j];
-                        k = kk - 1;
-                        for (i__ = j - 1; i__ >= 1; --i__) {
-                            x[i__] -= temp * ap[k];
-                            --k;
+		if (NL_FORTRAN_WRAP(lsame)(uplo, "U")) {
+			kk = *n * (*n + 1) / 2;
+			if (*incx == 1) {
+				for (j = *n; j >= 1; --j) {
+					if (x[j] != 0.) {
+						if (nounit) {
+							x[j] /= ap[kk];
+						}
+						temp = x[j];
+						k = kk - 1;
+						for (i__ = j - 1; i__ >= 1; --i__) {
+							x[i__] -= temp * ap[k];
+							--k;
 /* L10: */
-                        }
-                    }
-                    kk -= j;
+						}
+					}
+					kk -= j;
 /* L20: */
-                }
-            } else {
-                jx = kx + (*n - 1) * *incx;
-                for (j = *n; j >= 1; --j) {
-                    if (x[jx] != 0.) {
-                        if (nounit) {
-                            x[jx] /= ap[kk];
-                        }
-                        temp = x[jx];
-                        ix = jx;
-                        i__1 = kk - j + 1;
-                        for (k = kk - 1; k >= i__1; --k) {
-                            ix -= *incx;
-                            x[ix] -= temp * ap[k];
+				}
+			} else {
+				jx = kx + (*n - 1) * *incx;
+				for (j = *n; j >= 1; --j) {
+					if (x[jx] != 0.) {
+						if (nounit) {
+							x[jx] /= ap[kk];
+						}
+						temp = x[jx];
+						ix = jx;
+						i__1 = kk - j + 1;
+						for (k = kk - 1; k >= i__1; --k) {
+							ix -= *incx;
+							x[ix] -= temp * ap[k];
 /* L30: */
-                        }
-                    }
-                    jx -= *incx;
-                    kk -= j;
+						}
+					}
+					jx -= *incx;
+					kk -= j;
 /* L40: */
-                }
-            }
-        } else {
-            kk = 1;
-            if (*incx == 1) {
-                i__1 = *n;
-                for (j = 1; j <= i__1; ++j) {
-                    if (x[j] != 0.) {
-                        if (nounit) {
-                            x[j] /= ap[kk];
-                        }
-                        temp = x[j];
-                        k = kk + 1;
-                        i__2 = *n;
-                        for (i__ = j + 1; i__ <= i__2; ++i__) {
-                            x[i__] -= temp * ap[k];
-                            ++k;
+				}
+			}
+		} else {
+			kk = 1;
+			if (*incx == 1) {
+				i__1 = *n;
+				for (j = 1; j <= i__1; ++j) {
+					if (x[j] != 0.) {
+						if (nounit) {
+							x[j] /= ap[kk];
+						}
+						temp = x[j];
+						k = kk + 1;
+						i__2 = *n;
+						for (i__ = j + 1; i__ <= i__2; ++i__) {
+							x[i__] -= temp * ap[k];
+							++k;
 /* L50: */
-                        }
-                    }
-                    kk += *n - j + 1;
+						}
+					}
+					kk += *n - j + 1;
 /* L60: */
-                }
-            } else {
-                jx = kx;
-                i__1 = *n;
-                for (j = 1; j <= i__1; ++j) {
-                    if (x[jx] != 0.) {
-                        if (nounit) {
-                            x[jx] /= ap[kk];
-                        }
-                        temp = x[jx];
-                        ix = jx;
-                        i__2 = kk + *n - j;
-                        for (k = kk + 1; k <= i__2; ++k) {
-                            ix += *incx;
-                            x[ix] -= temp * ap[k];
+				}
+			} else {
+				jx = kx;
+				i__1 = *n;
+				for (j = 1; j <= i__1; ++j) {
+					if (x[jx] != 0.) {
+						if (nounit) {
+							x[jx] /= ap[kk];
+						}
+						temp = x[jx];
+						ix = jx;
+						i__2 = kk + *n - j;
+						for (k = kk + 1; k <= i__2; ++k) {
+							ix += *incx;
+							x[ix] -= temp * ap[k];
 /* L70: */
-                        }
-                    }
-                    jx += *incx;
-                    kk += *n - j + 1;
+						}
+					}
+					jx += *incx;
+					kk += *n - j + 1;
 /* L80: */
-                }
-            }
-        }
-    } else {
+				}
+			}
+		}
+	} else {
 
 /*        Form  x := inv( A' )*x. */
 
-        if (NL_FORTRAN_WRAP(lsame)(uplo, "U")) {
-            kk = 1;
-            if (*incx == 1) {
-                i__1 = *n;
-                for (j = 1; j <= i__1; ++j) {
-                    temp = x[j];
-                    k = kk;
-                    i__2 = j - 1;
-                    for (i__ = 1; i__ <= i__2; ++i__) {
-                        temp -= ap[k] * x[i__];
-                        ++k;
+		if (NL_FORTRAN_WRAP(lsame)(uplo, "U")) {
+			kk = 1;
+			if (*incx == 1) {
+				i__1 = *n;
+				for (j = 1; j <= i__1; ++j) {
+					temp = x[j];
+					k = kk;
+					i__2 = j - 1;
+					for (i__ = 1; i__ <= i__2; ++i__) {
+						temp -= ap[k] * x[i__];
+						++k;
 /* L90: */
-                    }
-                    if (nounit) {
-                        temp /= ap[kk + j - 1];
-                    }
-                    x[j] = temp;
-                    kk += j;
+					}
+					if (nounit) {
+						temp /= ap[kk + j - 1];
+					}
+					x[j] = temp;
+					kk += j;
 /* L100: */
-                }
-            } else {
-                jx = kx;
-                i__1 = *n;
-                for (j = 1; j <= i__1; ++j) {
-                    temp = x[jx];
-                    ix = kx;
-                    i__2 = kk + j - 2;
-                    for (k = kk; k <= i__2; ++k) {
-                        temp -= ap[k] * x[ix];
-                        ix += *incx;
+				}
+			} else {
+				jx = kx;
+				i__1 = *n;
+				for (j = 1; j <= i__1; ++j) {
+					temp = x[jx];
+					ix = kx;
+					i__2 = kk + j - 2;
+					for (k = kk; k <= i__2; ++k) {
+						temp -= ap[k] * x[ix];
+						ix += *incx;
 /* L110: */
-                    }
-                    if (nounit) {
-                        temp /= ap[kk + j - 1];
-                    }
-                    x[jx] = temp;
-                    jx += *incx;
-                    kk += j;
+					}
+					if (nounit) {
+						temp /= ap[kk + j - 1];
+					}
+					x[jx] = temp;
+					jx += *incx;
+					kk += j;
 /* L120: */
-                }
-            }
-        } else {
-            kk = *n * (*n + 1) / 2;
-            if (*incx == 1) {
-                for (j = *n; j >= 1; --j) {
-                    temp = x[j];
-                    k = kk;
-                    i__1 = j + 1;
-                    for (i__ = *n; i__ >= i__1; --i__) {
-                        temp -= ap[k] * x[i__];
-                        --k;
+				}
+			}
+		} else {
+			kk = *n * (*n + 1) / 2;
+			if (*incx == 1) {
+				for (j = *n; j >= 1; --j) {
+					temp = x[j];
+					k = kk;
+					i__1 = j + 1;
+					for (i__ = *n; i__ >= i__1; --i__) {
+						temp -= ap[k] * x[i__];
+						--k;
 /* L130: */
-                    }
-                    if (nounit) {
-                        temp /= ap[kk - *n + j];
-                    }
-                    x[j] = temp;
-                    kk -= *n - j + 1;
+					}
+					if (nounit) {
+						temp /= ap[kk - *n + j];
+					}
+					x[j] = temp;
+					kk -= *n - j + 1;
 /* L140: */
-                }
-            } else {
-                kx += (*n - 1) * *incx;
-                jx = kx;
-                for (j = *n; j >= 1; --j) {
-                    temp = x[jx];
-                    ix = kx;
-                    i__1 = kk - (*n - (j + 1));
-                    for (k = kk; k >= i__1; --k) {
-                        temp -= ap[k] * x[ix];
-                        ix -= *incx;
+				}
+			} else {
+				kx += (*n - 1) * *incx;
+				jx = kx;
+				for (j = *n; j >= 1; --j) {
+					temp = x[jx];
+					ix = kx;
+					i__1 = kk - (*n - (j + 1));
+					for (k = kk; k >= i__1; --k) {
+						temp -= ap[k] * x[ix];
+						ix -= *incx;
 /* L150: */
-                    }
-                    if (nounit) {
-                        temp /= ap[kk - *n + j];
-                    }
-                    x[jx] = temp;
-                    jx -= *incx;
-                    kk -= *n - j + 1;
+					}
+					if (nounit) {
+						temp /= ap[kk - *n + j];
+					}
+					x[jx] = temp;
+					jx -= *incx;
+					kk -= *n - j + 1;
 /* L160: */
-                }
-            }
-        }
-    }
+				}
+			}
+		}
+	}
 
-    return 0;
+	return 0;
 
 /*     End of DTPSV . */
 
 } /* dtpsv_ */
 
-#endif 
+#endif
 
 
 
@@ -3298,75 +3298,75 @@ static int NL_FORTRAN_WRAP(dtpsv)(
 
 /* x <- a*x */
 void dscal( int n, double alpha, double *x, int incx ) {
-    NL_FORTRAN_WRAP(dscal)(&n,&alpha,x,&incx);
-    if(nlCurrentContext != NULL) {
+	NL_FORTRAN_WRAP(dscal)(&n,&alpha,x,&incx);
+	if(nlCurrentContext != NULL) {
 	nlCurrentContext->flops += (NLulong)(n);
-    }
+	}
 }
 
 /* y <- x */
-void dcopy( 
-    int n, const double *x, int incx, double *y, int incy 
+void dcopy(
+	int n, const double *x, int incx, double *y, int incy
 ) {
-    NL_FORTRAN_WRAP(dcopy)(&n,(double*)x,&incx,y,&incy);
+	NL_FORTRAN_WRAP(dcopy)(&n,(double*)x,&incx,y,&incy);
 }
 
 /* y <- a*x+y */
-void daxpy( 
-    int n, double alpha, const double *x, int incx, double *y,
-    int incy 
+void daxpy(
+	int n, double alpha, const double *x, int incx, double *y,
+	int incy
 ) {
-    NL_FORTRAN_WRAP(daxpy)(&n,&alpha,(double*)x,&incx,y,&incy);
-    if(nlCurrentContext != NULL) {    
+	NL_FORTRAN_WRAP(daxpy)(&n,&alpha,(double*)x,&incx,y,&incy);
+	if(nlCurrentContext != NULL) {
 	nlCurrentContext->flops += (NLulong)(2*n);
-    }
+	}
 }
 
 /* returns x^T*y */
-double ddot( 
-    int n, const double *x, int incx, const double *y, int incy 
+double ddot(
+	int n, const double *x, int incx, const double *y, int incy
 ) {
-    if(nlCurrentContext != NULL) {    
+	if(nlCurrentContext != NULL) {
 	nlCurrentContext->flops += (NLulong)(2*n);
-    }
-    return NL_FORTRAN_WRAP(ddot)(&n,(double*)x,&incx,(double*)y,&incy);
+	}
+	return NL_FORTRAN_WRAP(ddot)(&n,(double*)x,&incx,(double*)y,&incy);
 }
 
 /* returns |x|_2 */
 double dnrm2( int n, const double *x, int incx ) {
-    if(nlCurrentContext != NULL) {    
+	if(nlCurrentContext != NULL) {
 	nlCurrentContext->flops += (NLulong)(2*n);
-    }
-    return NL_FORTRAN_WRAP(dnrm2)(&n,(double*)x,&incx);
+	}
+	return NL_FORTRAN_WRAP(dnrm2)(&n,(double*)x,&incx);
 }
 
 /* x <- A^{-1}*x,  x <- A^{-T}*x */
-void dtpsv( 
-    MatrixTriangle uplo, MatrixTranspose trans,
-    MatrixUnitTriangular diag, int n, const double *AP,
-    double *x, int incx 
+void dtpsv(
+	MatrixTriangle uplo, MatrixTranspose trans,
+	MatrixUnitTriangular diag, int n, const double *AP,
+	double *x, int incx
 ) {
-    static const char *UL[2] = { "U", "L" };
-    static const char *T[3]  = { "N", "T", 0 };
-    static const char *D[2]  = { "U", "N" };
-    NL_FORTRAN_WRAP(dtpsv)(
+	static const char *UL[2] = { "U", "L" };
+	static const char *T[3]  = { "N", "T", 0 };
+	static const char *D[2]  = { "U", "N" };
+	NL_FORTRAN_WRAP(dtpsv)(
 	UL[(int)uplo],T[(int)trans],D[(int)diag],&n,(double*)AP,x,&incx
-    );
-    /* TODO: update flops */
+	);
+	/* TODO: update flops */
 }
 
 /* y <- alpha*A*x + beta*y,  y <- alpha*A^T*x + beta*y,   A-(m,n) */
-void dgemv( 
-    MatrixTranspose trans, int m, int n, double alpha,
-    const double *A, int ldA, const double *x, int incx,
-    double beta, double *y, int incy 
+void dgemv(
+	MatrixTranspose trans, int m, int n, double alpha,
+	const double *A, int ldA, const double *x, int incx,
+	double beta, double *y, int incy
 ) {
-    static const char *T[3] = { "N", "T", 0 };
-    NL_FORTRAN_WRAP(dgemv)(
+	static const char *T[3] = { "N", "T", 0 };
+	NL_FORTRAN_WRAP(dgemv)(
 	T[(int)trans],&m,&n,&alpha,(double*)A,&ldA,
 	(double*)x,&incx,&beta,y,&incy
-    );
-    /* TODO: update flops */    
+	);
+	/* TODO: update flops */
 }
 
 
@@ -3380,7 +3380,7 @@ void dgemv(
 /* Solvers */
 
 /*
- * The implementation of the solvers is inspired by 
+ * The implementation of the solvers is inspired by
  * the lsolver library, by Christian Badura, available from:
  * http://www.mathematik.uni-freiburg.de
  * /IAM/Research/projectskr/lin_solver/
@@ -3394,406 +3394,406 @@ void dgemv(
 
 
 static NLuint nlSolveSystem_CG(
-    NLMatrix M, NLdouble* b, NLdouble* x,
-    double eps, NLuint max_iter
+	NLMatrix M, NLdouble* b, NLdouble* x,
+	double eps, NLuint max_iter
 ) {
-    NLint N = (NLint)M->m;
+	NLint N = (NLint)M->m;
 
-    NLdouble *g = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble *r = NL_NEW_ARRAY(NLdouble, N); 
-    NLdouble *p = NL_NEW_ARRAY(NLdouble, N);
-    NLuint its=0;
-    NLdouble t, tau, sig, rho, gam;
-    NLdouble b_square=ddot(N,b,1,b,1);
-    NLdouble err=eps*eps*b_square;
-    NLdouble curr_err;
+	NLdouble *g = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *r = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *p = NL_NEW_ARRAY(NLdouble, N);
+	NLuint its=0;
+	NLdouble t, tau, sig, rho, gam;
+	NLdouble b_square=ddot(N,b,1,b,1);
+	NLdouble err=eps*eps*b_square;
+	NLdouble curr_err;
 
-    nlMultMatrixVector(M,x,g);
-    daxpy(N,-1.,b,1,g,1);
-    dscal(N,-1.,g,1);
-    dcopy(N,g,1,r,1);
-    curr_err = ddot(N,g,1,g,1);
-    while ( curr_err >err && its < max_iter) {
+	nlMultMatrixVector(M,x,g);
+	daxpy(N,-1.,b,1,g,1);
+	dscal(N,-1.,g,1);
+	dcopy(N,g,1,r,1);
+	curr_err = ddot(N,g,1,g,1);
+	while ( curr_err >err && its < max_iter) {
 	if(nlCurrentContext != NULL) {
-	    if(nlCurrentContext->progress_func != NULL) {
+		if(nlCurrentContext->progress_func != NULL) {
 		nlCurrentContext->progress_func(its, max_iter, curr_err, err);
-	    }
-	    if(nlCurrentContext->verbose && !(its % 100)) {
+		}
+		if(nlCurrentContext->verbose && !(its % 100)) {
 		printf ( "%d : %.10e -- %.10e\n", its, curr_err, err );
-	    }
+		}
 	}
 	nlMultMatrixVector(M,r,p);
-        rho=ddot(N,p,1,p,1);
-        sig=ddot(N,r,1,p,1);
-        tau=ddot(N,g,1,r,1);
-        t=tau/sig;
-        daxpy(N,t,r,1,x,1);
-        daxpy(N,-t,p,1,g,1);
-        gam=(t*t*rho-tau)/tau;
-        dscal(N,gam,r,1);
-        daxpy(N,1.,g,1,r,1);
-        ++its;
-        curr_err = ddot(N,g,1,g,1);
-    }
-    NL_DELETE_ARRAY(g);
-    NL_DELETE_ARRAY(r);
-    NL_DELETE_ARRAY(p);
-    return its;
+		rho=ddot(N,p,1,p,1);
+		sig=ddot(N,r,1,p,1);
+		tau=ddot(N,g,1,r,1);
+		t=tau/sig;
+		daxpy(N,t,r,1,x,1);
+		daxpy(N,-t,p,1,g,1);
+		gam=(t*t*rho-tau)/tau;
+		dscal(N,gam,r,1);
+		daxpy(N,1.,g,1,r,1);
+		++its;
+		curr_err = ddot(N,g,1,g,1);
+	}
+	NL_DELETE_ARRAY(g);
+	NL_DELETE_ARRAY(r);
+	NL_DELETE_ARRAY(p);
+	return its;
 }
 
 static NLuint nlSolveSystem_PRE_CG(
-    NLMatrix M, NLMatrix P, NLdouble* b, NLdouble* x,
-    double eps, NLuint max_iter
+	NLMatrix M, NLMatrix P, NLdouble* b, NLdouble* x,
+	double eps, NLuint max_iter
 ) {
-    NLint     N        = (NLint)M->n;
-    NLdouble* r = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble* d = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble* h = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble *Ad = h;
-    NLuint its=0;
-    NLdouble rh, alpha, beta;
-    NLdouble b_square = ddot(N,b,1,b,1);
-    NLdouble err=eps*eps*b_square;
-    NLdouble curr_err;
+	NLint     N        = (NLint)M->n;
+	NLdouble* r = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble* d = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble* h = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *Ad = h;
+	NLuint its=0;
+	NLdouble rh, alpha, beta;
+	NLdouble b_square = ddot(N,b,1,b,1);
+	NLdouble err=eps*eps*b_square;
+	NLdouble curr_err;
 
-    nlMultMatrixVector(M,x,r);
-    daxpy(N,-1.,b,1,r,1);
-    nlMultMatrixVector(P,r,d);
-    dcopy(N,d,1,h,1);
-    rh=ddot(N,r,1,h,1);
-    curr_err = ddot(N,r,1,r,1);
+	nlMultMatrixVector(M,x,r);
+	daxpy(N,-1.,b,1,r,1);
+	nlMultMatrixVector(P,r,d);
+	dcopy(N,d,1,h,1);
+	rh=ddot(N,r,1,h,1);
+	curr_err = ddot(N,r,1,r,1);
 
-    while ( curr_err >err && its < max_iter) {
+	while ( curr_err >err && its < max_iter) {
 	if(nlCurrentContext != NULL) {
-	    if(nlCurrentContext->progress_func != NULL) {
+		if(nlCurrentContext->progress_func != NULL) {
 		nlCurrentContext->progress_func(its, max_iter, curr_err, err);
-	    }
-	    if( nlCurrentContext->verbose && !(its % 100)) {
+		}
+		if( nlCurrentContext->verbose && !(its % 100)) {
 		printf ( "%d : %.10e -- %.10e\n", its, curr_err, err );
-	    }
+		}
 	}
 	nlMultMatrixVector(M,d,Ad);
-        alpha=rh/ddot(N,d,1,Ad,1);
-        daxpy(N,-alpha,d,1,x,1);
-        daxpy(N,-alpha,Ad,1,r,1);
+		alpha=rh/ddot(N,d,1,Ad,1);
+		daxpy(N,-alpha,d,1,x,1);
+		daxpy(N,-alpha,Ad,1,r,1);
 	nlMultMatrixVector(P,r,h);
-        beta=1./rh; rh=ddot(N,r,1,h,1); beta*=rh;
-        dscal(N,beta,d,1);
-        daxpy(N,1.,h,1,d,1);
-        ++its;
-        curr_err = ddot(N,r,1,r,1);
-    }
-    NL_DELETE_ARRAY(r);
-    NL_DELETE_ARRAY(d);
-    NL_DELETE_ARRAY(h);
-    return its;
+		beta=1./rh; rh=ddot(N,r,1,h,1); beta*=rh;
+		dscal(N,beta,d,1);
+		daxpy(N,1.,h,1,d,1);
+		++its;
+		curr_err = ddot(N,r,1,r,1);
+	}
+	NL_DELETE_ARRAY(r);
+	NL_DELETE_ARRAY(d);
+	NL_DELETE_ARRAY(h);
+	return its;
 }
 
 static NLuint nlSolveSystem_BICGSTAB(
-    NLMatrix M, NLdouble* b, NLdouble* x,
-    double eps, NLuint max_iter
+	NLMatrix M, NLdouble* b, NLdouble* x,
+	double eps, NLuint max_iter
 ) {
-    NLint     N   = (NLint)M->n;
-    NLdouble *rT  = NL_NEW_ARRAY(NLdouble, N); 
-    NLdouble *d   = NL_NEW_ARRAY(NLdouble, N); 
-    NLdouble *h   = NL_NEW_ARRAY(NLdouble, N); 
-    NLdouble *u   = NL_NEW_ARRAY(NLdouble, N); 
-    NLdouble *Ad  = NL_NEW_ARRAY(NLdouble, N); 
-    NLdouble *t   = NL_NEW_ARRAY(NLdouble, N); 
-    NLdouble *s   = h;
-    NLdouble rTh, rTAd, rTr, alpha, beta, omega, st, tt;
-    NLuint its=0;
-    NLdouble b_square = ddot(N,b,1,b,1);
-    NLdouble err=eps*eps*b_square;
-    NLdouble *r = NL_NEW_ARRAY(NLdouble, N);
-    nlMultMatrixVector(M,x,r);
-    daxpy(N,-1.,b,1,r,1);
-    dcopy(N,r,1,d,1);
-    dcopy(N,d,1,h,1);
-    dcopy(N,h,1,rT,1);
-    nl_assert( ddot(N,rT,1,rT,1)>1e-40 );
-    rTh=ddot(N,rT,1,h,1);
-    rTr=ddot(N,r,1,r,1);
+	NLint     N   = (NLint)M->n;
+	NLdouble *rT  = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *d   = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *h   = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *u   = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *Ad  = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *t   = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *s   = h;
+	NLdouble rTh, rTAd, rTr, alpha, beta, omega, st, tt;
+	NLuint its=0;
+	NLdouble b_square = ddot(N,b,1,b,1);
+	NLdouble err=eps*eps*b_square;
+	NLdouble *r = NL_NEW_ARRAY(NLdouble, N);
+	nlMultMatrixVector(M,x,r);
+	daxpy(N,-1.,b,1,r,1);
+	dcopy(N,r,1,d,1);
+	dcopy(N,d,1,h,1);
+	dcopy(N,h,1,rT,1);
+	nl_assert( ddot(N,rT,1,rT,1)>1e-40 );
+	rTh=ddot(N,rT,1,h,1);
+	rTr=ddot(N,r,1,r,1);
 
-    while ( rTr>err && its < max_iter) {
+	while ( rTr>err && its < max_iter) {
 	if(nlCurrentContext != NULL) {
-	    if(nlCurrentContext->progress_func != NULL) {
+		if(nlCurrentContext->progress_func != NULL) {
 		nlCurrentContext->progress_func(its, max_iter, rTr, err);
-	    }
-	    if( (nlCurrentContext->verbose) && !(its % 100)) {
+		}
+		if( (nlCurrentContext->verbose) && !(its % 100)) {
 		printf ( "%d : %.10e -- %.10e\n", its, rTr, err );
-	    }
+		}
 	}
 	nlMultMatrixVector(M,d,Ad);
-        rTAd=ddot(N,rT,1,Ad,1);
-        nl_assert( fabs(rTAd)>1e-40 );
-        alpha=rTh/rTAd;
-        daxpy(N,-alpha,Ad,1,r,1);
-        dcopy(N,h,1,s,1);
-        daxpy(N,-alpha,Ad,1,s,1);
+		rTAd=ddot(N,rT,1,Ad,1);
+		nl_assert( fabs(rTAd)>1e-40 );
+		alpha=rTh/rTAd;
+		daxpy(N,-alpha,Ad,1,r,1);
+		dcopy(N,h,1,s,1);
+		daxpy(N,-alpha,Ad,1,s,1);
 	nlMultMatrixVector(M,s,t);
-        daxpy(N,1.,t,1,u,1);
-        dscal(N,alpha,u,1);
-        st=ddot(N,s,1,t,1);
-        tt=ddot(N,t,1,t,1);
-        if ( fabs(st)<1e-40 || fabs(tt)<1e-40 ) {
-            omega = 0.;
-        } else {
-            omega = st/tt;
-        }
-        daxpy(N,-omega,t,1,r,1);
-        daxpy(N,-alpha,d,1,x,1);
-        daxpy(N,-omega,s,1,x,1);
-        dcopy(N,s,1,h,1);
-        daxpy(N,-omega,t,1,h,1);
-        beta=(alpha/omega)/rTh; rTh=ddot(N,rT,1,h,1); beta*=rTh;
-        dscal(N,beta,d,1);
-        daxpy(N,1.,h,1,d,1);
-        daxpy(N,-beta*omega,Ad,1,d,1);
-        rTr=ddot(N,r,1,r,1);
-        ++its;
-    }
-    NL_DELETE_ARRAY(r);
-    NL_DELETE_ARRAY(rT);
-    NL_DELETE_ARRAY(d);
-    NL_DELETE_ARRAY(h);
-    NL_DELETE_ARRAY(u);
-    NL_DELETE_ARRAY(Ad);
-    NL_DELETE_ARRAY(t);
-    return its;
+		daxpy(N,1.,t,1,u,1);
+		dscal(N,alpha,u,1);
+		st=ddot(N,s,1,t,1);
+		tt=ddot(N,t,1,t,1);
+		if ( fabs(st)<1e-40 || fabs(tt)<1e-40 ) {
+			omega = 0.;
+		} else {
+			omega = st/tt;
+		}
+		daxpy(N,-omega,t,1,r,1);
+		daxpy(N,-alpha,d,1,x,1);
+		daxpy(N,-omega,s,1,x,1);
+		dcopy(N,s,1,h,1);
+		daxpy(N,-omega,t,1,h,1);
+		beta=(alpha/omega)/rTh; rTh=ddot(N,rT,1,h,1); beta*=rTh;
+		dscal(N,beta,d,1);
+		daxpy(N,1.,h,1,d,1);
+		daxpy(N,-beta*omega,Ad,1,d,1);
+		rTr=ddot(N,r,1,r,1);
+		++its;
+	}
+	NL_DELETE_ARRAY(r);
+	NL_DELETE_ARRAY(rT);
+	NL_DELETE_ARRAY(d);
+	NL_DELETE_ARRAY(h);
+	NL_DELETE_ARRAY(u);
+	NL_DELETE_ARRAY(Ad);
+	NL_DELETE_ARRAY(t);
+	return its;
 }
 
 static NLuint nlSolveSystem_PRE_BICGSTAB(
-    NLMatrix M, NLMatrix P, NLdouble* b, NLdouble* x,
-    double eps, NLuint max_iter
+	NLMatrix M, NLMatrix P, NLdouble* b, NLdouble* x,
+	double eps, NLuint max_iter
 ) {
-    NLint     N   = (NLint)M->n;
-    NLdouble *rT  = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble *d   = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble *h   = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble *u   = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble *Sd  = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble *t   = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble *aux = NL_NEW_ARRAY(NLdouble, N);
-    NLdouble *s   = h;
-    NLdouble rTh, rTSd, rTr, alpha, beta, omega, st, tt;
-    NLuint its=0;
-    NLdouble b_square = ddot(N,b,1,b,1);
-    NLdouble err  = eps*eps*b_square;
-    NLdouble *r   = NL_NEW_ARRAY(NLdouble, N);
+	NLint     N   = (NLint)M->n;
+	NLdouble *rT  = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *d   = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *h   = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *u   = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *Sd  = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *t   = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *aux = NL_NEW_ARRAY(NLdouble, N);
+	NLdouble *s   = h;
+	NLdouble rTh, rTSd, rTr, alpha, beta, omega, st, tt;
+	NLuint its=0;
+	NLdouble b_square = ddot(N,b,1,b,1);
+	NLdouble err  = eps*eps*b_square;
+	NLdouble *r   = NL_NEW_ARRAY(NLdouble, N);
 
-    nlMultMatrixVector(M,x,r);
-    daxpy(N,-1.,b,1,r,1);
-    nlMultMatrixVector(P,r,d);
-    dcopy(N,d,1,h,1);
-    dcopy(N,h,1,rT,1);
-    nl_assert( ddot(N,rT,1,rT,1)>1e-40 );
-    rTh=ddot(N,rT,1,h,1);
-    rTr=ddot(N,r,1,r,1);
+	nlMultMatrixVector(M,x,r);
+	daxpy(N,-1.,b,1,r,1);
+	nlMultMatrixVector(P,r,d);
+	dcopy(N,d,1,h,1);
+	dcopy(N,h,1,rT,1);
+	nl_assert( ddot(N,rT,1,rT,1)>1e-40 );
+	rTh=ddot(N,rT,1,h,1);
+	rTr=ddot(N,r,1,r,1);
 
-    while ( rTr>err && its < max_iter) {
-	if(nlCurrentContext != NULL) {	
-	    if(nlCurrentContext->progress_func != NULL) {
+	while ( rTr>err && its < max_iter) {
+	if(nlCurrentContext != NULL) {
+		if(nlCurrentContext->progress_func != NULL) {
 		nlCurrentContext->progress_func(its, max_iter, rTr, err);
-	    }
-	    if( (nlCurrentContext->verbose) && !(its % 100)) {
+		}
+		if( (nlCurrentContext->verbose) && !(its % 100)) {
 		printf ( "%d : %.10e -- %.10e\n", its, rTr, err );
-	    }
+		}
 	}
 	nlMultMatrixVector(M,d,aux);
 	nlMultMatrixVector(P,aux,Sd);
-        rTSd=ddot(N,rT,1,Sd,1);
-        nl_assert( fabs(rTSd)>1e-40 );
-        alpha=rTh/rTSd;
-        daxpy(N,-alpha,aux,1,r,1);
-        dcopy(N,h,1,s,1);
-        daxpy(N,-alpha,Sd,1,s,1);
+		rTSd=ddot(N,rT,1,Sd,1);
+		nl_assert( fabs(rTSd)>1e-40 );
+		alpha=rTh/rTSd;
+		daxpy(N,-alpha,aux,1,r,1);
+		dcopy(N,h,1,s,1);
+		daxpy(N,-alpha,Sd,1,s,1);
 	nlMultMatrixVector(M,s,aux);
 	nlMultMatrixVector(P,aux,t);
-        daxpy(N,1.,t,1,u,1);
-        dscal(N,alpha,u,1);
-        st=ddot(N,s,1,t,1);
-        tt=ddot(N,t,1,t,1);
-        if ( fabs(st)<1e-40 || fabs(tt)<1e-40 ) {
-            omega = 0.;
-        } else {
-            omega = st/tt;
-        }
-        daxpy(N,-omega,aux,1,r,1);
-        daxpy(N,-alpha,d,1,x,1);
-        daxpy(N,-omega,s,1,x,1);
-        dcopy(N,s,1,h,1);
-        daxpy(N,-omega,t,1,h,1);
-        beta=(alpha/omega)/rTh; rTh=ddot(N,rT,1,h,1); beta*=rTh;
-        dscal(N,beta,d,1);
-        daxpy(N,1.,h,1,d,1);
-        daxpy(N,-beta*omega,Sd,1,d,1);
-        rTr=ddot(N,r,1,r,1);
-        ++its;
-    }
-    NL_DELETE_ARRAY(r);
-    NL_DELETE_ARRAY(rT);
-    NL_DELETE_ARRAY(d);
-    NL_DELETE_ARRAY(h);
-    NL_DELETE_ARRAY(u);
-    NL_DELETE_ARRAY(Sd);
-    NL_DELETE_ARRAY(t);
-    NL_DELETE_ARRAY(aux);
-    return its;
+		daxpy(N,1.,t,1,u,1);
+		dscal(N,alpha,u,1);
+		st=ddot(N,s,1,t,1);
+		tt=ddot(N,t,1,t,1);
+		if ( fabs(st)<1e-40 || fabs(tt)<1e-40 ) {
+			omega = 0.;
+		} else {
+			omega = st/tt;
+		}
+		daxpy(N,-omega,aux,1,r,1);
+		daxpy(N,-alpha,d,1,x,1);
+		daxpy(N,-omega,s,1,x,1);
+		dcopy(N,s,1,h,1);
+		daxpy(N,-omega,t,1,h,1);
+		beta=(alpha/omega)/rTh; rTh=ddot(N,rT,1,h,1); beta*=rTh;
+		dscal(N,beta,d,1);
+		daxpy(N,1.,h,1,d,1);
+		daxpy(N,-beta*omega,Sd,1,d,1);
+		rTr=ddot(N,r,1,r,1);
+		++its;
+	}
+	NL_DELETE_ARRAY(r);
+	NL_DELETE_ARRAY(rT);
+	NL_DELETE_ARRAY(d);
+	NL_DELETE_ARRAY(h);
+	NL_DELETE_ARRAY(u);
+	NL_DELETE_ARRAY(Sd);
+	NL_DELETE_ARRAY(t);
+	NL_DELETE_ARRAY(aux);
+	return its;
 }
 
 static NLuint nlSolveSystem_GMRES(
-    NLMatrix M, NLdouble* b, NLdouble* x,
-    double eps, NLuint max_iter, NLuint inner_iter
+	NLMatrix M, NLdouble* b, NLdouble* x,
+	double eps, NLuint max_iter, NLuint inner_iter
 ) {
-    NLint    n    = (NLint)M->n;
-    NLint    m    = (NLint)inner_iter;
-    typedef NLdouble *NLdoubleP;     
-    NLdouble *V   = NL_NEW_ARRAY(NLdouble, n*(m+1)   );
-    NLdouble *U   = NL_NEW_ARRAY(NLdouble, m*(m+1)/2 );
-    NLdouble *r   = NL_NEW_ARRAY(NLdouble, n         );
-    NLdouble *y   = NL_NEW_ARRAY(NLdouble, m+1       );
-    NLdouble *c   = NL_NEW_ARRAY(NLdouble, m         );
-    NLdouble *s   = NL_NEW_ARRAY(NLdouble, m         );
-    NLdouble **v  = NL_NEW_ARRAY(NLdoubleP, m+1      );
-    NLint i, j, io, uij, u0j; 
-    NLint its = -1;
-    NLdouble beta, h, rd, dd, nrm2b;
+	NLint    n    = (NLint)M->n;
+	NLint    m    = (NLint)inner_iter;
+	typedef NLdouble *NLdoubleP;
+	NLdouble *V   = NL_NEW_ARRAY(NLdouble, n*(m+1)   );
+	NLdouble *U   = NL_NEW_ARRAY(NLdouble, m*(m+1)/2 );
+	NLdouble *r   = NL_NEW_ARRAY(NLdouble, n         );
+	NLdouble *y   = NL_NEW_ARRAY(NLdouble, m+1       );
+	NLdouble *c   = NL_NEW_ARRAY(NLdouble, m         );
+	NLdouble *s   = NL_NEW_ARRAY(NLdouble, m         );
+	NLdouble **v  = NL_NEW_ARRAY(NLdoubleP, m+1      );
+	NLint i, j, io, uij, u0j;
+	NLint its = -1;
+	NLdouble beta, h, rd, dd, nrm2b;
 
-    for ( i=0; i<=m; ++i ){
-        v[i]=V+i*n;
-    }
-    
-    nrm2b=dnrm2(n,b,1);
-    io=0;
+	for ( i=0; i<=m; ++i ){
+		v[i]=V+i*n;
+	}
 
-    do  { /* outer loop */
-        ++io;
+	nrm2b=dnrm2(n,b,1);
+	io=0;
+
+	do  { /* outer loop */
+		++io;
 	nlMultMatrixVector(M,x,r);
-        daxpy(n,-1.,b,1,r,1);
-        beta=dnrm2(n,r,1);
-        dcopy(n,r,1,v[0],1);
-        dscal(n,1./beta,v[0],1);
+		daxpy(n,-1.,b,1,r,1);
+		beta=dnrm2(n,r,1);
+		dcopy(n,r,1,v[0],1);
+		dscal(n,1./beta,v[0],1);
 
-        y[0]=beta;
-        j=0;
-        uij=0;
-        do { /* inner loop: j=0,...,m-1 */
-            u0j=uij;
-	    nlMultMatrixVector(M,v[j],v[j+1]);
-            dgemv(
-                Transpose,n,j+1,1.,V,n,v[j+1],1,0.,U+u0j,1
-            );
-            dgemv(
-                NoTranspose,n,j+1,-1.,V,n,U+u0j,1,1.,v[j+1],1
-            );
-            h=dnrm2(n,v[j+1],1);
-            dscal(n,1./h,v[j+1],1);
-            for (i=0; i<j; ++i ) { /* rotiere neue Spalte */
-                double tmp = c[i]*U[uij]-s[i]*U[uij+1];
-                U[uij+1]   = s[i]*U[uij]+c[i]*U[uij+1];
-                U[uij]     = tmp;
-                ++uij;
-            }
-            { /* berechne neue Rotation */
-                rd     = U[uij];
-                dd     = sqrt(rd*rd+h*h);
-                c[j]   = rd/dd;
-                s[j]   = -h/dd;
-                U[uij] = dd;
-                ++uij;
-            }
-            { /* rotiere rechte Seite y (vorher: y[j+1]=0) */
-                y[j+1] = s[j]*y[j];
-                y[j]   = c[j]*y[j];
-            }
-            ++j;
-        } while ( 
-            j<m && fabs(y[j])>=eps*nrm2b 
-        );
-        { /* minimiere bzgl Y */
-            dtpsv(
-                UpperTriangle,
-                NoTranspose,
-                NotUnitTriangular,
-                j,U,y,1
-            );
-            /* correct X */
-            dgemv(NoTranspose,n,j,-1.,V,n,y,1,1.,x,1);
-        }
-    } while ( fabs(y[j])>=eps*nrm2b && (m*(io-1)+j) < (NLint)max_iter);
-    
-    /* Count the inner iterations */
-    its = m*(io-1)+j;
-    NL_DELETE_ARRAY(V);
-    NL_DELETE_ARRAY(U);
-    NL_DELETE_ARRAY(r);
-    NL_DELETE_ARRAY(y);
-    NL_DELETE_ARRAY(c);
-    NL_DELETE_ARRAY(s);
-    NL_DELETE_ARRAY(v);
-    return (NLuint)its;
+		y[0]=beta;
+		j=0;
+		uij=0;
+		do { /* inner loop: j=0,...,m-1 */
+			u0j=uij;
+		nlMultMatrixVector(M,v[j],v[j+1]);
+			dgemv(
+				Transpose,n,j+1,1.,V,n,v[j+1],1,0.,U+u0j,1
+			);
+			dgemv(
+				NoTranspose,n,j+1,-1.,V,n,U+u0j,1,1.,v[j+1],1
+			);
+			h=dnrm2(n,v[j+1],1);
+			dscal(n,1./h,v[j+1],1);
+			for (i=0; i<j; ++i ) { /* rotiere neue Spalte */
+				double tmp = c[i]*U[uij]-s[i]*U[uij+1];
+				U[uij+1]   = s[i]*U[uij]+c[i]*U[uij+1];
+				U[uij]     = tmp;
+				++uij;
+			}
+			{ /* berechne neue Rotation */
+				rd     = U[uij];
+				dd     = sqrt(rd*rd+h*h);
+				c[j]   = rd/dd;
+				s[j]   = -h/dd;
+				U[uij] = dd;
+				++uij;
+			}
+			{ /* rotiere rechte Seite y (vorher: y[j+1]=0) */
+				y[j+1] = s[j]*y[j];
+				y[j]   = c[j]*y[j];
+			}
+			++j;
+		} while (
+			j<m && fabs(y[j])>=eps*nrm2b
+		);
+		{ /* minimiere bzgl Y */
+			dtpsv(
+				UpperTriangle,
+				NoTranspose,
+				NotUnitTriangular,
+				j,U,y,1
+			);
+			/* correct X */
+			dgemv(NoTranspose,n,j,-1.,V,n,y,1,1.,x,1);
+		}
+	} while ( fabs(y[j])>=eps*nrm2b && (m*(io-1)+j) < (NLint)max_iter);
+
+	/* Count the inner iterations */
+	its = m*(io-1)+j;
+	NL_DELETE_ARRAY(V);
+	NL_DELETE_ARRAY(U);
+	NL_DELETE_ARRAY(r);
+	NL_DELETE_ARRAY(y);
+	NL_DELETE_ARRAY(c);
+	NL_DELETE_ARRAY(s);
+	NL_DELETE_ARRAY(v);
+	return (NLuint)its;
 }
 
 
 /* Main driver routine */
 
 NLuint nlSolveSystemIterative(
-    NLMatrix M, NLMatrix P, NLdouble* b, NLdouble* x,
-    NLenum solver,
-    double eps, NLuint max_iter, NLuint inner_iter
+	NLMatrix M, NLMatrix P, NLdouble* b, NLdouble* x,
+	NLenum solver,
+	double eps, NLuint max_iter, NLuint inner_iter
 ) {
-    NLuint result=0;
-    NLdouble* Ax;
-    NLdouble accu;
-    NLuint i;
-    NLdouble b_square=ddot((NLint)M->n,b,1,b,1);
-    nl_assert(M->m == M->n);
-    switch(solver) {
+	NLuint result=0;
+	NLdouble* Ax;
+	NLdouble accu;
+	NLuint i;
+	NLdouble b_square=ddot((NLint)M->n,b,1,b,1);
+	nl_assert(M->m == M->n);
+	switch(solver) {
 	case NL_CG:
-	    if(P == NULL) {
+		if(P == NULL) {
 		result = nlSolveSystem_CG(M,b,x,eps,max_iter);
-	    } else {
-		result = nlSolveSystem_PRE_CG(M,P,b,x,eps,max_iter);		
-	    }
-	    break;
+		} else {
+		result = nlSolveSystem_PRE_CG(M,P,b,x,eps,max_iter);
+		}
+		break;
 	case NL_BICGSTAB:
-	    if(P == NULL) {
+		if(P == NULL) {
 		result = nlSolveSystem_BICGSTAB(M,b,x,eps,max_iter);
-	    } else {
+		} else {
 		result = nlSolveSystem_PRE_BICGSTAB(M,P,b,x,eps,max_iter);
-	    }
-	    break;
+		}
+		break;
 	case NL_GMRES:
-	    result = nlSolveSystem_GMRES(M,b,x,eps,max_iter,inner_iter);
-	    break;
+		result = nlSolveSystem_GMRES(M,b,x,eps,max_iter,inner_iter);
+		break;
 	default:
-	    nl_assert_not_reached;
-    }
-    if(nlCurrentContext != NULL) {
+		nl_assert_not_reached;
+	}
+	if(nlCurrentContext != NULL) {
 	Ax = NL_NEW_ARRAY(NLdouble, M->n);
 	nlMultMatrixVector(M,x,Ax);
 	accu = 0.0;
 	for(i = 0; i < M->n; ++i) {
-	    accu+=(Ax[i]-b[i])*(Ax[i]-b[i]);
+		accu+=(Ax[i]-b[i])*(Ax[i]-b[i]);
 	}
 	if(b_square == 0.0) {
-	    nlCurrentContext->error = sqrt(accu);
-	    if(nlCurrentContext->verbose) {
+		nlCurrentContext->error = sqrt(accu);
+		if(nlCurrentContext->verbose) {
 		printf("in OpenNL : ||Ax-b|| = %e\n",nlCurrentContext->error);
-	    }
+		}
 	} else {
-	    nlCurrentContext->error = sqrt(accu/b_square);
-	    if(nlCurrentContext->verbose) {
+		nlCurrentContext->error = sqrt(accu/b_square);
+		if(nlCurrentContext->verbose) {
 		printf("in OpenNL : ||Ax-b||/||b|| = %e\n",
-		       nlCurrentContext->error
+			   nlCurrentContext->error
 		);
-	    }
+		}
 	}
 	NL_DELETE_ARRAY(Ax);
-    }
-    nlCurrentContext->used_iterations = result;
-    return result;
+	}
+	nlCurrentContext->used_iterations = result;
+	return result;
 }
 
 
@@ -3804,173 +3804,173 @@ NLuint nlSolveSystemIterative(
 
 
 typedef struct {
-    NLuint m;
+	NLuint m;
 
-    NLuint n;
+	NLuint n;
 
-    NLenum type;
+	NLenum type;
 
-    NLDestroyMatrixFunc destroy_func;
+	NLDestroyMatrixFunc destroy_func;
 
-    NLMultMatrixVectorFunc mult_func;
-    
-    NLdouble* diag_inv;
-    
+	NLMultMatrixVectorFunc mult_func;
+
+	NLdouble* diag_inv;
+
 } NLJacobiPreconditioner;
 
 
 static void nlJacobiPreconditionerDestroy(NLJacobiPreconditioner* M) {
-    NL_DELETE_ARRAY(M->diag_inv);
+	NL_DELETE_ARRAY(M->diag_inv);
 }
 
 static void nlJacobiPreconditionerMult(NLJacobiPreconditioner* M, const double* x, double* y) {
-    NLuint i;
-    for(i=0; i<M->n; ++i) {
+	NLuint i;
+	for(i=0; i<M->n; ++i) {
 	y[i] = x[i] * M->diag_inv[i];
-    }
-    nlCurrentContext->flops += (NLulong)(M->n);    
+	}
+	nlCurrentContext->flops += (NLulong)(M->n);
 }
 
 NLMatrix nlNewJacobiPreconditioner(NLMatrix M_in) {
-    NLSparseMatrix* M = NULL;
-    NLJacobiPreconditioner* result = NULL;
-    NLuint i;
-    nl_assert(M_in->type == NL_MATRIX_SPARSE_DYNAMIC);
-    nl_assert(M_in->m == M_in->n);
-    M = (NLSparseMatrix*)M_in;
-    result = NL_NEW(NLJacobiPreconditioner);
-    result->m = M->m;
-    result->n = M->n;
-    result->type = NL_MATRIX_OTHER;
-    result->destroy_func = (NLDestroyMatrixFunc)nlJacobiPreconditionerDestroy;
-    result->mult_func = (NLMultMatrixVectorFunc)nlJacobiPreconditionerMult;
-    result->diag_inv = NL_NEW_ARRAY(double, M->n);
-    for(i=0; i<M->n; ++i) {
+	NLSparseMatrix* M = NULL;
+	NLJacobiPreconditioner* result = NULL;
+	NLuint i;
+	nl_assert(M_in->type == NL_MATRIX_SPARSE_DYNAMIC);
+	nl_assert(M_in->m == M_in->n);
+	M = (NLSparseMatrix*)M_in;
+	result = NL_NEW(NLJacobiPreconditioner);
+	result->m = M->m;
+	result->n = M->n;
+	result->type = NL_MATRIX_OTHER;
+	result->destroy_func = (NLDestroyMatrixFunc)nlJacobiPreconditionerDestroy;
+	result->mult_func = (NLMultMatrixVectorFunc)nlJacobiPreconditionerMult;
+	result->diag_inv = NL_NEW_ARRAY(double, M->n);
+	for(i=0; i<M->n; ++i) {
 	result->diag_inv[i] = (M->diag[i] == 0.0) ? 1.0 : 1.0/M->diag[i];
-    }
-    return (NLMatrix)result;
+	}
+	return (NLMatrix)result;
 }
 
 
 
 
 typedef struct {
-    NLuint m;
+	NLuint m;
 
-    NLuint n;
+	NLuint n;
 
-    NLenum type;
+	NLenum type;
 
-    NLDestroyMatrixFunc destroy_func;
+	NLDestroyMatrixFunc destroy_func;
 
-    NLMultMatrixVectorFunc mult_func;
+	NLMultMatrixVectorFunc mult_func;
 
-    NLSparseMatrix* M;
+	NLSparseMatrix* M;
 
-    double omega;
-    
-    NLdouble* work;
-    
+	double omega;
+
+	NLdouble* work;
+
 } NLSSORPreconditioner;
 
 
 static void nlSSORPreconditionerDestroy(NLSSORPreconditioner* M) {
-    NL_DELETE_ARRAY(M->work);
+	NL_DELETE_ARRAY(M->work);
 }
 
 
 
 static void nlSparseMatrixMultLowerInverse(
-    NLSparseMatrix* A, const NLdouble* x, NLdouble* y, double omega
+	NLSparseMatrix* A, const NLdouble* x, NLdouble* y, double omega
 ) {
-    NLuint n       = A->n;
-    NLdouble* diag = A->diag;
-    NLuint i;
-    NLuint ij;
-    NLCoeff* c = NULL;
-    NLdouble S;
+	NLuint n       = A->n;
+	NLdouble* diag = A->diag;
+	NLuint i;
+	NLuint ij;
+	NLCoeff* c = NULL;
+	NLdouble S;
 
-    nl_assert(A->storage & NL_MATRIX_STORE_SYMMETRIC);
-    nl_assert(A->storage & NL_MATRIX_STORE_ROWS);
+	nl_assert(A->storage & NL_MATRIX_STORE_SYMMETRIC);
+	nl_assert(A->storage & NL_MATRIX_STORE_ROWS);
 
-    for(i=0; i<n; i++) {
-        NLRowColumn*  Ri = &(A->row[i]);       
-        S = 0;
-        for(ij=0; ij < Ri->size; ij++) {
-            c = &(Ri->coeff[ij]);
-            nl_parano_assert(c->index <= i); 
-            if(c->index != i) {
-                S += c->value * y[c->index]; 
-            }
-        }
-        nlCurrentContext->flops += (NLulong)(2*Ri->size);                    
-        y[i] = (x[i] - S) * omega / diag[i];
-    }
-    nlCurrentContext->flops += (NLulong)(n*3);                
+	for(i=0; i<n; i++) {
+		NLRowColumn*  Ri = &(A->row[i]);
+		S = 0;
+		for(ij=0; ij < Ri->size; ij++) {
+			c = &(Ri->coeff[ij]);
+			nl_parano_assert(c->index <= i);
+			if(c->index != i) {
+				S += c->value * y[c->index];
+			}
+		}
+		nlCurrentContext->flops += (NLulong)(2*Ri->size);
+		y[i] = (x[i] - S) * omega / diag[i];
+	}
+	nlCurrentContext->flops += (NLulong)(n*3);
 }
 static void nlSparseMatrixMultUpperInverse(
-    NLSparseMatrix* A, const NLdouble* x, NLdouble* y, NLdouble omega
+	NLSparseMatrix* A, const NLdouble* x, NLdouble* y, NLdouble omega
 ) {
-    NLuint n       = A->n;
-    NLdouble* diag = A->diag;
-    NLint i;
-    NLuint ij;
-    NLCoeff* c = NULL;
-    NLdouble S;
+	NLuint n       = A->n;
+	NLdouble* diag = A->diag;
+	NLint i;
+	NLuint ij;
+	NLCoeff* c = NULL;
+	NLdouble S;
 
-    nl_assert(A->storage & NL_MATRIX_STORE_SYMMETRIC);
-    nl_assert(A->storage & NL_MATRIX_STORE_COLUMNS);
+	nl_assert(A->storage & NL_MATRIX_STORE_SYMMETRIC);
+	nl_assert(A->storage & NL_MATRIX_STORE_COLUMNS);
 
-    for(i=(NLint)(n-1); i>=0; i--) {
-        NLRowColumn*  Ci = &(A->column[i]);       
-        S = 0;
-        for(ij=0; ij < Ci->size; ij++) {
-            c = &(Ci->coeff[ij]);
-            nl_parano_assert(c->index >= i); 
-            if((NLint)(c->index) != i) {
-                S += c->value * y[c->index]; 
-            }
-        }
-        nlCurrentContext->flops += (NLulong)(2*Ci->size);                    
-        y[i] = (x[i] - S) * omega / diag[i];
-    }
-    nlCurrentContext->flops += (NLulong)(n*3);                
+	for(i=(NLint)(n-1); i>=0; i--) {
+		NLRowColumn*  Ci = &(A->column[i]);
+		S = 0;
+		for(ij=0; ij < Ci->size; ij++) {
+			c = &(Ci->coeff[ij]);
+			nl_parano_assert(c->index >= i);
+			if((NLint)(c->index) != i) {
+				S += c->value * y[c->index];
+			}
+		}
+		nlCurrentContext->flops += (NLulong)(2*Ci->size);
+		y[i] = (x[i] - S) * omega / diag[i];
+	}
+	nlCurrentContext->flops += (NLulong)(n*3);
 }
 
 
 static void nlSSORPreconditionerMult(NLSSORPreconditioner* P, const double* x, double* y) {
-    NLdouble* diag = P->M->diag;
-    NLuint i;
-    nlSparseMatrixMultLowerInverse(
-        P->M, x, P->work, P->omega
-    );
-    for(i=0; i<P->n; i++) {
-        P->work[i] *= (diag[i] / P->omega);
-    }
-    nlCurrentContext->flops += (NLulong)(P->n);
-    nlSparseMatrixMultUpperInverse(
-        P->M, P->work, y, P->omega
-    );
-    dscal((NLint)P->n, 2.0 - P->omega, y, 1);
-    nlCurrentContext->flops += (NLulong)(P->n);    
+	NLdouble* diag = P->M->diag;
+	NLuint i;
+	nlSparseMatrixMultLowerInverse(
+		P->M, x, P->work, P->omega
+	);
+	for(i=0; i<P->n; i++) {
+		P->work[i] *= (diag[i] / P->omega);
+	}
+	nlCurrentContext->flops += (NLulong)(P->n);
+	nlSparseMatrixMultUpperInverse(
+		P->M, P->work, y, P->omega
+	);
+	dscal((NLint)P->n, 2.0 - P->omega, y, 1);
+	nlCurrentContext->flops += (NLulong)(P->n);
 }
 
 NLMatrix nlNewSSORPreconditioner(NLMatrix M_in, double omega) {
-    NLSparseMatrix* M = NULL;
-    NLSSORPreconditioner* result = NULL;
-    nl_assert(M_in->type == NL_MATRIX_SPARSE_DYNAMIC);
-    nl_assert(M_in->m == M_in->n);
-    M = (NLSparseMatrix*)M_in;
-    result = NL_NEW(NLSSORPreconditioner);
-    result->m = M->m;
-    result->n = M->n;
-    result->type = NL_MATRIX_OTHER;
-    result->destroy_func = (NLDestroyMatrixFunc)nlSSORPreconditionerDestroy;
-    result->mult_func = (NLMultMatrixVectorFunc)nlSSORPreconditionerMult;
-    result->M = M;
-    result->work = NL_NEW_ARRAY(NLdouble, result->n);
-    result->omega = omega;
-    return (NLMatrix)result;
+	NLSparseMatrix* M = NULL;
+	NLSSORPreconditioner* result = NULL;
+	nl_assert(M_in->type == NL_MATRIX_SPARSE_DYNAMIC);
+	nl_assert(M_in->m == M_in->n);
+	M = (NLSparseMatrix*)M_in;
+	result = NL_NEW(NLSSORPreconditioner);
+	result->m = M->m;
+	result->n = M->n;
+	result->type = NL_MATRIX_OTHER;
+	result->destroy_func = (NLDestroyMatrixFunc)nlSSORPreconditionerDestroy;
+	result->mult_func = (NLMultMatrixVectorFunc)nlSSORPreconditionerMult;
+	result->M = M;
+	result->work = NL_NEW_ARRAY(NLdouble, result->n);
+	result->omega = omega;
+	return (NLMatrix)result;
 }
 
 
@@ -3998,67 +3998,67 @@ NLMatrix nlNewSSORPreconditioner(NLMatrix M_in, double omega) {
 
 
 typedef enum {
-    SLU_NC,    /* column-wise, no supernode */
-    SLU_NCP,   /* column-wise, column-permuted, no supernode 
-                  (The consecutive columns of nonzeros, after permutation,
-                   may not be stored  contiguously.) */
-    SLU_NR,    /* row-wize, no supernode */
-    SLU_SC,    /* column-wise, supernode */
-    SLU_SCP,   /* supernode, column-wise, permuted */    
-    SLU_SR,    /* row-wise, supernode */
-    SLU_DN,     /* Fortran style column-wise storage for dense matrix */
-    SLU_NR_loc  /* distributed compressed row format  */ 
+	SLU_NC,    /* column-wise, no supernode */
+	SLU_NCP,   /* column-wise, column-permuted, no supernode
+				  (The consecutive columns of nonzeros, after permutation,
+				   may not be stored  contiguously.) */
+	SLU_NR,    /* row-wize, no supernode */
+	SLU_SC,    /* column-wise, supernode */
+	SLU_SCP,   /* supernode, column-wise, permuted */
+	SLU_SR,    /* row-wise, supernode */
+	SLU_DN,     /* Fortran style column-wise storage for dense matrix */
+	SLU_NR_loc  /* distributed compressed row format  */
 } Stype_t;
 
 typedef enum {
-    SLU_S,     /* single */
-    SLU_D,     /* double */
-    SLU_C,     /* single complex */
-    SLU_Z      /* double complex */
+	SLU_S,     /* single */
+	SLU_D,     /* double */
+	SLU_C,     /* single complex */
+	SLU_Z      /* double complex */
 } Dtype_t;
 
 
 typedef enum {
-    SLU_GE,    /* general */
-    SLU_TRLU,  /* lower triangular, unit diagonal */
-    SLU_TRUU,  /* upper triangular, unit diagonal */
-    SLU_TRL,   /* lower triangular */
-    SLU_TRU,   /* upper triangular */
-    SLU_SYL,   /* symmetric, store lower half */
-    SLU_SYU,   /* symmetric, store upper half */
-    SLU_HEL,   /* Hermitian, store lower half */
-    SLU_HEU    /* Hermitian, store upper half */
+	SLU_GE,    /* general */
+	SLU_TRLU,  /* lower triangular, unit diagonal */
+	SLU_TRUU,  /* upper triangular, unit diagonal */
+	SLU_TRL,   /* lower triangular */
+	SLU_TRU,   /* upper triangular */
+	SLU_SYL,   /* symmetric, store lower half */
+	SLU_SYU,   /* symmetric, store upper half */
+	SLU_HEL,   /* Hermitian, store lower half */
+	SLU_HEU    /* Hermitian, store upper half */
 } Mtype_t;
 
 typedef int int_t;
 
 typedef struct {
-    int_t  nnz;	    /* number of nonzeros in the matrix */
-    void *nzval;    /* pointer to array of nonzero values, packed by raw */
-    int_t  *colind; /* pointer to array of columns indices of the nonzeros */
-    int_t  *rowptr; /* pointer to array of beginning of rows in nzval[] 
-		       and colind[]  */
-                    /* Note:
-		       Zero-based indexing is used;
-		       rowptr[] has nrow+1 entries, the last one pointing
-		       beyond the last row, so that rowptr[nrow] = nnz. */
+	int_t  nnz;	    /* number of nonzeros in the matrix */
+	void *nzval;    /* pointer to array of nonzero values, packed by raw */
+	int_t  *colind; /* pointer to array of columns indices of the nonzeros */
+	int_t  *rowptr; /* pointer to array of beginning of rows in nzval[]
+			   and colind[]  */
+					/* Note:
+			   Zero-based indexing is used;
+			   rowptr[] has nrow+1 entries, the last one pointing
+			   beyond the last row, so that rowptr[nrow] = nnz. */
 } NRformat;
 
 typedef struct {
-        Stype_t Stype; /* Storage type: interprets the storage structure 
-                          pointed to by *Store. */
-        Dtype_t Dtype; /* Data type. */
-        Mtype_t Mtype; /* Matrix type: describes the mathematical property of 
-                          the matrix. */
-        int_t  nrow;   /* number of rows */
-        int_t  ncol;   /* number of columns */
-        void *Store;   /* pointer to the actual storage of the matrix */
+		Stype_t Stype; /* Storage type: interprets the storage structure
+						  pointed to by *Store. */
+		Dtype_t Dtype; /* Data type. */
+		Mtype_t Mtype; /* Matrix type: describes the mathematical property of
+						  the matrix. */
+		int_t  nrow;   /* number of rows */
+		int_t  ncol;   /* number of columns */
+		void *Store;   /* pointer to the actual storage of the matrix */
 } SuperMatrix;
 
 /* Stype == SLU_DN */
 typedef struct {
-    int_t lda;    /* leading dimension */
-    void *nzval;  /* array of size lda*ncol to represent a dense matrix */
+	int_t lda;    /* leading dimension */
+	void *nzval;  /* array of size lda*ncol to represent a dense matrix */
 } DNformat;
 
 
@@ -4066,7 +4066,7 @@ typedef enum {NO, YES}                                          yes_no_t;
 typedef enum {DOFACT, SamePattern, SamePattern_SameRowPerm, FACTORED} fact_t;
 typedef enum {NOROWPERM, LargeDiag, MY_PERMR}                   rowperm_t;
 typedef enum {NATURAL, MMD_ATA, MMD_AT_PLUS_A, COLAMD,
-              METIS_AT_PLUS_A, PARMETIS, ZOLTAN, MY_PERMC}      colperm_t;
+			  METIS_AT_PLUS_A, PARMETIS, ZOLTAN, MY_PERMC}      colperm_t;
 typedef enum {NOTRANS, TRANS, CONJ}                             trans_t;
 typedef enum {NOEQUIL, ROW, COL, BOTH}                          DiagScale_t;
 typedef enum {NOREFINE, SLU_SINGLE=1, SLU_DOUBLE, SLU_EXTRA}    IterRefine_t;
@@ -4077,33 +4077,33 @@ typedef enum {ONE_NORM, TWO_NORM, INF_NORM}                     norm_t;
 typedef enum {SILU, SMILU_1, SMILU_2, SMILU_3}                  milu_t;
 
 typedef struct {
-    fact_t        Fact;
-    yes_no_t      Equil;
-    colperm_t     ColPerm;
-    trans_t       Trans;
-    IterRefine_t  IterRefine;
-    double        DiagPivotThresh;
-    yes_no_t      SymmetricMode;
-    yes_no_t      PivotGrowth;
-    yes_no_t      ConditionNumber;
-    rowperm_t     RowPerm;
-    int           ILU_DropRule;
-    double        ILU_DropTol;    /* threshold for dropping */
-    double        ILU_FillFactor; /* gamma in the secondary dropping */
-    norm_t        ILU_Norm;       /* infinity-norm, 1-norm, or 2-norm */
-    double        ILU_FillTol;    /* threshold for zero pivot perturbation */
-    milu_t        ILU_MILU;
-    double        ILU_MILU_Dim;   /* Dimension of PDE (if available) */
-    yes_no_t      ParSymbFact;
-    yes_no_t      ReplaceTinyPivot; /* used in SuperLU_DIST */
-    yes_no_t      SolveInitialized;
-    yes_no_t      RefineInitialized;
-    yes_no_t      PrintStat;
-    int           nnzL, nnzU;      /* used to store nnzs for now       */
-    int           num_lookaheads;  /* num of levels in look-ahead      */
-    yes_no_t      lookahead_etree; /* use etree computed from the
-                                      serial symbolic factorization */
-    yes_no_t      SymPattern;      /* symmetric factorization          */
+	fact_t        Fact;
+	yes_no_t      Equil;
+	colperm_t     ColPerm;
+	trans_t       Trans;
+	IterRefine_t  IterRefine;
+	double        DiagPivotThresh;
+	yes_no_t      SymmetricMode;
+	yes_no_t      PivotGrowth;
+	yes_no_t      ConditionNumber;
+	rowperm_t     RowPerm;
+	int           ILU_DropRule;
+	double        ILU_DropTol;    /* threshold for dropping */
+	double        ILU_FillFactor; /* gamma in the secondary dropping */
+	norm_t        ILU_Norm;       /* infinity-norm, 1-norm, or 2-norm */
+	double        ILU_FillTol;    /* threshold for zero pivot perturbation */
+	milu_t        ILU_MILU;
+	double        ILU_MILU_Dim;   /* Dimension of PDE (if available) */
+	yes_no_t      ParSymbFact;
+	yes_no_t      ReplaceTinyPivot; /* used in SuperLU_DIST */
+	yes_no_t      SolveInitialized;
+	yes_no_t      RefineInitialized;
+	yes_no_t      PrintStat;
+	int           nnzL, nnzU;      /* used to store nnzs for now       */
+	int           num_lookaheads;  /* num of levels in look-ahead      */
+	yes_no_t      lookahead_etree; /* use etree computed from the
+									  serial symbolic factorization */
+	yes_no_t      SymPattern;      /* symmetric factorization          */
 } superlu_options_t;
 
 typedef void* superlu_options_ptr;
@@ -4112,46 +4112,46 @@ typedef float    flops_t;
 typedef unsigned char Logical;
 
 typedef struct {
-    int     *panel_histo;    /* histogram of panel size distribution */
-    double  *utime;          /* running time at various phases */
-    flops_t *ops;            /* operation count at various phases */
-    int     TinyPivots;      /* number of tiny pivots */
-    int     RefineSteps;     /* number of iterative refinement steps */
-    int     expansions;      /* number of memory expansions (SuperLU4) */
+	int     *panel_histo;    /* histogram of panel size distribution */
+	double  *utime;          /* running time at various phases */
+	flops_t *ops;            /* operation count at various phases */
+	int     TinyPivots;      /* number of tiny pivots */
+	int     RefineSteps;     /* number of iterative refinement steps */
+	int     expansions;      /* number of memory expansions (SuperLU4) */
 } SuperLUStat_t;
 
 /*! \brief Headers for 4 types of dynamatically managed memory */
 typedef struct e_node {
-    int size;      /* length of the memory that has been used */
-    void *mem;     /* pointer to the new malloc'd store */
+	int size;      /* length of the memory that has been used */
+	void *mem;     /* pointer to the new malloc'd store */
 } ExpHeader;
 
 typedef struct {
-    int  size;
-    int  used;
-    int  top1;  /* grow upward, relative to &array[0] */
-    int  top2;  /* grow downward */
-    void *array;
+	int  size;
+	int  used;
+	int  top1;  /* grow upward, relative to &array[0] */
+	int  top2;  /* grow downward */
+	void *array;
 } LU_stack_t;
 
 typedef struct {
-    int     *xsup;    /* supernode and column mapping */
-    int     *supno;   
-    int     *lsub;    /* compressed L subscripts */
-    int	    *xlsub;
-    void    *lusup;   /* L supernodes */
-    int     *xlusup;
-    void    *ucol;    /* U columns */
-    int     *usub;
-    int	    *xusub;
-    int     nzlmax;   /* current max size of lsub */
-    int     nzumax;   /*    "    "    "      ucol */
-    int     nzlumax;  /*    "    "    "     lusup */
-    int     n;        /* number of columns in the matrix */
-    LU_space_t MemModel; /* 0 - system malloc'd; 1 - user provided */
-    int     num_expansions;
-    ExpHeader *expanders; /* Array of pointers to 4 types of memory */
-    LU_stack_t stack;     /* use user supplied memory */
+	int     *xsup;    /* supernode and column mapping */
+	int     *supno;
+	int     *lsub;    /* compressed L subscripts */
+	int	    *xlsub;
+	void    *lusup;   /* L supernodes */
+	int     *xlusup;
+	void    *ucol;    /* U columns */
+	int     *usub;
+	int	    *xusub;
+	int     nzlmax;   /* current max size of lsub */
+	int     nzumax;   /*    "    "    "      ucol */
+	int     nzlumax;  /*    "    "    "     lusup */
+	int     n;        /* number of columns in the matrix */
+	LU_space_t MemModel; /* 0 - system malloc'd; 1 - user provided */
+	int     num_expansions;
+	ExpHeader *expanders; /* Array of pointers to 4 types of memory */
+	LU_stack_t stack;     /* use user supplied memory */
 } GlobalLU_t;
 
 
@@ -4172,12 +4172,12 @@ typedef void (*FUNPTR_StatInit)(SuperLUStat_t *);
 typedef void (*FUNPTR_StatFree)(SuperLUStat_t *);
 
 typedef void (*FUNPTR_dCreate_CompCol_Matrix)(
-    SuperMatrix *, int, int, int, const double *,
-    const int *, const int *, Stype_t, Dtype_t, Mtype_t);
+	SuperMatrix *, int, int, int, const double *,
+	const int *, const int *, Stype_t, Dtype_t, Mtype_t);
 
 typedef void (*FUNPTR_dCreate_Dense_Matrix)(
-    SuperMatrix *, int, int, const double *, int,
-    Stype_t, Dtype_t, Mtype_t);
+	SuperMatrix *, int, int, const double *, int,
+	Stype_t, Dtype_t, Mtype_t);
 
 typedef void (*FUNPTR_Destroy_SuperNode_Matrix)(SuperMatrix *);
 typedef void (*FUNPTR_Destroy_CompCol_Matrix)(SuperMatrix *);
@@ -4185,13 +4185,13 @@ typedef void (*FUNPTR_Destroy_CompCol_Permuted)(SuperMatrix *);
 typedef void (*FUNPTR_Destroy_SuperMatrix_Store)(SuperMatrix *);
 
 typedef void (*FUNPTR_dgssv)(
-    superlu_options_ptr, SuperMatrix *, int *, int *, SuperMatrix *,
-    SuperMatrix *, SuperMatrix *, SuperLUStat_t *, int *
+	superlu_options_ptr, SuperMatrix *, int *, int *, SuperMatrix *,
+	SuperMatrix *, SuperMatrix *, SuperLUStat_t *, int *
 );
 
 typedef void (*FUNPTR_dgstrs)(
-    trans_t, SuperMatrix *, SuperMatrix *, int *, int *,
-    SuperMatrix *, SuperLUStat_t*, int *    
+	trans_t, SuperMatrix *, SuperMatrix *, int *, int *,
+	SuperMatrix *, SuperLUStat_t*, int *
 );
 
 typedef void (*FUNPTR_get_perm_c)(int, SuperMatrix *, int *);
@@ -4202,60 +4202,60 @@ typedef int (*FUNPTR_sp_ienv)(int);
 typedef int (*FUNPTR_input_error)(const char *, int *);
 
 typedef void (*FUNPTR_dgstrf) (superlu_options_t *options, SuperMatrix *A,
-        int relax, int panel_size, int *etree, void *work, int lwork,
-        int *perm_c, int *perm_r, SuperMatrix *L, SuperMatrix *U,
-    	GlobalLU_t *Glu, /* persistent to facilitate multiple factorizations */
-        SuperLUStat_t *stat, int *info
+		int relax, int panel_size, int *etree, void *work, int lwork,
+		int *perm_c, int *perm_r, SuperMatrix *L, SuperMatrix *U,
+		GlobalLU_t *Glu, /* persistent to facilitate multiple factorizations */
+		SuperLUStat_t *stat, int *info
 );
 
 
 typedef struct {
-    FUNPTR_set_default_options set_default_options;
-    FUNPTR_ilu_set_default_options ilu_set_default_options;    
-    FUNPTR_StatInit StatInit;
-    FUNPTR_StatFree StatFree;
-    FUNPTR_dCreate_CompCol_Matrix dCreate_CompCol_Matrix;
-    FUNPTR_dCreate_Dense_Matrix dCreate_Dense_Matrix;
-    FUNPTR_Destroy_SuperNode_Matrix Destroy_SuperNode_Matrix;
-    FUNPTR_Destroy_CompCol_Matrix Destroy_CompCol_Matrix;
-    FUNPTR_Destroy_CompCol_Permuted Destroy_CompCol_Permuted;    
-    FUNPTR_Destroy_SuperMatrix_Store Destroy_SuperMatrix_Store;
-    FUNPTR_dgssv dgssv;
-    FUNPTR_dgstrs dgstrs;
-    FUNPTR_get_perm_c get_perm_c;
-    FUNPTR_sp_preorder sp_preorder;
-    FUNPTR_sp_ienv sp_ienv;
-    FUNPTR_dgstrf dgstrf;
-    FUNPTR_input_error input_error;
-    
-    NLdll DLL_handle;
+	FUNPTR_set_default_options set_default_options;
+	FUNPTR_ilu_set_default_options ilu_set_default_options;
+	FUNPTR_StatInit StatInit;
+	FUNPTR_StatFree StatFree;
+	FUNPTR_dCreate_CompCol_Matrix dCreate_CompCol_Matrix;
+	FUNPTR_dCreate_Dense_Matrix dCreate_Dense_Matrix;
+	FUNPTR_Destroy_SuperNode_Matrix Destroy_SuperNode_Matrix;
+	FUNPTR_Destroy_CompCol_Matrix Destroy_CompCol_Matrix;
+	FUNPTR_Destroy_CompCol_Permuted Destroy_CompCol_Permuted;
+	FUNPTR_Destroy_SuperMatrix_Store Destroy_SuperMatrix_Store;
+	FUNPTR_dgssv dgssv;
+	FUNPTR_dgstrs dgstrs;
+	FUNPTR_get_perm_c get_perm_c;
+	FUNPTR_sp_preorder sp_preorder;
+	FUNPTR_sp_ienv sp_ienv;
+	FUNPTR_dgstrf dgstrf;
+	FUNPTR_input_error input_error;
+
+	NLdll DLL_handle;
 } SuperLUContext;
 
 static SuperLUContext* SuperLU() {
-    static SuperLUContext context;
-    static NLboolean init = NL_FALSE;
-    if(!init) {
-        init = NL_TRUE;
-        memset(&context, 0, sizeof(context));
-    }
-    return &context;
+	static SuperLUContext context;
+	static NLboolean init = NL_FALSE;
+	if(!init) {
+		init = NL_TRUE;
+		memset(&context, 0, sizeof(context));
+	}
+	return &context;
 }
 
 static NLboolean SuperLU_is_initialized() {
-    return
-        SuperLU()->DLL_handle != NULL &&
-        SuperLU()->set_default_options != NULL &&
-        SuperLU()->ilu_set_default_options != NULL &&   
-        SuperLU()->StatInit != NULL &&
-        SuperLU()->StatFree != NULL &&
-        SuperLU()->dCreate_CompCol_Matrix != NULL &&
-        SuperLU()->dCreate_Dense_Matrix != NULL &&
-        SuperLU()->Destroy_SuperNode_Matrix != NULL &&
-        SuperLU()->Destroy_CompCol_Matrix != NULL &&
-        SuperLU()->Destroy_CompCol_Permuted != NULL &&	
-        SuperLU()->Destroy_SuperMatrix_Store != NULL &&
-        SuperLU()->dgssv != NULL &&
-        SuperLU()->dgstrs != NULL &&
+	return
+		SuperLU()->DLL_handle != NULL &&
+		SuperLU()->set_default_options != NULL &&
+		SuperLU()->ilu_set_default_options != NULL &&
+		SuperLU()->StatInit != NULL &&
+		SuperLU()->StatFree != NULL &&
+		SuperLU()->dCreate_CompCol_Matrix != NULL &&
+		SuperLU()->dCreate_Dense_Matrix != NULL &&
+		SuperLU()->Destroy_SuperNode_Matrix != NULL &&
+		SuperLU()->Destroy_CompCol_Matrix != NULL &&
+		SuperLU()->Destroy_CompCol_Permuted != NULL &&
+		SuperLU()->Destroy_SuperMatrix_Store != NULL &&
+		SuperLU()->dgssv != NULL &&
+		SuperLU()->dgstrs != NULL &&
 	SuperLU()->get_perm_c != NULL &&
 	SuperLU()->sp_preorder != NULL &&
 	SuperLU()->sp_ienv != NULL &&
@@ -4264,283 +4264,283 @@ static NLboolean SuperLU_is_initialized() {
 }
 
 static void nlTerminateExtension_SUPERLU(void) {
-    if(SuperLU()->DLL_handle != NULL) {
-        nlCloseDLL(SuperLU()->DLL_handle);
-        SuperLU()->DLL_handle = NULL;
-    }
+	if(SuperLU()->DLL_handle != NULL) {
+		nlCloseDLL(SuperLU()->DLL_handle);
+		SuperLU()->DLL_handle = NULL;
+	}
 }
 
 
 #define find_superlu_func(name)                                   \
-    if(                                                           \
-        (                                                         \
-            SuperLU()->name =                                     \
-            (FUNPTR_##name)nlFindFunction(SuperLU()->DLL_handle,#name) \
-        ) == NULL                                                 \
-    ) {                                                           \
-        nlError("nlInitExtension_SUPERLU","function not found");  \
-        nlError("nlInitExtension_SUPERLU",#name);                 \
-        return NL_FALSE;                                          \
-    }
+	if(                                                           \
+		(                                                         \
+			SuperLU()->name =                                     \
+			(FUNPTR_##name)nlFindFunction(SuperLU()->DLL_handle,#name) \
+		) == NULL                                                 \
+	) {                                                           \
+		nlError("nlInitExtension_SUPERLU","function not found");  \
+		nlError("nlInitExtension_SUPERLU",#name);                 \
+		return NL_FALSE;                                          \
+	}
 
 
 NLboolean nlInitExtension_SUPERLU(void) {
-    
-    if(SuperLU()->DLL_handle != NULL) {
-        return SuperLU_is_initialized();
-    }
 
-    SuperLU()->DLL_handle = nlOpenDLL(SUPERLU_LIB_NAME);
-    if(SuperLU()->DLL_handle == NULL) {
-        return NL_FALSE;
-    }
-    
-    find_superlu_func(set_default_options);
-    find_superlu_func(ilu_set_default_options);    
-    find_superlu_func(StatInit);
-    find_superlu_func(StatFree);
-    find_superlu_func(dCreate_CompCol_Matrix);
-    find_superlu_func(dCreate_Dense_Matrix);
-    find_superlu_func(Destroy_SuperNode_Matrix);
-    find_superlu_func(Destroy_CompCol_Matrix);
-    find_superlu_func(Destroy_CompCol_Permuted);        
-    find_superlu_func(Destroy_SuperMatrix_Store);
-    find_superlu_func(dgssv);
-    find_superlu_func(dgstrs);
-    find_superlu_func(get_perm_c);    
-    find_superlu_func(sp_preorder);
-    find_superlu_func(sp_ienv);
-    find_superlu_func(dgstrf);
-    find_superlu_func(input_error);
+	if(SuperLU()->DLL_handle != NULL) {
+		return SuperLU_is_initialized();
+	}
 
-    atexit(nlTerminateExtension_SUPERLU);
-    return NL_TRUE;
+	SuperLU()->DLL_handle = nlOpenDLL(SUPERLU_LIB_NAME);
+	if(SuperLU()->DLL_handle == NULL) {
+		return NL_FALSE;
+	}
+
+	find_superlu_func(set_default_options);
+	find_superlu_func(ilu_set_default_options);
+	find_superlu_func(StatInit);
+	find_superlu_func(StatFree);
+	find_superlu_func(dCreate_CompCol_Matrix);
+	find_superlu_func(dCreate_Dense_Matrix);
+	find_superlu_func(Destroy_SuperNode_Matrix);
+	find_superlu_func(Destroy_CompCol_Matrix);
+	find_superlu_func(Destroy_CompCol_Permuted);
+	find_superlu_func(Destroy_SuperMatrix_Store);
+	find_superlu_func(dgssv);
+	find_superlu_func(dgstrs);
+	find_superlu_func(get_perm_c);
+	find_superlu_func(sp_preorder);
+	find_superlu_func(sp_ienv);
+	find_superlu_func(dgstrf);
+	find_superlu_func(input_error);
+
+	atexit(nlTerminateExtension_SUPERLU);
+	return NL_TRUE;
 }
 
 
 
 typedef struct {
-    NLuint m;
+	NLuint m;
 
-    NLuint n;
+	NLuint n;
 
-    NLenum type;
+	NLenum type;
 
-    NLDestroyMatrixFunc destroy_func;
+	NLDestroyMatrixFunc destroy_func;
 
-    NLMultMatrixVectorFunc mult_func;
+	NLMultMatrixVectorFunc mult_func;
 
-    SuperMatrix L;
+	SuperMatrix L;
 
-    SuperMatrix U;
+	SuperMatrix U;
 
-    int* perm_r;
+	int* perm_r;
 
-    int* perm_c;
+	int* perm_c;
 
-    trans_t trans;
-    
+	trans_t trans;
+
 } NLSuperLUFactorizedMatrix;
 
 
 static void nlSuperLUFactorizedMatrixDestroy(NLSuperLUFactorizedMatrix* M) {
-    SuperLU()->Destroy_SuperNode_Matrix(&M->L);
-    SuperLU()->Destroy_CompCol_Matrix(&M->U);    
-    NL_DELETE_ARRAY(M->perm_r);
-    NL_DELETE_ARRAY(M->perm_c);
+	SuperLU()->Destroy_SuperNode_Matrix(&M->L);
+	SuperLU()->Destroy_CompCol_Matrix(&M->U);
+	NL_DELETE_ARRAY(M->perm_r);
+	NL_DELETE_ARRAY(M->perm_c);
 }
 
 static void nlSuperLUFactorizedMatrixMult(
-    NLSuperLUFactorizedMatrix* M, const double* x, double* y
+	NLSuperLUFactorizedMatrix* M, const double* x, double* y
 ) {
-    SuperMatrix B;
-    SuperLUStat_t stat;
-    int info = 0;
-    NLuint i;
+	SuperMatrix B;
+	SuperLUStat_t stat;
+	int info = 0;
+	NLuint i;
 
-    /* Create vector */
-    SuperLU()->dCreate_Dense_Matrix(
-        &B, (int)(M->n), 1, y, (int)(M->n), 
-        SLU_DN, /* Fortran-type column-wise storage */
-        SLU_D,  /* doubles */
-        SLU_GE  /* general */
-    );
+	/* Create vector */
+	SuperLU()->dCreate_Dense_Matrix(
+		&B, (int)(M->n), 1, y, (int)(M->n),
+		SLU_DN, /* Fortran-type column-wise storage */
+		SLU_D,  /* doubles */
+		SLU_GE  /* general */
+	);
 
-    /* copy rhs onto y (superLU matrix-vector product expects it here */
-    for(i = 0; i < M->n; i++){
-        y[i] = x[i];
-    }
+	/* copy rhs onto y (superLU matrix-vector product expects it here */
+	for(i = 0; i < M->n; i++){
+		y[i] = x[i];
+	}
 
-    /* Call SuperLU triangular solve */
-    SuperLU()->StatInit(&stat) ;
+	/* Call SuperLU triangular solve */
+	SuperLU()->StatInit(&stat) ;
 
-    SuperLU()->dgstrs(
-       M->trans, &M->L, &M->U, M->perm_c, M->perm_r, &B, &stat, &info
-    );
+	SuperLU()->dgstrs(
+	   M->trans, &M->L, &M->U, M->perm_c, M->perm_r, &B, &stat, &info
+	);
 
-    SuperLU()->StatFree(&stat) ;
-    
-    /*  Only the "store" structure needs to be 
-     *  deallocated (the array has been allocated
-     * by client code).
-     */
-    SuperLU()->Destroy_SuperMatrix_Store(&B) ;
+	SuperLU()->StatFree(&stat) ;
+
+	/*  Only the "store" structure needs to be
+	 *  deallocated (the array has been allocated
+	 * by client code).
+	 */
+	SuperLU()->Destroy_SuperMatrix_Store(&B) ;
 }
 
 /*
  * Copied from SUPERLU/dgssv.c, removed call to linear solve.
  */
 static void dgssv_factorize_only(
-      superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
-      SuperMatrix *L, SuperMatrix *U,
-      SuperLUStat_t *stat, int *info, trans_t *trans
+	  superlu_options_t *options, SuperMatrix *A, int *perm_c, int *perm_r,
+	  SuperMatrix *L, SuperMatrix *U,
+	  SuperLUStat_t *stat, int *info, trans_t *trans
 ) {
-    SuperMatrix *AA = NULL;
-        /* A in SLU_NC format used by the factorization routine.*/
-    SuperMatrix AC; /* Matrix postmultiplied by Pc */
-    int      lwork = 0, *etree, i;
-    GlobalLU_t Glu; /* Not needed on return. */
-    
-    /* Set default values for some parameters */
-    int      panel_size;     /* panel size */
-    int      relax;          /* no of columns in a relaxed snodes */
-    int      permc_spec;
+	SuperMatrix *AA = NULL;
+		/* A in SLU_NC format used by the factorization routine.*/
+	SuperMatrix AC; /* Matrix postmultiplied by Pc */
+	int      lwork = 0, *etree, i;
+	GlobalLU_t Glu; /* Not needed on return. */
 
-    nl_assert(A->Stype == SLU_NR || A->Stype == SLU_NC);
-    
-    *trans = NOTRANS;
+	/* Set default values for some parameters */
+	int      panel_size;     /* panel size */
+	int      relax;          /* no of columns in a relaxed snodes */
+	int      permc_spec;
 
-    if ( options->Fact != DOFACT ) *info = -1;
-    else if ( A->nrow != A->ncol || A->nrow < 0 ||
+	nl_assert(A->Stype == SLU_NR || A->Stype == SLU_NC);
+
+	*trans = NOTRANS;
+
+	if ( options->Fact != DOFACT ) *info = -1;
+	else if ( A->nrow != A->ncol || A->nrow < 0 ||
 	 (A->Stype != SLU_NC && A->Stype != SLU_NR) ||
 	 A->Dtype != SLU_D || A->Mtype != SLU_GE )
 	*info = -2;
-    if ( *info != 0 ) {
+	if ( *info != 0 ) {
 	i = -(*info);
 	SuperLU()->input_error("SUPERLU/OpenNL dgssv_factorize_only", &i);
 	return;
-    }
+	}
 
-    /* Convert A to SLU_NC format when necessary. */
-    if ( A->Stype == SLU_NR ) {
+	/* Convert A to SLU_NC format when necessary. */
+	if ( A->Stype == SLU_NR ) {
 	NRformat *Astore = (NRformat*)A->Store;
 	AA = NL_NEW(SuperMatrix);
 	SuperLU()->dCreate_CompCol_Matrix(
-	    AA, A->ncol, A->nrow, Astore->nnz, 
-	    (double*)Astore->nzval, Astore->colind, Astore->rowptr,
-	    SLU_NC, A->Dtype, A->Mtype
+		AA, A->ncol, A->nrow, Astore->nnz,
+		(double*)Astore->nzval, Astore->colind, Astore->rowptr,
+		SLU_NC, A->Dtype, A->Mtype
 	);
 	*trans = TRANS;
-    } else {
-        if ( A->Stype == SLU_NC ) AA = A;
-    }
+	} else {
+		if ( A->Stype == SLU_NC ) AA = A;
+	}
 
-    nl_assert(AA != NULL);
-    
-    /*
-     * Get column permutation vector perm_c[], according to permc_spec:
-     *   permc_spec = NATURAL:  natural ordering 
-     *   permc_spec = MMD_AT_PLUS_A: minimum degree on structure of A'+A
-     *   permc_spec = MMD_ATA:  minimum degree on structure of A'*A
-     *   permc_spec = COLAMD:   approximate minimum degree column ordering
-     *   permc_spec = MY_PERMC: the ordering already supplied in perm_c[]
-     */
-    permc_spec = options->ColPerm;
-    if ( permc_spec != MY_PERMC && options->Fact == DOFACT )
+	nl_assert(AA != NULL);
+
+	/*
+	 * Get column permutation vector perm_c[], according to permc_spec:
+	 *   permc_spec = NATURAL:  natural ordering
+	 *   permc_spec = MMD_AT_PLUS_A: minimum degree on structure of A'+A
+	 *   permc_spec = MMD_ATA:  minimum degree on structure of A'*A
+	 *   permc_spec = COLAMD:   approximate minimum degree column ordering
+	 *   permc_spec = MY_PERMC: the ordering already supplied in perm_c[]
+	 */
+	permc_spec = options->ColPerm;
+	if ( permc_spec != MY_PERMC && options->Fact == DOFACT )
 	SuperLU()->get_perm_c(permc_spec, AA, perm_c);
-    
-    etree = NL_NEW_ARRAY(int,A->ncol);
-    SuperLU()->sp_preorder(options, AA, perm_c, etree, &AC);
-    panel_size = SuperLU()->sp_ienv(1);
-    relax = SuperLU()->sp_ienv(2);
-    SuperLU()->dgstrf(options, &AC, relax, panel_size, etree,
-            NULL, lwork, perm_c, perm_r, L, U, &Glu, stat, info);
 
-    NL_DELETE_ARRAY(etree);
-    SuperLU()->Destroy_CompCol_Permuted(&AC);
-    if ( A->Stype == SLU_NR ) {
+	etree = NL_NEW_ARRAY(int,A->ncol);
+	SuperLU()->sp_preorder(options, AA, perm_c, etree, &AC);
+	panel_size = SuperLU()->sp_ienv(1);
+	relax = SuperLU()->sp_ienv(2);
+	SuperLU()->dgstrf(options, &AC, relax, panel_size, etree,
+			NULL, lwork, perm_c, perm_r, L, U, &Glu, stat, info);
+
+	NL_DELETE_ARRAY(etree);
+	SuperLU()->Destroy_CompCol_Permuted(&AC);
+	if ( A->Stype == SLU_NR ) {
 	SuperLU()->Destroy_SuperMatrix_Store(AA);
 	NL_DELETE(AA);
-    }
+	}
 }
 
 
 NLMatrix nlMatrixFactorize_SUPERLU(
-    NLMatrix M, NLenum solver
+	NLMatrix M, NLenum solver
 ) {
-    NLSuperLUFactorizedMatrix* LU = NULL;
-    NLCRSMatrix* CRS = NULL;
-    SuperMatrix superM;
-    NLuint n = M->n;
-    superlu_options_t options;
-    SuperLUStat_t     stat;
-    NLint info = 0;       /* status code  */
-    
-    nl_assert(M->m == M->n);
+	NLSuperLUFactorizedMatrix* LU = NULL;
+	NLCRSMatrix* CRS = NULL;
+	SuperMatrix superM;
+	NLuint n = M->n;
+	superlu_options_t options;
+	SuperLUStat_t     stat;
+	NLint info = 0;       /* status code  */
 
-    if(M->type == NL_MATRIX_CRS) {
-        CRS = (NLCRSMatrix*)M;
-    } else if(M->type == NL_MATRIX_SPARSE_DYNAMIC) {
-        CRS = (NLCRSMatrix*)nlCRSMatrixNewFromSparseMatrix((NLSparseMatrix*)M);
-    }
+	nl_assert(M->m == M->n);
 
-    LU = NL_NEW(NLSuperLUFactorizedMatrix);
-    LU->m = M->m;
-    LU->n = M->n;
-    LU->type = NL_MATRIX_OTHER;
-    LU->destroy_func = (NLDestroyMatrixFunc)(nlSuperLUFactorizedMatrixDestroy);
-    LU->mult_func = (NLMultMatrixVectorFunc)(nlSuperLUFactorizedMatrixMult);
-    LU->perm_c = NL_NEW_ARRAY(int, n);
-    LU->perm_r = NL_NEW_ARRAY(int, n);    
+	if(M->type == NL_MATRIX_CRS) {
+		CRS = (NLCRSMatrix*)M;
+	} else if(M->type == NL_MATRIX_SPARSE_DYNAMIC) {
+		CRS = (NLCRSMatrix*)nlCRSMatrixNewFromSparseMatrix((NLSparseMatrix*)M);
+	}
 
-    SuperLU()->dCreate_CompCol_Matrix(
-        &superM, (int)n, (int)n, (int)nlCRSMatrixNNZ(CRS),
-        CRS->val, (int*)CRS->colind, (int*)CRS->rowptr, 
-        SLU_NR,              /* Row_wise, no supernode */
-        SLU_D,               /* doubles                */ 
-        CRS->symmetric_storage ? SLU_SYL : SLU_GE
-    );
+	LU = NL_NEW(NLSuperLUFactorizedMatrix);
+	LU->m = M->m;
+	LU->n = M->n;
+	LU->type = NL_MATRIX_OTHER;
+	LU->destroy_func = (NLDestroyMatrixFunc)(nlSuperLUFactorizedMatrixDestroy);
+	LU->mult_func = (NLMultMatrixVectorFunc)(nlSuperLUFactorizedMatrixMult);
+	LU->perm_c = NL_NEW_ARRAY(int, n);
+	LU->perm_r = NL_NEW_ARRAY(int, n);
 
-    SuperLU()->set_default_options(&options);
-    switch(solver) {
-    case NL_SUPERLU_EXT: {
-        options.ColPerm = NATURAL;
-    } break;
-    case NL_PERM_SUPERLU_EXT: {
-        options.ColPerm = COLAMD;
-    } break;
-    case NL_SYMMETRIC_SUPERLU_EXT: {
-        options.ColPerm = MMD_AT_PLUS_A;
-        options.SymmetricMode = YES;
-    } break;
-    default: 
-        nl_assert_not_reached;
-    }
-    
-    SuperLU()->StatInit(&stat);
+	SuperLU()->dCreate_CompCol_Matrix(
+		&superM, (int)n, (int)n, (int)nlCRSMatrixNNZ(CRS),
+		CRS->val, (int*)CRS->colind, (int*)CRS->rowptr,
+		SLU_NR,              /* Row_wise, no supernode */
+		SLU_D,               /* doubles                */
+		CRS->symmetric_storage ? SLU_SYL : SLU_GE
+	);
 
-    dgssv_factorize_only(
+	SuperLU()->set_default_options(&options);
+	switch(solver) {
+	case NL_SUPERLU_EXT: {
+		options.ColPerm = NATURAL;
+	} break;
+	case NL_PERM_SUPERLU_EXT: {
+		options.ColPerm = COLAMD;
+	} break;
+	case NL_SYMMETRIC_SUPERLU_EXT: {
+		options.ColPerm = MMD_AT_PLUS_A;
+		options.SymmetricMode = YES;
+	} break;
+	default:
+		nl_assert_not_reached;
+	}
+
+	SuperLU()->StatInit(&stat);
+
+	dgssv_factorize_only(
 	  &options, &superM, LU->perm_c, LU->perm_r,
 	  &LU->L, &LU->U, &stat, &info, &LU->trans
-    );
+	);
 
-    SuperLU()->StatFree(&stat);
-    
-    /*
-     * Only the "store" structure needs to be deallocated 
-     * (the arrays have been allocated by us, they are in CRS).
-     */
-    SuperLU()->Destroy_SuperMatrix_Store(&superM);
-    
-    if((NLMatrix)CRS != M) {
-        nlDeleteMatrix((NLMatrix)CRS);
-    }
+	SuperLU()->StatFree(&stat);
 
-    if(info != 0) {
+	/*
+	 * Only the "store" structure needs to be deallocated
+	 * (the arrays have been allocated by us, they are in CRS).
+	 */
+	SuperLU()->Destroy_SuperMatrix_Store(&superM);
+
+	if((NLMatrix)CRS != M) {
+		nlDeleteMatrix((NLMatrix)CRS);
+	}
+
+	if(info != 0) {
 	NL_DELETE(LU);
 	LU = NULL;
-    }
-    return (NLMatrix)LU;
+	}
+	return (NLMatrix)LU;
 }
 
 /******* extracted from nl_cholmod.c *******/
@@ -4565,66 +4565,66 @@ NLMatrix nlMatrixFactorize_SUPERLU(
  * no integers.  Entry in row i and column j is located in x [i+j*d].
  */
 typedef struct cholmod_dense_struct {
-    size_t nrow ;       /* the matrix is nrow-by-ncol */
-    size_t ncol ;
-    size_t nzmax ;      /* maximum number of entries in the matrix */
-    size_t d ;          /* leading dimension (d >= nrow must hold) */
-    void *x ;           /* size nzmax or 2*nzmax, if present */
-    void *z ;           /* size nzmax, if present */
-    int xtype ;         /* pattern, real, complex, or zomplex */
-    int dtype ;         /* x and z double or float */
+	size_t nrow ;       /* the matrix is nrow-by-ncol */
+	size_t ncol ;
+	size_t nzmax ;      /* maximum number of entries in the matrix */
+	size_t d ;          /* leading dimension (d >= nrow must hold) */
+	void *x ;           /* size nzmax or 2*nzmax, if present */
+	void *z ;           /* size nzmax, if present */
+	int xtype ;         /* pattern, real, complex, or zomplex */
+	int dtype ;         /* x and z double or float */
 } cholmod_dense ;
 
 /* A sparse matrix stored in compressed-column form. */
 
 typedef struct cholmod_sparse_struct
 {
-    size_t nrow ;       /* the matrix is nrow-by-ncol */
-    size_t ncol ;
-    size_t nzmax ;      /* maximum number of entries in the matrix */
+	size_t nrow ;       /* the matrix is nrow-by-ncol */
+	size_t ncol ;
+	size_t nzmax ;      /* maximum number of entries in the matrix */
 
-    /* pointers to int or SuiteSparse_long: */
-    void *p ;           /* p [0..ncol], the column pointers */
-    void *i ;           /* i [0..nzmax-1], the row indices */
+	/* pointers to int or SuiteSparse_long: */
+	void *p ;           /* p [0..ncol], the column pointers */
+	void *i ;           /* i [0..nzmax-1], the row indices */
 
-    /* for unpacked matrices only: */
-    void *nz ;          /* nz [0..ncol-1], the # of nonzeros in each col.  In
-                         * packed form, the nonzero pattern of column j is in
-        * A->i [A->p [j] ... A->p [j+1]-1].  In unpacked form, column j is in
-        * A->i [A->p [j] ... A->p [j]+A->nz[j]-1] instead.  In both cases, the
-        * numerical values (if present) are in the corresponding locations in
-        * the array x (or z if A->xtype is CHOLMOD_ZOMPLEX). */
+	/* for unpacked matrices only: */
+	void *nz ;          /* nz [0..ncol-1], the # of nonzeros in each col.  In
+						 * packed form, the nonzero pattern of column j is in
+		* A->i [A->p [j] ... A->p [j+1]-1].  In unpacked form, column j is in
+		* A->i [A->p [j] ... A->p [j]+A->nz[j]-1] instead.  In both cases, the
+		* numerical values (if present) are in the corresponding locations in
+		* the array x (or z if A->xtype is CHOLMOD_ZOMPLEX). */
 
-    /* pointers to double or float: */
-    void *x ;           /* size nzmax or 2*nzmax, if present */
-    void *z ;           /* size nzmax, if present */
+	/* pointers to double or float: */
+	void *x ;           /* size nzmax or 2*nzmax, if present */
+	void *z ;           /* size nzmax, if present */
 
-    int stype ;         /* Describes what parts of the matrix are considered:
-                         *
-        * 0:  matrix is "unsymmetric": use both upper and lower triangular parts
-        *     (the matrix may actually be symmetric in pattern and value, but
-        *     both parts are explicitly stored and used).  May be square or
-        *     rectangular.
-        * >0: matrix is square and symmetric, use upper triangular part.
-        *     Entries in the lower triangular part are ignored.
-        * <0: matrix is square and symmetric, use lower triangular part.
-        *     Entries in the upper triangular part are ignored.
-        *
-        * Note that stype>0 and stype<0 are different for cholmod_sparse and
-        * cholmod_triplet.  See the cholmod_triplet data structure for more
-        * details.
-        */
+	int stype ;         /* Describes what parts of the matrix are considered:
+						 *
+		* 0:  matrix is "unsymmetric": use both upper and lower triangular parts
+		*     (the matrix may actually be symmetric in pattern and value, but
+		*     both parts are explicitly stored and used).  May be square or
+		*     rectangular.
+		* >0: matrix is square and symmetric, use upper triangular part.
+		*     Entries in the lower triangular part are ignored.
+		* <0: matrix is square and symmetric, use lower triangular part.
+		*     Entries in the upper triangular part are ignored.
+		*
+		* Note that stype>0 and stype<0 are different for cholmod_sparse and
+		* cholmod_triplet.  See the cholmod_triplet data structure for more
+		* details.
+		*/
 
-    int itype ;         /* CHOLMOD_INT:     p, i, and nz are int.
-                         * CHOLMOD_INTLONG: p is SuiteSparse_long,
-                         *                  i and nz are int.
-                         * CHOLMOD_LONG:    p, i, and nz are SuiteSparse_long */
+	int itype ;         /* CHOLMOD_INT:     p, i, and nz are int.
+						 * CHOLMOD_INTLONG: p is SuiteSparse_long,
+						 *                  i and nz are int.
+						 * CHOLMOD_LONG:    p, i, and nz are SuiteSparse_long */
 
-    int xtype ;         /* pattern, real, complex, or zomplex */
-    int dtype ;         /* x and z are double or float */
-    int sorted ;        /* TRUE if columns are sorted, FALSE otherwise */
-    int packed ;        /* TRUE if packed (nz ignored), FALSE if unpacked
-                         * (nz is required) */
+	int xtype ;         /* pattern, real, complex, or zomplex */
+	int dtype ;         /* x and z are double or float */
+	int sorted ;        /* TRUE if columns are sorted, FALSE otherwise */
+	int packed ;        /* TRUE if packed (nz ignored), FALSE if unpacked
+						 * (nz is required) */
 
 } cholmod_sparse ;
 
@@ -4637,287 +4637,287 @@ typedef void* cholmod_factor_ptr;
 
 
 typedef enum cholmod_xtype_enum {
-    CHOLMOD_PATTERN =0,
-    CHOLMOD_REAL    =1,
-    CHOLMOD_COMPLEX =2,
-    CHOLMOD_ZOMPLEX =3
+	CHOLMOD_PATTERN =0,
+	CHOLMOD_REAL    =1,
+	CHOLMOD_COMPLEX =2,
+	CHOLMOD_ZOMPLEX =3
 } cholmod_xtype;
 
 
 typedef enum cholmod_solve_type_enum {
-   CHOLMOD_A    =0,   
-   CHOLMOD_LDLt =1,   
-   CHOLMOD_LD   =2,   
-   CHOLMOD_DLt  =3,   
-   CHOLMOD_L    =4,   
-   CHOLMOD_Lt   =5,   
-   CHOLMOD_D    =6,   
-   CHOLMOD_P    =7,   
-   CHOLMOD_Pt   =8   
+   CHOLMOD_A    =0,
+   CHOLMOD_LDLt =1,
+   CHOLMOD_LD   =2,
+   CHOLMOD_DLt  =3,
+   CHOLMOD_L    =4,
+   CHOLMOD_Lt   =5,
+   CHOLMOD_D    =6,
+   CHOLMOD_P    =7,
+   CHOLMOD_Pt   =8
 } cholmod_solve_type;
-    
+
 typedef int cholmod_stype;
 
 typedef void (*FUNPTR_cholmod_start)(cholmod_common_ptr);
 
 typedef cholmod_sparse_ptr (*FUNPTR_cholmod_allocate_sparse)(
-    size_t m, size_t n, size_t nnz, int sorted,
-    int packed, int stype, int xtype, cholmod_common_ptr
+	size_t m, size_t n, size_t nnz, int sorted,
+	int packed, int stype, int xtype, cholmod_common_ptr
 );
 
 typedef cholmod_dense_ptr (*FUNPTR_cholmod_allocate_dense)(
-    size_t m, size_t n, size_t d, int xtype, cholmod_common_ptr
+	size_t m, size_t n, size_t d, int xtype, cholmod_common_ptr
 );
 
 typedef cholmod_factor_ptr (*FUNPTR_cholmod_analyze)(
-    cholmod_sparse_ptr A, cholmod_common_ptr
+	cholmod_sparse_ptr A, cholmod_common_ptr
 );
 
 typedef int (*FUNPTR_cholmod_factorize)(
-    cholmod_sparse_ptr A, cholmod_factor_ptr L, cholmod_common_ptr
+	cholmod_sparse_ptr A, cholmod_factor_ptr L, cholmod_common_ptr
 );
 
 typedef cholmod_dense_ptr (*FUNPTR_cholmod_solve)(
-    int solve_type, cholmod_factor_ptr, cholmod_dense_ptr, cholmod_common_ptr
+	int solve_type, cholmod_factor_ptr, cholmod_dense_ptr, cholmod_common_ptr
 );
 
 typedef void (*FUNPTR_cholmod_free_factor)(
-    cholmod_factor_ptr*, cholmod_common_ptr
+	cholmod_factor_ptr*, cholmod_common_ptr
 );
 
 typedef void (*FUNPTR_cholmod_free_dense)(
-    cholmod_dense_ptr*, cholmod_common_ptr
+	cholmod_dense_ptr*, cholmod_common_ptr
 );
 
 typedef void (*FUNPTR_cholmod_free_sparse)(
-    cholmod_sparse_ptr*, cholmod_common_ptr
+	cholmod_sparse_ptr*, cholmod_common_ptr
 );
 
 typedef void (*FUNPTR_cholmod_finish)(cholmod_common_ptr);
 
 typedef struct {
-    char cholmod_common[16384];
+	char cholmod_common[16384];
 
-    FUNPTR_cholmod_start cholmod_start;
-    FUNPTR_cholmod_allocate_sparse cholmod_allocate_sparse;
-    FUNPTR_cholmod_allocate_dense cholmod_allocate_dense;
-    FUNPTR_cholmod_analyze cholmod_analyze;
-    FUNPTR_cholmod_factorize cholmod_factorize;
-    FUNPTR_cholmod_solve cholmod_solve;
-    FUNPTR_cholmod_free_factor cholmod_free_factor;
-    FUNPTR_cholmod_free_sparse cholmod_free_sparse;        
-    FUNPTR_cholmod_free_dense cholmod_free_dense;
-    FUNPTR_cholmod_finish cholmod_finish;
-    
-    NLdll DLL_handle;
+	FUNPTR_cholmod_start cholmod_start;
+	FUNPTR_cholmod_allocate_sparse cholmod_allocate_sparse;
+	FUNPTR_cholmod_allocate_dense cholmod_allocate_dense;
+	FUNPTR_cholmod_analyze cholmod_analyze;
+	FUNPTR_cholmod_factorize cholmod_factorize;
+	FUNPTR_cholmod_solve cholmod_solve;
+	FUNPTR_cholmod_free_factor cholmod_free_factor;
+	FUNPTR_cholmod_free_sparse cholmod_free_sparse;
+	FUNPTR_cholmod_free_dense cholmod_free_dense;
+	FUNPTR_cholmod_finish cholmod_finish;
+
+	NLdll DLL_handle;
 } CHOLMODContext;
 
 static CHOLMODContext* CHOLMOD() {
-    static CHOLMODContext context;
-    static NLboolean init = NL_FALSE;
-    if(!init) {
-        init = NL_TRUE;
-        memset(&context, 0, sizeof(context));
-    }
-    return &context;
+	static CHOLMODContext context;
+	static NLboolean init = NL_FALSE;
+	if(!init) {
+		init = NL_TRUE;
+		memset(&context, 0, sizeof(context));
+	}
+	return &context;
 }
 
 
 static NLboolean CHOLMOD_is_initialized() {
-    return
-        CHOLMOD()->DLL_handle != NULL &&
-        CHOLMOD()->cholmod_start != NULL &&
-        CHOLMOD()->cholmod_allocate_sparse != NULL &&
-        CHOLMOD()->cholmod_allocate_dense != NULL &&
-        CHOLMOD()->cholmod_analyze != NULL &&
-        CHOLMOD()->cholmod_factorize != NULL &&
-        CHOLMOD()->cholmod_solve != NULL &&
-        CHOLMOD()->cholmod_free_factor != NULL &&
-        CHOLMOD()->cholmod_free_sparse != NULL &&
-        CHOLMOD()->cholmod_free_dense != NULL &&
-        CHOLMOD()->cholmod_finish != NULL ;
+	return
+		CHOLMOD()->DLL_handle != NULL &&
+		CHOLMOD()->cholmod_start != NULL &&
+		CHOLMOD()->cholmod_allocate_sparse != NULL &&
+		CHOLMOD()->cholmod_allocate_dense != NULL &&
+		CHOLMOD()->cholmod_analyze != NULL &&
+		CHOLMOD()->cholmod_factorize != NULL &&
+		CHOLMOD()->cholmod_solve != NULL &&
+		CHOLMOD()->cholmod_free_factor != NULL &&
+		CHOLMOD()->cholmod_free_sparse != NULL &&
+		CHOLMOD()->cholmod_free_dense != NULL &&
+		CHOLMOD()->cholmod_finish != NULL ;
 }
 
 #define find_cholmod_func(name)                                        \
-    if(                                                                \
-        (                                                              \
-            CHOLMOD()->name =                                          \
-            (FUNPTR_##name)nlFindFunction(CHOLMOD()->DLL_handle,#name) \
-        ) == NULL                                                      \
-    ) {                                                                \
-        nlError("nlInitExtension_CHOLMOD","function not found");       \
-        return NL_FALSE;                                               \
-    }
+	if(                                                                \
+		(                                                              \
+			CHOLMOD()->name =                                          \
+			(FUNPTR_##name)nlFindFunction(CHOLMOD()->DLL_handle,#name) \
+		) == NULL                                                      \
+	) {                                                                \
+		nlError("nlInitExtension_CHOLMOD","function not found");       \
+		return NL_FALSE;                                               \
+	}
 
 
 static void nlTerminateExtension_CHOLMOD(void) {
-    if(CHOLMOD()->DLL_handle != NULL) {
-        CHOLMOD()->cholmod_finish(&CHOLMOD()->cholmod_common);
-        nlCloseDLL(CHOLMOD()->DLL_handle);
-        CHOLMOD()->DLL_handle = NULL;
-    }
+	if(CHOLMOD()->DLL_handle != NULL) {
+		CHOLMOD()->cholmod_finish(&CHOLMOD()->cholmod_common);
+		nlCloseDLL(CHOLMOD()->DLL_handle);
+		CHOLMOD()->DLL_handle = NULL;
+	}
 }
 
 NLboolean nlInitExtension_CHOLMOD(void) {
-    if(CHOLMOD()->DLL_handle != NULL) {
-        return CHOLMOD_is_initialized();
-    }
+	if(CHOLMOD()->DLL_handle != NULL) {
+		return CHOLMOD_is_initialized();
+	}
 
-    CHOLMOD()->DLL_handle = nlOpenDLL(CHOLMOD_LIB_NAME);
-    if(CHOLMOD()->DLL_handle == NULL) {
-        return NL_FALSE;
-    }
+	CHOLMOD()->DLL_handle = nlOpenDLL(CHOLMOD_LIB_NAME);
+	if(CHOLMOD()->DLL_handle == NULL) {
+		return NL_FALSE;
+	}
 
-    find_cholmod_func(cholmod_start);
-    find_cholmod_func(cholmod_allocate_sparse);
-    find_cholmod_func(cholmod_allocate_dense);
-    find_cholmod_func(cholmod_analyze);
-    find_cholmod_func(cholmod_factorize);
-    find_cholmod_func(cholmod_solve);
-    find_cholmod_func(cholmod_free_factor);
-    find_cholmod_func(cholmod_free_sparse);
-    find_cholmod_func(cholmod_free_dense);
-    find_cholmod_func(cholmod_finish);
+	find_cholmod_func(cholmod_start);
+	find_cholmod_func(cholmod_allocate_sparse);
+	find_cholmod_func(cholmod_allocate_dense);
+	find_cholmod_func(cholmod_analyze);
+	find_cholmod_func(cholmod_factorize);
+	find_cholmod_func(cholmod_solve);
+	find_cholmod_func(cholmod_free_factor);
+	find_cholmod_func(cholmod_free_sparse);
+	find_cholmod_func(cholmod_free_dense);
+	find_cholmod_func(cholmod_finish);
 
-    CHOLMOD()->cholmod_start(&CHOLMOD()->cholmod_common);
+	CHOLMOD()->cholmod_start(&CHOLMOD()->cholmod_common);
 
-    atexit(nlTerminateExtension_CHOLMOD);
-    return NL_TRUE;
+	atexit(nlTerminateExtension_CHOLMOD);
+	return NL_TRUE;
 }
 
 
 
 typedef struct {
-    NLuint m;
+	NLuint m;
 
-    NLuint n;
+	NLuint n;
 
-    NLenum type;
+	NLenum type;
 
-    NLDestroyMatrixFunc destroy_func;
+	NLDestroyMatrixFunc destroy_func;
 
-    NLMultMatrixVectorFunc mult_func;
+	NLMultMatrixVectorFunc mult_func;
 
-    cholmod_factor_ptr L;
-    
+	cholmod_factor_ptr L;
+
 } NLCholmodFactorizedMatrix;
 
 static void nlCholmodFactorizedMatrixDestroy(NLCholmodFactorizedMatrix* M) {
-    CHOLMOD()->cholmod_free_factor(&M->L, &CHOLMOD()->cholmod_common);
+	CHOLMOD()->cholmod_free_factor(&M->L, &CHOLMOD()->cholmod_common);
 }
 
 static void nlCholmodFactorizedMatrixMult(
-    NLCholmodFactorizedMatrix* M, const double* x, double* y
+	NLCholmodFactorizedMatrix* M, const double* x, double* y
 ) {
-    /* 
-     * TODO: see whether CHOLDMOD can use user-allocated vectors
-     * (and avoid copy)
-     */
-    cholmod_dense_ptr X=CHOLMOD()->cholmod_allocate_dense(
-        M->n, 1, M->n, CHOLMOD_REAL, &CHOLMOD()->cholmod_common
-    );
-    cholmod_dense_ptr Y=NULL;
+	/*
+	 * TODO: see whether CHOLDMOD can use user-allocated vectors
+	 * (and avoid copy)
+	 */
+	cholmod_dense_ptr X=CHOLMOD()->cholmod_allocate_dense(
+		M->n, 1, M->n, CHOLMOD_REAL, &CHOLMOD()->cholmod_common
+	);
+	cholmod_dense_ptr Y=NULL;
 
-    memcpy(X->x, x, M->n*sizeof(double));    
-    Y = CHOLMOD()->cholmod_solve(CHOLMOD_A, M->L, X, &CHOLMOD()->cholmod_common);
-    memcpy(y, Y->x, M->n*sizeof(double));    
-    
-    CHOLMOD()->cholmod_free_dense(&X, &CHOLMOD()->cholmod_common);
-    CHOLMOD()->cholmod_free_dense(&Y, &CHOLMOD()->cholmod_common);
+	memcpy(X->x, x, M->n*sizeof(double));
+	Y = CHOLMOD()->cholmod_solve(CHOLMOD_A, M->L, X, &CHOLMOD()->cholmod_common);
+	memcpy(y, Y->x, M->n*sizeof(double));
+
+	CHOLMOD()->cholmod_free_dense(&X, &CHOLMOD()->cholmod_common);
+	CHOLMOD()->cholmod_free_dense(&Y, &CHOLMOD()->cholmod_common);
 }
 
 NLMatrix nlMatrixFactorize_CHOLMOD(
-    NLMatrix M, NLenum solver
+	NLMatrix M, NLenum solver
 ) {
-    NLCholmodFactorizedMatrix* LLt = NULL;
-    NLCRSMatrix* CRS = NULL;
-    cholmod_sparse_ptr cM= NULL;
-    NLuint nnz, cur, i, j, jj;
-    int* rowptr = NULL;
-    int* colind = NULL;
-    double* val = NULL;
-    NLuint n = M->n;
+	NLCholmodFactorizedMatrix* LLt = NULL;
+	NLCRSMatrix* CRS = NULL;
+	cholmod_sparse_ptr cM= NULL;
+	NLuint nnz, cur, i, j, jj;
+	int* rowptr = NULL;
+	int* colind = NULL;
+	double* val = NULL;
+	NLuint n = M->n;
 
-    nl_assert(solver == NL_CHOLMOD_EXT);
-    nl_assert(M->m == M->n);
-    
-    if(M->type == NL_MATRIX_CRS) {
-        CRS = (NLCRSMatrix*)M;
-    } else if(M->type == NL_MATRIX_SPARSE_DYNAMIC) {
-	/* 
+	nl_assert(solver == NL_CHOLMOD_EXT);
+	nl_assert(M->m == M->n);
+
+	if(M->type == NL_MATRIX_CRS) {
+		CRS = (NLCRSMatrix*)M;
+	} else if(M->type == NL_MATRIX_SPARSE_DYNAMIC) {
+	/*
 	 * Note: since we convert once again into symmetric storage,
 	 * we could also directly read the NLSparseMatrix there instead
 	 * of copying once more...
 	 */
-        CRS = (NLCRSMatrix*)nlCRSMatrixNewFromSparseMatrix((NLSparseMatrix*)M);
-    }
-
-    LLt = NL_NEW(NLCholmodFactorizedMatrix);
-    LLt->m = M->m;
-    LLt->n = M->n;
-    LLt->type = NL_MATRIX_OTHER;
-    LLt->destroy_func = (NLDestroyMatrixFunc)(nlCholmodFactorizedMatrixDestroy);
-    LLt->mult_func = (NLMultMatrixVectorFunc)(nlCholmodFactorizedMatrixMult);
-
-    /*
-     * Compute required nnz, if matrix is not already with symmetric storage,
-     * ignore entries in the upper triangular part.
-     */
-    
-    nnz=0;
-    for(i=0; i<n; ++i) {
-	for(jj=CRS->rowptr[i]; jj<CRS->rowptr[i+1]; ++jj) {
-	    j=CRS->colind[jj];
-	    if(j <= i) {
-		++nnz;
-	    }
+		CRS = (NLCRSMatrix*)nlCRSMatrixNewFromSparseMatrix((NLSparseMatrix*)M);
 	}
-    }
 
-    /*
-     * Copy CRS matrix into CHOLDMOD matrix (and ignore upper trianglar part)
-     */
-    
-    cM = CHOLMOD()->cholmod_allocate_sparse(
-        n, n, nnz,    /* Dimensions and number of non-zeros */
-        NL_FALSE,     /* Sorted = false */
-        NL_TRUE,      /* Packed = true  */
-        1,            /* stype (-1 = lower triangular, 1 = upper triangular) */
-        CHOLMOD_REAL, /* Entries are real numbers */
-        &CHOLMOD()->cholmod_common
-    );
+	LLt = NL_NEW(NLCholmodFactorizedMatrix);
+	LLt->m = M->m;
+	LLt->n = M->n;
+	LLt->type = NL_MATRIX_OTHER;
+	LLt->destroy_func = (NLDestroyMatrixFunc)(nlCholmodFactorizedMatrixDestroy);
+	LLt->mult_func = (NLMultMatrixVectorFunc)(nlCholmodFactorizedMatrixMult);
 
-    rowptr = (int*)cM->p;
-    colind = (int*)cM->i;
-    val = (double*)cM->x;
-    cur = 0;
-    for(i=0; i<n; ++i) {
-        rowptr[i] = (int)cur;
+	/*
+	 * Compute required nnz, if matrix is not already with symmetric storage,
+	 * ignore entries in the upper triangular part.
+	 */
+
+	nnz=0;
+	for(i=0; i<n; ++i) {
 	for(jj=CRS->rowptr[i]; jj<CRS->rowptr[i+1]; ++jj) {
-            j = CRS->colind[jj];
-            if(j <= i) {
+		j=CRS->colind[jj];
+		if(j <= i) {
+		++nnz;
+		}
+	}
+	}
+
+	/*
+	 * Copy CRS matrix into CHOLDMOD matrix (and ignore upper trianglar part)
+	 */
+
+	cM = CHOLMOD()->cholmod_allocate_sparse(
+		n, n, nnz,    /* Dimensions and number of non-zeros */
+		NL_FALSE,     /* Sorted = false */
+		NL_TRUE,      /* Packed = true  */
+		1,            /* stype (-1 = lower triangular, 1 = upper triangular) */
+		CHOLMOD_REAL, /* Entries are real numbers */
+		&CHOLMOD()->cholmod_common
+	);
+
+	rowptr = (int*)cM->p;
+	colind = (int*)cM->i;
+	val = (double*)cM->x;
+	cur = 0;
+	for(i=0; i<n; ++i) {
+		rowptr[i] = (int)cur;
+	for(jj=CRS->rowptr[i]; jj<CRS->rowptr[i+1]; ++jj) {
+			j = CRS->colind[jj];
+			if(j <= i) {
 		val[cur] = CRS->val[jj];
 		colind[cur] = (int)j;
 		++cur;
-            }
-        }
-    }
-    rowptr[n] = (int)cur;
-    nl_assert(cur==nnz);
+			}
+		}
+	}
+	rowptr[n] = (int)cur;
+	nl_assert(cur==nnz);
 
-    LLt->L = CHOLMOD()->cholmod_analyze(cM, &CHOLMOD()->cholmod_common);
-    if(!CHOLMOD()->cholmod_factorize(cM, LLt->L, &CHOLMOD()->cholmod_common)) {
-        CHOLMOD()->cholmod_free_factor(&LLt->L, &CHOLMOD()->cholmod_common);
+	LLt->L = CHOLMOD()->cholmod_analyze(cM, &CHOLMOD()->cholmod_common);
+	if(!CHOLMOD()->cholmod_factorize(cM, LLt->L, &CHOLMOD()->cholmod_common)) {
+		CHOLMOD()->cholmod_free_factor(&LLt->L, &CHOLMOD()->cholmod_common);
 	NL_DELETE(LLt);
-    }
-    
-    CHOLMOD()->cholmod_free_sparse(&cM, &CHOLMOD()->cholmod_common);
-    
-    if((NLMatrix)CRS != M) {
-        nlDeleteMatrix((NLMatrix)CRS);
-    }
+	}
 
-    return (NLMatrix)(LLt);
+	CHOLMOD()->cholmod_free_sparse(&cM, &CHOLMOD()->cholmod_common);
+
+	if((NLMatrix)CRS != M) {
+		nlDeleteMatrix((NLMatrix)CRS);
+	}
+
+	return (NLMatrix)(LLt);
 }
 
 
@@ -4943,131 +4943,131 @@ typedef int ARlogical;
 /* double precision symmetric routines */
 
 typedef void (*FUNPTR_dsaupd)(
-    ARint *ido, char *bmat, ARint *n, char *which,
-    ARint *nev, double *tol, double *resid,
-    ARint *ncv, double *V, ARint *ldv,
-    ARint *iparam, ARint *ipntr, double *workd,
-    double *workl, ARint *lworkl, ARint *info
+	ARint *ido, char *bmat, ARint *n, char *which,
+	ARint *nev, double *tol, double *resid,
+	ARint *ncv, double *V, ARint *ldv,
+	ARint *iparam, ARint *ipntr, double *workd,
+	double *workl, ARint *lworkl, ARint *info
 );
 
 typedef void (*FUNPTR_dseupd)(
-    ARlogical *rvec, char *HowMny, ARlogical *select,
-    double *d, double *Z, ARint *ldz,
-    double *sigma, char *bmat, ARint *n,
-    char *which, ARint *nev, double *tol,
-    double *resid, ARint *ncv, double *V,
-    ARint *ldv, ARint *iparam, ARint *ipntr,
-    double *workd, double *workl,
-    ARint *lworkl, ARint *info
+	ARlogical *rvec, char *HowMny, ARlogical *select,
+	double *d, double *Z, ARint *ldz,
+	double *sigma, char *bmat, ARint *n,
+	char *which, ARint *nev, double *tol,
+	double *resid, ARint *ncv, double *V,
+	ARint *ldv, ARint *iparam, ARint *ipntr,
+	double *workd, double *workl,
+	ARint *lworkl, ARint *info
 );
 
 /* double precision nonsymmetric routines */
-    
+
 typedef void (*FUNPTR_dnaupd)(
-    ARint *ido, char *bmat, ARint *n, char *which,
-    ARint *nev, double *tol, double *resid,
-    ARint *ncv, double *V, ARint *ldv,
-    ARint *iparam, ARint *ipntr, double *workd,
-    double *workl, ARint *lworkl, ARint *info
+	ARint *ido, char *bmat, ARint *n, char *which,
+	ARint *nev, double *tol, double *resid,
+	ARint *ncv, double *V, ARint *ldv,
+	ARint *iparam, ARint *ipntr, double *workd,
+	double *workl, ARint *lworkl, ARint *info
 );
 
 typedef void (*FUNPTR_dneupd)(
-    ARlogical *rvec, char *HowMny, ARlogical *select,
-    double *dr, double *di, double *Z,
-    ARint *ldz, double *sigmar,
-    double *sigmai, double *workev,
-    char *bmat, ARint *n, char *which,
-    ARint *nev, double *tol, double *resid,
-    ARint *ncv, double *V, ARint *ldv,
-    ARint *iparam, ARint *ipntr,
-    double *workd, double *workl,
-    ARint *lworkl, ARint *info
+	ARlogical *rvec, char *HowMny, ARlogical *select,
+	double *dr, double *di, double *Z,
+	ARint *ldz, double *sigmar,
+	double *sigmai, double *workev,
+	char *bmat, ARint *n, char *which,
+	ARint *nev, double *tol, double *resid,
+	ARint *ncv, double *V, ARint *ldv,
+	ARint *iparam, ARint *ipntr,
+	double *workd, double *workl,
+	ARint *lworkl, ARint *info
 );
 
 
 
 typedef struct {
-    FUNPTR_dsaupd dsaupd;
-    FUNPTR_dseupd dseupd;
-    FUNPTR_dnaupd dnaupd;
-    FUNPTR_dneupd dneupd;
-    NLdll DLL_handle;
+	FUNPTR_dsaupd dsaupd;
+	FUNPTR_dseupd dseupd;
+	FUNPTR_dnaupd dnaupd;
+	FUNPTR_dneupd dneupd;
+	NLdll DLL_handle;
 } ARPACKContext;
 
 
 static ARPACKContext* ARPACK() {
-    static ARPACKContext context;
-    static NLboolean init = NL_FALSE;
-    if(!init) {
-        init = NL_TRUE;
-        memset(&context, 0, sizeof(context));
-    }
-    return &context;
+	static ARPACKContext context;
+	static NLboolean init = NL_FALSE;
+	if(!init) {
+		init = NL_TRUE;
+		memset(&context, 0, sizeof(context));
+	}
+	return &context;
 }
 
 static NLboolean ARPACK_is_initialized() {
-    return
-        ARPACK()->DLL_handle != NULL &&
-        ARPACK()->dsaupd != NULL &&
-        ARPACK()->dseupd != NULL &&   
-        ARPACK()->dnaupd != NULL &&
-        ARPACK()->dneupd != NULL;
+	return
+		ARPACK()->DLL_handle != NULL &&
+		ARPACK()->dsaupd != NULL &&
+		ARPACK()->dseupd != NULL &&
+		ARPACK()->dnaupd != NULL &&
+		ARPACK()->dneupd != NULL;
 }
 
 static void nlTerminateExtension_ARPACK(void) {
-    if(ARPACK()->DLL_handle != NULL) {
-        nlCloseDLL(ARPACK()->DLL_handle);
-        ARPACK()->DLL_handle = NULL;
-    }
+	if(ARPACK()->DLL_handle != NULL) {
+		nlCloseDLL(ARPACK()->DLL_handle);
+		ARPACK()->DLL_handle = NULL;
+	}
 }
 
 
 static char* u(const char* str) {
-    static char buff[1000];
-    sprintf(buff, "%s_", str);
-    return buff;
+	static char buff[1000];
+	sprintf(buff, "%s_", str);
+	return buff;
 }
 
 #define find_arpack_func(name)                                             \
-    if(                                                                    \
-        (                                                                  \
-            ARPACK()->name =                                               \
-            (FUNPTR_##name)nlFindFunction(ARPACK()->DLL_handle,u(#name))   \
-        ) == NULL                                                          \
-    ) {                                                                    \
-        nlError("nlInitExtension_ARPACK","function not found");            \
-        nlError("nlInitExtension_ARPACK",u(#name));	   		   \
-        return NL_FALSE;                                                   \
-    }
+	if(                                                                    \
+		(                                                                  \
+			ARPACK()->name =                                               \
+			(FUNPTR_##name)nlFindFunction(ARPACK()->DLL_handle,u(#name))   \
+		) == NULL                                                          \
+	) {                                                                    \
+		nlError("nlInitExtension_ARPACK","function not found");            \
+		nlError("nlInitExtension_ARPACK",u(#name));	   		   \
+		return NL_FALSE;                                                   \
+	}
 
 NLboolean nlInitExtension_ARPACK(void) {
-    if(ARPACK()->DLL_handle != NULL) {
-        return ARPACK_is_initialized();
-    }
+	if(ARPACK()->DLL_handle != NULL) {
+		return ARPACK_is_initialized();
+	}
 
-    ARPACK()->DLL_handle = nlOpenDLL(ARPACK_LIB_NAME);
-    if(ARPACK()->DLL_handle == NULL) {
-        return NL_FALSE;
-    }
+	ARPACK()->DLL_handle = nlOpenDLL(ARPACK_LIB_NAME);
+	if(ARPACK()->DLL_handle == NULL) {
+		return NL_FALSE;
+	}
 
-    find_arpack_func(dsaupd);
-    find_arpack_func(dseupd);
-    find_arpack_func(dnaupd);
-    find_arpack_func(dneupd);
+	find_arpack_func(dsaupd);
+	find_arpack_func(dseupd);
+	find_arpack_func(dnaupd);
+	find_arpack_func(dneupd);
 
-    atexit(nlTerminateExtension_ARPACK);
-    return NL_TRUE;
+	atexit(nlTerminateExtension_ARPACK);
+	return NL_TRUE;
 }
 
 
 
 static NLMatrix create_OP(NLboolean symmetric) {
-    NLuint n = nlCurrentContext->M->n;
-    NLuint i;
-    NLMatrix result = NULL;
-    
-	
-    if(nlCurrentContext->eigen_shift != 0.0) {
+	NLuint n = nlCurrentContext->M->n;
+	NLuint i;
+	NLMatrix result = NULL;
+
+
+	if(nlCurrentContext->eigen_shift != 0.0) {
 	/*
 	 * A = M
 	 */
@@ -5075,294 +5075,294 @@ static NLMatrix create_OP(NLboolean symmetric) {
 	nlSparseMatrixConstruct(A, n, n, NL_MATRIX_STORE_ROWS);
 	nlSparseMatrixAddMatrix(A, 1.0, nlCurrentContext->M);
 	if(nlCurrentContext->B == NULL) {
-	    /*
-	     * A = A - shift * Id
-	     */
-	    for(i=0; i<n; ++i) {
+		/*
+		 * A = A - shift * Id
+		 */
+		for(i=0; i<n; ++i) {
 		nlSparseMatrixAdd(A, i, i, -nlCurrentContext->eigen_shift);
-	    }
+		}
 	} else {
-	    /*
-	     * A = A - shift * B
-	     */
-	    nlSparseMatrixAddMatrix(A, -nlCurrentContext->eigen_shift, nlCurrentContext->B);
+		/*
+		 * A = A - shift * B
+		 */
+		nlSparseMatrixAddMatrix(A, -nlCurrentContext->eigen_shift, nlCurrentContext->B);
 	}
 
-	/* 
-	 * OP = A^{-1} 
+	/*
+	 * OP = A^{-1}
 	 */
 	if(nlCurrentContext->verbose) {
-	    fprintf(stderr, "Factorizing matrix...\n");
+		fprintf(stderr, "Factorizing matrix...\n");
 	}
 	result = nlMatrixFactorize(
-	    (NLMatrix)A, symmetric ? NL_SYMMETRIC_SUPERLU_EXT : NL_PERM_SUPERLU_EXT
+		(NLMatrix)A, symmetric ? NL_SYMMETRIC_SUPERLU_EXT : NL_PERM_SUPERLU_EXT
 	);
 	if(nlCurrentContext->verbose) {
-	    fprintf(stderr, "Matrix factorized\n");
+		fprintf(stderr, "Matrix factorized\n");
 	}
 	nlDeleteMatrix((NLMatrix)A);
-    } else {
-	/* 
-	 * OP = M^{-1} 
+	} else {
+	/*
+	 * OP = M^{-1}
 	 */
 	if(nlCurrentContext->verbose) {
-	    fprintf(stderr, "Factorizing matrix...\n");
+		fprintf(stderr, "Factorizing matrix...\n");
 	}
 	result = nlMatrixFactorize(
-	    nlCurrentContext->M, symmetric ? NL_SYMMETRIC_SUPERLU_EXT : NL_PERM_SUPERLU_EXT
-	    );
+		nlCurrentContext->M, symmetric ? NL_SYMMETRIC_SUPERLU_EXT : NL_PERM_SUPERLU_EXT
+		);
 	if(nlCurrentContext->verbose) {
-	    fprintf(stderr, "Matrix factorized\n");
+		fprintf(stderr, "Matrix factorized\n");
 	}
-    }
-    
-    if(nlCurrentContext->B != NULL) {
-	/* 
-	 * OP = OP * B
-	 */	
-	result = nlMatrixNewFromProduct(
-	    result, NL_TRUE, /* mem. ownership transferred */
-	    nlCurrentContext->B, NL_FALSE  /* mem. ownership kept by context */
-	);
-    }
+	}
 
-    return result;
+	if(nlCurrentContext->B != NULL) {
+	/*
+	 * OP = OP * B
+	 */
+	result = nlMatrixNewFromProduct(
+		result, NL_TRUE, /* mem. ownership transferred */
+		nlCurrentContext->B, NL_FALSE  /* mem. ownership kept by context */
+	);
+	}
+
+	return result;
 }
 
 static int eigencompare(const void* pi, const void* pj) {
-    NLuint i = *(const NLuint*)pi;
-    NLuint j = *(const NLuint*)pj;
-    double vali = fabs(nlCurrentContext->temp_eigen_value[i]);
-    double valj = fabs(nlCurrentContext->temp_eigen_value[j]);
-    if(vali == valj) {
+	NLuint i = *(const NLuint*)pi;
+	NLuint j = *(const NLuint*)pj;
+	double vali = fabs(nlCurrentContext->temp_eigen_value[i]);
+	double valj = fabs(nlCurrentContext->temp_eigen_value[j]);
+	if(vali == valj) {
 	return 0;
-    }
-    return vali < valj ? -1 : 1;
+	}
+	return vali < valj ? -1 : 1;
 }
 
 void nlEigenSolve_ARPACK(void) {
-    NLboolean symmetric = nlCurrentContext->symmetric && (nlCurrentContext->B == NULL); 
-    int n = (int)nlCurrentContext->M->n; /* Dimension of the matrix */
-    int nev = /* Number of eigenvectors requested */
+	NLboolean symmetric = nlCurrentContext->symmetric && (nlCurrentContext->B == NULL);
+	int n = (int)nlCurrentContext->M->n; /* Dimension of the matrix */
+	int nev = /* Number of eigenvectors requested */
 	(int)nlCurrentContext->nb_systems;
-    NLMatrix OP = create_OP(symmetric);
-    int ncv = (int)(nev * 2.5); /* Length of Arnoldi factorization */
-                 /* Rule of thumb in ARPACK documentation: ncv > 2 * nev */
-    int* iparam = NULL;
-    int* ipntr  = NULL;
-    NLdouble* resid = NULL;
-    NLdouble* workev = NULL;
-    NLdouble* workd = NULL;
-    NLdouble* workl = NULL;
-    NLdouble* v = NULL;
-    NLdouble* d = NULL;
-    ARlogical* select = NULL;
-    ARlogical rvec = 1;
-    double sigmar = 0.0;
-    double sigmai = 0.0;
-    int ierr;
-    int i,k,kk;
-    int ldv = (int)n;
-    char* bmat = (char*)"I";   /*Standard problem */
-    char* which = (char*)"LM"; /*Largest eigenvalues, but we invert->smallest */
-    char* howmny = (char*)"A"; /*which eigens should be computed: all */
-    double tol = nlCurrentContext->threshold;
-    int ido = 0;  /* reverse communication variable (which operation ?) */
-    int info = 1; /* start with initial value of resid */
-    int lworkl;   /* size of work array */
-    NLboolean converged = NL_FALSE;
-    NLdouble value;
-    int index;
-    int* sorted; /* indirection array for sorting eigenpairs */
+	NLMatrix OP = create_OP(symmetric);
+	int ncv = (int)(nev * 2.5); /* Length of Arnoldi factorization */
+				 /* Rule of thumb in ARPACK documentation: ncv > 2 * nev */
+	int* iparam = NULL;
+	int* ipntr  = NULL;
+	NLdouble* resid = NULL;
+	NLdouble* workev = NULL;
+	NLdouble* workd = NULL;
+	NLdouble* workl = NULL;
+	NLdouble* v = NULL;
+	NLdouble* d = NULL;
+	ARlogical* select = NULL;
+	ARlogical rvec = 1;
+	double sigmar = 0.0;
+	double sigmai = 0.0;
+	int ierr;
+	int i,k,kk;
+	int ldv = (int)n;
+	char* bmat = (char*)"I";   /*Standard problem */
+	char* which = (char*)"LM"; /*Largest eigenvalues, but we invert->smallest */
+	char* howmny = (char*)"A"; /*which eigens should be computed: all */
+	double tol = nlCurrentContext->threshold;
+	int ido = 0;  /* reverse communication variable (which operation ?) */
+	int info = 1; /* start with initial value of resid */
+	int lworkl;   /* size of work array */
+	NLboolean converged = NL_FALSE;
+	NLdouble value;
+	int index;
+	int* sorted; /* indirection array for sorting eigenpairs */
 
-    if(ncv > n) {
+	if(ncv > n) {
 	ncv = n;
-    }
+	}
 
-    if(nev > n) {
+	if(nev > n) {
 	nev = n;
-    }
+	}
 
-    if(nev + 2 > ncv) {
+	if(nev + 2 > ncv) {
 	nev = ncv  - 2;
-    }
+	}
 
-    
-    if(symmetric) {
+
+	if(symmetric) {
 	lworkl = ncv * (ncv + 8) ;
-    } else {
-	lworkl = 3*ncv*ncv + 6*ncv ; 
-    }
-    iparam = NL_NEW_ARRAY(int, 11);
-    ipntr  = NL_NEW_ARRAY(int, 14);
+	} else {
+	lworkl = 3*ncv*ncv + 6*ncv ;
+	}
+	iparam = NL_NEW_ARRAY(int, 11);
+	ipntr  = NL_NEW_ARRAY(int, 14);
 
-    iparam[1-1] = 1; /* ARPACK chooses the shifts */
-    iparam[3-1] = (int)nlCurrentContext->max_iterations;
-    iparam[7-1] = 1; /* Normal mode, use 3 dor shift-invert */
+	iparam[1-1] = 1; /* ARPACK chooses the shifts */
+	iparam[3-1] = (int)nlCurrentContext->max_iterations;
+	iparam[7-1] = 1; /* Normal mode, use 3 dor shift-invert */
 
-    workev = NL_NEW_ARRAY(NLdouble, 3*ncv);
-    workd = NL_NEW_ARRAY(NLdouble, 3*n);
+	workev = NL_NEW_ARRAY(NLdouble, 3*ncv);
+	workd = NL_NEW_ARRAY(NLdouble, 3*n);
 
-    resid = NL_NEW_ARRAY(NLdouble, n);
-    for(i=0; i<n; ++i) {
+	resid = NL_NEW_ARRAY(NLdouble, n);
+	for(i=0; i<n; ++i) {
 	resid[i] = 1.0; /* (double)i / (double)n; */
-    }
-    v = NL_NEW_ARRAY(NLdouble, ldv*ncv);
-    if(symmetric) {
+	}
+	v = NL_NEW_ARRAY(NLdouble, ldv*ncv);
+	if(symmetric) {
 	d = NL_NEW_ARRAY(NLdouble, 2*ncv);
-    } else {
-	d = NL_NEW_ARRAY(NLdouble, 3*ncv);	
-    }
-    workl = NL_NEW_ARRAY(NLdouble, lworkl);
-
-    
-
-    if(nlCurrentContext->verbose) {
-	if(symmetric) {
-	    fprintf(stderr, "calling dsaupd()\n");	    
 	} else {
-	    fprintf(stderr, "calling dnaupd()\n");
+	d = NL_NEW_ARRAY(NLdouble, 3*ncv);
 	}
-    }
-    while(!converged) {
+	workl = NL_NEW_ARRAY(NLdouble, lworkl);
+
+
+
 	if(nlCurrentContext->verbose) {
-	    fprintf(stderr, ".");
-	    fflush(stderr);
+	if(symmetric) {
+		fprintf(stderr, "calling dsaupd()\n");
+	} else {
+		fprintf(stderr, "calling dnaupd()\n");
+	}
+	}
+	while(!converged) {
+	if(nlCurrentContext->verbose) {
+		fprintf(stderr, ".");
+		fflush(stderr);
 	}
 	if(symmetric) {
-	    ARPACK()->dsaupd(
+		ARPACK()->dsaupd(
 		&ido, bmat, &n, which, &nev, &tol, resid, &ncv,
 		v, &ldv, iparam, ipntr, workd, workl, &lworkl, &info
-	    );
+		);
 	} else {
-	    ARPACK()->dnaupd(
+		ARPACK()->dnaupd(
 		&ido, bmat, &n, which, &nev, &tol, resid, &ncv,
 		v, &ldv, iparam, ipntr, workd, workl, &lworkl, &info
-	    );
+		);
 	}
 	if(ido == 1) {
-	    nlMultMatrixVector(
+		nlMultMatrixVector(
 		OP,
 		workd+ipntr[1-1]-1, /*The "-1"'s are for FORTRAN-to-C conversion */
 		workd+ipntr[2-1]-1  /*to keep the same indices as in ARPACK doc */
-	    );
+		);
 	} else {
-	    converged = NL_TRUE;
+		converged = NL_TRUE;
 	}
-    }
+	}
 
-    
 
-    if(info < 0) {
+
+	if(info < 0) {
 	if(symmetric) {
-	    fprintf(stderr, "\nError with dsaupd(): %d\n", info);	    
+		fprintf(stderr, "\nError with dsaupd(): %d\n", info);
 	} else {
-	    fprintf(stderr, "\nError with dnaupd(): %d\n", info);
+		fprintf(stderr, "\nError with dnaupd(): %d\n", info);
 	}
-    } else {
+	} else {
 	if(nlCurrentContext->verbose) {
-	    fprintf(stderr, "\nconverged\n");
+		fprintf(stderr, "\nconverged\n");
 	}
-	
+
 	select = NL_NEW_ARRAY(ARlogical, ncv);
 	for(i=0; i<ncv; ++i) {
-	    select[i] = 1;
+		select[i] = 1;
 	}
-	
+
 	if(nlCurrentContext->verbose) {
-	    if(symmetric) {
-		fprintf(stderr, "calling dseupd()\n");		
-	    } else {
+		if(symmetric) {
+		fprintf(stderr, "calling dseupd()\n");
+		} else {
 		fprintf(stderr, "calling dneupd()\n");
-	    }
+		}
 	}
-	
-        if(symmetric) {
-            ARPACK()->dseupd(
-                &rvec, howmny, select, d, v, 
-                &ldv, &sigmar, bmat, &n, which, &nev, 
-                &tol, resid, &ncv, v, &ldv, 
-                iparam, ipntr, workd,
-		workl, &lworkl, &ierr 
-	    );
-        } else {
-	    ARPACK()->dneupd(
+
+		if(symmetric) {
+			ARPACK()->dseupd(
+				&rvec, howmny, select, d, v,
+				&ldv, &sigmar, bmat, &n, which, &nev,
+				&tol, resid, &ncv, v, &ldv,
+				iparam, ipntr, workd,
+		workl, &lworkl, &ierr
+		);
+		} else {
+		ARPACK()->dneupd(
 		&rvec, howmny, select, d, d+ncv,
-                v, &ldv, 
-                &sigmar, &sigmai, workev, bmat, &n,
-		which, &nev, &tol, 
-                resid, &ncv, v, &ldv, iparam, 
-		ipntr, workd, workl, &lworkl, &ierr 
-            ) ;
-	}	
+				v, &ldv,
+				&sigmar, &sigmai, workev, bmat, &n,
+		which, &nev, &tol,
+				resid, &ncv, v, &ldv, iparam,
+		ipntr, workd, workl, &lworkl, &ierr
+			) ;
+	}
 
 
 	if(nlCurrentContext->verbose) {
-	    if(ierr != 0) {		
+		if(ierr != 0) {
 		if(symmetric) {
-		    fprintf(stderr, "Error with dseupd(): %d\n", ierr);		
+			fprintf(stderr, "Error with dseupd(): %d\n", ierr);
 		} else {
-		    fprintf(stderr, "Error with dneupd(): %d\n", ierr);
+			fprintf(stderr, "Error with dneupd(): %d\n", ierr);
 		}
-	    } else {
+		} else {
 		if(symmetric) {
-		    fprintf(stderr, "dseupd() OK, nconv= %d\n", iparam[3-1]);
+			fprintf(stderr, "dseupd() OK, nconv= %d\n", iparam[3-1]);
 		} else {
-		    fprintf(stderr, "dneupd() OK, nconv= %d\n", iparam[3-1]);
+			fprintf(stderr, "dneupd() OK, nconv= %d\n", iparam[3-1]);
 		}
-	    }
+		}
 	}
-	
+
 	NL_DELETE_ARRAY(select);
-    }
+	}
 
-    
 
-    for(i=0; i<nev; ++i) {
+
+	for(i=0; i<nev; ++i) {
 	d[i] = (fabs(d[i]) < 1e-30) ? 1e30 : 1.0 / d[i] ;
 	d[i] += nlCurrentContext->eigen_shift ;
-    }            
+	}
 
-    
-    
-    /* Make it visible to the eigen_compare function */
-    nlCurrentContext->temp_eigen_value = d;
-    sorted = NL_NEW_ARRAY(int, nev);
-    for(i=0; i<nev; ++i) {
+
+
+	/* Make it visible to the eigen_compare function */
+	nlCurrentContext->temp_eigen_value = d;
+	sorted = NL_NEW_ARRAY(int, nev);
+	for(i=0; i<nev; ++i) {
 	sorted[i] = i;
-    }
-    qsort(sorted, (size_t)nev, sizeof(NLuint), eigencompare);
-    nlCurrentContext->temp_eigen_value = NULL;
-    
-    
+	}
+	qsort(sorted, (size_t)nev, sizeof(NLuint), eigencompare);
+	nlCurrentContext->temp_eigen_value = NULL;
 
-    for(k=0; k<nev; ++k) {
+
+
+	for(k=0; k<nev; ++k) {
 	kk = sorted[k];
 	nlCurrentContext->eigen_value[k] = d[kk];
 	for(i=0; i<(int)nlCurrentContext->nb_variables; ++i) {
-	    if(!nlCurrentContext->variable_is_locked[i]) {
+		if(!nlCurrentContext->variable_is_locked[i]) {
 		index = (int)nlCurrentContext->variable_index[i];
 		nl_assert(index < n);
 		value = v[kk*n+index];
 		NL_BUFFER_ITEM(
-		    nlCurrentContext->variable_buffer[k],(NLuint)i
+			nlCurrentContext->variable_buffer[k],(NLuint)i
 		) = value;
-	    }
+		}
 	}
-    }
-    
-    
+	}
 
-    NL_DELETE_ARRAY(sorted);
-    NL_DELETE_ARRAY(workl);
-    NL_DELETE_ARRAY(d);
-    NL_DELETE_ARRAY(v);
-    NL_DELETE_ARRAY(resid);
-    NL_DELETE_ARRAY(workd);
-    NL_DELETE_ARRAY(workev);
-    nlDeleteMatrix(OP);
-    NL_DELETE_ARRAY(iparam);
-    NL_DELETE_ARRAY(ipntr);
+
+
+	NL_DELETE_ARRAY(sorted);
+	NL_DELETE_ARRAY(workl);
+	NL_DELETE_ARRAY(d);
+	NL_DELETE_ARRAY(v);
+	NL_DELETE_ARRAY(resid);
+	NL_DELETE_ARRAY(workd);
+	NL_DELETE_ARRAY(workev);
+	nlDeleteMatrix(OP);
+	NL_DELETE_ARRAY(iparam);
+	NL_DELETE_ARRAY(ipntr);
 }
 
 
@@ -5372,14 +5372,14 @@ void nlEigenSolve_ARPACK(void) {
 
 
 NLboolean nlSolverIsCNC(NLint solver){
-    return solver == NL_CNC_FLOAT_CRS_EXT 
-        || solver == NL_CNC_DOUBLE_CRS_EXT 
-        || solver == NL_CNC_FLOAT_BCRS2_EXT 
-        || solver == NL_CNC_DOUBLE_BCRS2_EXT         
-        || solver == NL_CNC_FLOAT_ELL_EXT         
-        || solver == NL_CNC_DOUBLE_ELL_EXT         
-        || solver == NL_CNC_FLOAT_HYB_EXT         
-        || solver == NL_CNC_DOUBLE_HYB_EXT ;        
+	return solver == NL_CNC_FLOAT_CRS_EXT
+		|| solver == NL_CNC_DOUBLE_CRS_EXT
+		|| solver == NL_CNC_FLOAT_BCRS2_EXT
+		|| solver == NL_CNC_DOUBLE_BCRS2_EXT
+		|| solver == NL_CNC_FLOAT_ELL_EXT
+		|| solver == NL_CNC_DOUBLE_ELL_EXT
+		|| solver == NL_CNC_FLOAT_HYB_EXT
+		|| solver == NL_CNC_DOUBLE_HYB_EXT ;
 }
 
 
@@ -5389,38 +5389,38 @@ NLboolean nlSolverIsCNC(NLint solver){
 #ifdef NL_USE_CNC
 
 NLuint nlSolve_CNC() {
-    unsigned int i;
-    NLdouble* b        = nlCurrentContext->b ;
-    NLdouble* x        = nlCurrentContext->x ;
-    NLdouble  eps      = nlCurrentContext->threshold ;
-    NLuint    max_iter = nlCurrentContext->max_iterations ;
-    NLSparseMatrix *M  = &(nlCurrentContext->M);
-    
-    /* local variables for the final error computation */
-    NLuint val_ret;
-    NLdouble * Ax=NL_NEW_ARRAY(NLdouble,nlCurrentContext->n);
-    NLdouble accu     = 0.0;
-    NLdouble b_square = 0.0;
-    
-    
-    val_ret=cnc_solve_cg(M, b, x, max_iter, eps, nlCurrentContext->solver);
-    
-    /* compute the final error */
-    nlCurrentContext->matrix_vector_prod(x,Ax);
-    for(i = 0 ; i < M->n ; ++i) { 
-        accu     +=(Ax[i]-b[i])*(Ax[i]-b[i]);
-        b_square += b[i]*b[i]; 
-    } 
-    printf("in OpenNL : ||Ax-b||/||b|| = %e\n",sqrt(accu)/sqrt(b_square));
-    /* cleaning */
-    NL_DELETE_ARRAY(Ax);
-    return val_ret;
+	unsigned int i;
+	NLdouble* b        = nlCurrentContext->b ;
+	NLdouble* x        = nlCurrentContext->x ;
+	NLdouble  eps      = nlCurrentContext->threshold ;
+	NLuint    max_iter = nlCurrentContext->max_iterations ;
+	NLSparseMatrix *M  = &(nlCurrentContext->M);
+
+	/* local variables for the final error computation */
+	NLuint val_ret;
+	NLdouble * Ax=NL_NEW_ARRAY(NLdouble,nlCurrentContext->n);
+	NLdouble accu     = 0.0;
+	NLdouble b_square = 0.0;
+
+
+	val_ret=cnc_solve_cg(M, b, x, max_iter, eps, nlCurrentContext->solver);
+
+	/* compute the final error */
+	nlCurrentContext->matrix_vector_prod(x,Ax);
+	for(i = 0 ; i < M->n ; ++i) {
+		accu     +=(Ax[i]-b[i])*(Ax[i]-b[i]);
+		b_square += b[i]*b[i];
+	}
+	printf("in OpenNL : ||Ax-b||/||b|| = %e\n",sqrt(accu)/sqrt(b_square));
+	/* cleaning */
+	NL_DELETE_ARRAY(Ax);
+	return val_ret;
 }
 
 #else
 
 NLuint nlSolve_CNC() {
-    nl_assert_not_reached ;
+	nl_assert_not_reached ;
 }
 
 #endif
@@ -5431,22 +5431,22 @@ NLuint nlSolve_CNC() {
 
 
 static NLSparseMatrix* nlGetCurrentSparseMatrix() {
-    NLSparseMatrix* result = NULL;
-    switch(nlCurrentContext->matrix_mode) {
+	NLSparseMatrix* result = NULL;
+	switch(nlCurrentContext->matrix_mode) {
 	case NL_STIFFNESS_MATRIX: {
-	    nl_assert(nlCurrentContext->M != NULL);	    
-	    nl_assert(nlCurrentContext->M->type == NL_MATRIX_SPARSE_DYNAMIC);
-	    result = (NLSparseMatrix*)(nlCurrentContext->M);
+		nl_assert(nlCurrentContext->M != NULL);
+		nl_assert(nlCurrentContext->M->type == NL_MATRIX_SPARSE_DYNAMIC);
+		result = (NLSparseMatrix*)(nlCurrentContext->M);
 	} break;
 	case NL_MASS_MATRIX: {
-	    nl_assert(nlCurrentContext->B != NULL);
-	    nl_assert(nlCurrentContext->B->type == NL_MATRIX_SPARSE_DYNAMIC);
-	    result = (NLSparseMatrix*)(nlCurrentContext->B);
+		nl_assert(nlCurrentContext->B != NULL);
+		nl_assert(nlCurrentContext->B->type == NL_MATRIX_SPARSE_DYNAMIC);
+		result = (NLSparseMatrix*)(nlCurrentContext->B);
 	} break;
 	default:
-	    nl_assert_not_reached;
-    }
-    return result;
+		nl_assert_not_reached;
+	}
+	return result;
 }
 
 
@@ -5454,27 +5454,27 @@ static NLSparseMatrix* nlGetCurrentSparseMatrix() {
 
 NLboolean nlInitExtension(const char* extension) {
 
-    nl_arg_used(extension);
+	nl_arg_used(extension);
 
-    if(!strcmp(extension, "SUPERLU")) {
-        return nlInitExtension_SUPERLU();
-    } else if(!strcmp(extension, "CHOLMOD")) {
-        return nlInitExtension_CHOLMOD();
-    } else if(!strcmp(extension, "ARPACK")) {
-	/* 
+	if(!strcmp(extension, "SUPERLU")) {
+		return nlInitExtension_SUPERLU();
+	} else if(!strcmp(extension, "CHOLMOD")) {
+		return nlInitExtension_CHOLMOD();
+	} else if(!strcmp(extension, "ARPACK")) {
+	/*
 	 * SUPERLU is needed by OpenNL's ARPACK driver
 	 * (factorizes the matrix for the shift-invert spectral
 	 *  transform).
 	 */
 	return nlInitExtension_SUPERLU() && nlInitExtension_ARPACK();
-    }
+	}
 
 #ifdef NL_USE_CNC
-    if(!strcmp(extension, "CNC")) {
-        return NL_TRUE;
-    }
+	if(!strcmp(extension, "CNC")) {
+		return NL_TRUE;
+	}
 #endif
-    return NL_FALSE;
+	return NL_FALSE;
 }
 
 
@@ -5483,843 +5483,843 @@ NLboolean nlInitExtension(const char* extension) {
 /* Get/Set parameters */
 
 void nlSolverParameterd(NLenum pname, NLdouble param) {
-    nlCheckState(NL_STATE_INITIAL);
-    switch(pname) {
-    case NL_THRESHOLD: {
-        nl_assert(param >= 0);
-        nlCurrentContext->threshold = (NLdouble)param;
-        nlCurrentContext->threshold_defined = NL_TRUE;
-    } break;
-    case NL_OMEGA: {
-        nl_range_assert(param,1.0,2.0);
-        nlCurrentContext->omega = (NLdouble)param;
-    } break;
-    default: {
-        nlError("nlSolverParameterd","Invalid parameter");
-        nl_assert_not_reached;
-    }
-    }
+	nlCheckState(NL_STATE_INITIAL);
+	switch(pname) {
+	case NL_THRESHOLD: {
+		nl_assert(param >= 0);
+		nlCurrentContext->threshold = (NLdouble)param;
+		nlCurrentContext->threshold_defined = NL_TRUE;
+	} break;
+	case NL_OMEGA: {
+		nl_range_assert(param,1.0,2.0);
+		nlCurrentContext->omega = (NLdouble)param;
+	} break;
+	default: {
+		nlError("nlSolverParameterd","Invalid parameter");
+		nl_assert_not_reached;
+	}
+	}
 }
 
 void nlSolverParameteri(NLenum pname, NLint param) {
-    nlCheckState(NL_STATE_INITIAL);
-    switch(pname) {
-    case NL_SOLVER: {
-        nlCurrentContext->solver = (NLenum)param;
-    } break;
-    case NL_NB_VARIABLES: {
-        nl_assert(param > 0);
-        nlCurrentContext->nb_variables = (NLuint)param;
-    } break;
-    case NL_NB_SYSTEMS: {
+	nlCheckState(NL_STATE_INITIAL);
+	switch(pname) {
+	case NL_SOLVER: {
+		nlCurrentContext->solver = (NLenum)param;
+	} break;
+	case NL_NB_VARIABLES: {
+		nl_assert(param > 0);
+		nlCurrentContext->nb_variables = (NLuint)param;
+	} break;
+	case NL_NB_SYSTEMS: {
 	nl_assert(param > 0);
 	nlCurrentContext->nb_systems = (NLuint)param;
-    } break;
-    case NL_LEAST_SQUARES: {
-        nlCurrentContext->least_squares = (NLboolean)param;
-    } break;
-    case NL_MAX_ITERATIONS: {
-        nl_assert(param > 0);
-        nlCurrentContext->max_iterations = (NLuint)param;
-        nlCurrentContext->max_iterations_defined = NL_TRUE;
-    } break;
-    case NL_SYMMETRIC: {
-        nlCurrentContext->symmetric = (NLboolean)param;        
-    } break;
-    case NL_INNER_ITERATIONS: {
-        nl_assert(param > 0);
-        nlCurrentContext->inner_iterations = (NLuint)param;
-    } break;
-    case NL_PRECONDITIONER: {
-        nlCurrentContext->preconditioner = (NLuint)param;
-        nlCurrentContext->preconditioner_defined = NL_TRUE;
-    } break;
-    default: {
-        nlError("nlSolverParameteri","Invalid parameter");
-        nl_assert_not_reached;
-    }
-    }
+	} break;
+	case NL_LEAST_SQUARES: {
+		nlCurrentContext->least_squares = (NLboolean)param;
+	} break;
+	case NL_MAX_ITERATIONS: {
+		nl_assert(param > 0);
+		nlCurrentContext->max_iterations = (NLuint)param;
+		nlCurrentContext->max_iterations_defined = NL_TRUE;
+	} break;
+	case NL_SYMMETRIC: {
+		nlCurrentContext->symmetric = (NLboolean)param;
+	} break;
+	case NL_INNER_ITERATIONS: {
+		nl_assert(param > 0);
+		nlCurrentContext->inner_iterations = (NLuint)param;
+	} break;
+	case NL_PRECONDITIONER: {
+		nlCurrentContext->preconditioner = (NLuint)param;
+		nlCurrentContext->preconditioner_defined = NL_TRUE;
+	} break;
+	default: {
+		nlError("nlSolverParameteri","Invalid parameter");
+		nl_assert_not_reached;
+	}
+	}
 }
 
 void nlGetBooleanv(NLenum pname, NLboolean* params) {
-    switch(pname) {
-    case NL_LEAST_SQUARES: {
-        *params = nlCurrentContext->least_squares;
-    } break;
-    case NL_SYMMETRIC: {
-        *params = nlCurrentContext->symmetric;
-    } break;
-    default: {
-        nlError("nlGetBooleanv","Invalid parameter");
-        nl_assert_not_reached;
-    } 
-    }
+	switch(pname) {
+	case NL_LEAST_SQUARES: {
+		*params = nlCurrentContext->least_squares;
+	} break;
+	case NL_SYMMETRIC: {
+		*params = nlCurrentContext->symmetric;
+	} break;
+	default: {
+		nlError("nlGetBooleanv","Invalid parameter");
+		nl_assert_not_reached;
+	}
+	}
 }
 
 void nlGetDoublev(NLenum pname, NLdouble* params) {
-    switch(pname) {
-    case NL_THRESHOLD: {
-        *params = nlCurrentContext->threshold;
-    } break;
-    case NL_OMEGA: {
-        *params = nlCurrentContext->omega;
-    } break;
-    case NL_ERROR: {
-        *params = nlCurrentContext->error;
-    } break;
-    case NL_ELAPSED_TIME: {
-        *params = nlCurrentContext->elapsed_time;        
-    } break;
-    case NL_GFLOPS: {
-        if(nlCurrentContext->elapsed_time == 0) {
-            *params = 0.0;
-        } else {
-            *params = (NLdouble)(nlCurrentContext->flops) /
-                (nlCurrentContext->elapsed_time * 1e9);
-        }
-    } break;
-    default: {
-        nlError("nlGetDoublev","Invalid parameter");
-        nl_assert_not_reached;
-    } 
-    }
+	switch(pname) {
+	case NL_THRESHOLD: {
+		*params = nlCurrentContext->threshold;
+	} break;
+	case NL_OMEGA: {
+		*params = nlCurrentContext->omega;
+	} break;
+	case NL_ERROR: {
+		*params = nlCurrentContext->error;
+	} break;
+	case NL_ELAPSED_TIME: {
+		*params = nlCurrentContext->elapsed_time;
+	} break;
+	case NL_GFLOPS: {
+		if(nlCurrentContext->elapsed_time == 0) {
+			*params = 0.0;
+		} else {
+			*params = (NLdouble)(nlCurrentContext->flops) /
+				(nlCurrentContext->elapsed_time * 1e9);
+		}
+	} break;
+	default: {
+		nlError("nlGetDoublev","Invalid parameter");
+		nl_assert_not_reached;
+	}
+	}
 }
 
 void nlGetIntegerv(NLenum pname, NLint* params) {
-    switch(pname) {
-    case NL_SOLVER: {
-        *params = (NLint)(nlCurrentContext->solver);
-    } break;
-    case NL_NB_VARIABLES: {
-        *params = (NLint)(nlCurrentContext->nb_variables);
-    } break;
-    case NL_NB_SYSTEMS: {
+	switch(pname) {
+	case NL_SOLVER: {
+		*params = (NLint)(nlCurrentContext->solver);
+	} break;
+	case NL_NB_VARIABLES: {
+		*params = (NLint)(nlCurrentContext->nb_variables);
+	} break;
+	case NL_NB_SYSTEMS: {
 	*params = (NLint)(nlCurrentContext->nb_systems);
-    } break;
-    case NL_LEAST_SQUARES: {
-        *params = (NLint)(nlCurrentContext->least_squares);
-    } break;
-    case NL_MAX_ITERATIONS: {
-        *params = (NLint)(nlCurrentContext->max_iterations);
-    } break;
-    case NL_SYMMETRIC: {
-        *params = (NLint)(nlCurrentContext->symmetric);
-    } break;
-    case NL_USED_ITERATIONS: {
-        *params = (NLint)(nlCurrentContext->used_iterations);
-    } break;
-    case NL_PRECONDITIONER: {
-        *params = (NLint)(nlCurrentContext->preconditioner);        
-    } break;
-    case NL_NNZ: {
-        *params = (NLint)(nlMatrixNNZ(nlCurrentContext->M));
-    } break;
-    default: {
-        nlError("nlGetIntegerv","Invalid parameter");
-        nl_assert_not_reached;
-    } 
-    }
+	} break;
+	case NL_LEAST_SQUARES: {
+		*params = (NLint)(nlCurrentContext->least_squares);
+	} break;
+	case NL_MAX_ITERATIONS: {
+		*params = (NLint)(nlCurrentContext->max_iterations);
+	} break;
+	case NL_SYMMETRIC: {
+		*params = (NLint)(nlCurrentContext->symmetric);
+	} break;
+	case NL_USED_ITERATIONS: {
+		*params = (NLint)(nlCurrentContext->used_iterations);
+	} break;
+	case NL_PRECONDITIONER: {
+		*params = (NLint)(nlCurrentContext->preconditioner);
+	} break;
+	case NL_NNZ: {
+		*params = (NLint)(nlMatrixNNZ(nlCurrentContext->M));
+	} break;
+	default: {
+		nlError("nlGetIntegerv","Invalid parameter");
+		nl_assert_not_reached;
+	}
+	}
 }
 
 
 /* Enable / Disable */
 
 void nlEnable(NLenum pname) {
-    switch(pname) {
+	switch(pname) {
 	case NL_NORMALIZE_ROWS: {
-	    nl_assert(nlCurrentContext->state != NL_STATE_ROW);
-	    nlCurrentContext->normalize_rows = NL_TRUE;
+		nl_assert(nlCurrentContext->state != NL_STATE_ROW);
+		nlCurrentContext->normalize_rows = NL_TRUE;
 	} break;
 	case NL_VERBOSE: {
-	    nlCurrentContext->verbose = NL_TRUE;
+		nlCurrentContext->verbose = NL_TRUE;
 	} break;
 	case NL_VARIABLES_BUFFER: {
-	    nlCurrentContext->user_variable_buffers = NL_TRUE;
+		nlCurrentContext->user_variable_buffers = NL_TRUE;
 	} break;
-    default: {
-        nlError("nlEnable","Invalid parameter");        
-        nl_assert_not_reached;
-    }
-    }
+	default: {
+		nlError("nlEnable","Invalid parameter");
+		nl_assert_not_reached;
+	}
+	}
 }
 
 void nlDisable(NLenum pname) {
-    switch(pname) {
+	switch(pname) {
 	case NL_NORMALIZE_ROWS: {
-	    nl_assert(nlCurrentContext->state != NL_STATE_ROW);
-	    nlCurrentContext->normalize_rows = NL_FALSE;
+		nl_assert(nlCurrentContext->state != NL_STATE_ROW);
+		nlCurrentContext->normalize_rows = NL_FALSE;
 	} break;
 	case NL_VERBOSE: {
-	    nlCurrentContext->verbose = NL_FALSE;
+		nlCurrentContext->verbose = NL_FALSE;
 	} break;
 	case NL_VARIABLES_BUFFER: {
-	    nlCurrentContext->user_variable_buffers = NL_FALSE;
+		nlCurrentContext->user_variable_buffers = NL_FALSE;
 	} break;
 	default: {
-	    nlError("nlDisable","Invalid parameter");                
-	    nl_assert_not_reached;
+		nlError("nlDisable","Invalid parameter");
+		nl_assert_not_reached;
 	}
-    }
+	}
 }
 
 NLboolean nlIsEnabled(NLenum pname) {
-    NLboolean result = NL_FALSE;
-    switch(pname) {
+	NLboolean result = NL_FALSE;
+	switch(pname) {
 	case NL_NORMALIZE_ROWS: {
-	    result = nlCurrentContext->normalize_rows;
+		result = nlCurrentContext->normalize_rows;
 	} break;
 	case NL_VERBOSE: {
-	    result = nlCurrentContext->verbose;
+		result = nlCurrentContext->verbose;
 	} break;
 	case NL_VARIABLES_BUFFER: {
-	    result = nlCurrentContext->user_variable_buffers;
+		result = nlCurrentContext->user_variable_buffers;
 	} break;
 	default: {
-	    nlError("nlIsEnables","Invalid parameter");
-	    nl_assert_not_reached;
+		nlError("nlIsEnables","Invalid parameter");
+		nl_assert_not_reached;
 	}
-    }
-    return result;
+	}
+	return result;
 }
 
 
 /* NL functions */
 
 void  nlSetFunction(NLenum pname, NLfunc param) {
-    switch(pname) {
-    case NL_FUNC_SOLVER:
-        nlCurrentContext->solver_func = (NLSolverFunc)(param);
-        nlCurrentContext->solver = NL_SOLVER_USER;	
-        break;
-    case NL_FUNC_MATRIX:
+	switch(pname) {
+	case NL_FUNC_SOLVER:
+		nlCurrentContext->solver_func = (NLSolverFunc)(param);
+		nlCurrentContext->solver = NL_SOLVER_USER;
+		break;
+	case NL_FUNC_MATRIX:
 	nlDeleteMatrix(nlCurrentContext->M);
 	nlCurrentContext->M = nlMatrixNewFromFunction(
-	    nlCurrentContext->n, nlCurrentContext->n,
-	    (NLMatrixFunc)param
+		nlCurrentContext->n, nlCurrentContext->n,
+		(NLMatrixFunc)param
 	);
-        break;
-    case NL_FUNC_PRECONDITIONER:
+		break;
+	case NL_FUNC_PRECONDITIONER:
 	nlDeleteMatrix(nlCurrentContext->P);
 	nlCurrentContext->P = nlMatrixNewFromFunction(
-	    nlCurrentContext->n, nlCurrentContext->n,
-	    (NLMatrixFunc)param
+		nlCurrentContext->n, nlCurrentContext->n,
+		(NLMatrixFunc)param
 	);
-        nlCurrentContext->preconditioner = NL_PRECOND_USER;
-        break;
-    case NL_FUNC_PROGRESS:
-        nlCurrentContext->progress_func = (NLProgressFunc)(param);
-        break;
-    default:
-        nlError("nlSetFunction","Invalid parameter");        
-        nl_assert_not_reached;
-    }
+		nlCurrentContext->preconditioner = NL_PRECOND_USER;
+		break;
+	case NL_FUNC_PROGRESS:
+		nlCurrentContext->progress_func = (NLProgressFunc)(param);
+		break;
+	default:
+		nlError("nlSetFunction","Invalid parameter");
+		nl_assert_not_reached;
+	}
 }
 
 void nlGetFunction(NLenum pname, NLfunc* param) {
-    switch(pname) {
-    case NL_FUNC_SOLVER:
-        *param = (NLfunc)(nlCurrentContext->solver_func);
-        break;
-    case NL_FUNC_MATRIX:
-        *param = (NLfunc)(nlMatrixGetFunction(nlCurrentContext->M));
-        break;
-    case NL_FUNC_PRECONDITIONER:
-        *param = (NLfunc)(nlMatrixGetFunction(nlCurrentContext->P));
-        break;
-    default:
-        nlError("nlGetFunction","Invalid parameter");                
-        nl_assert_not_reached;
-    }
+	switch(pname) {
+	case NL_FUNC_SOLVER:
+		*param = (NLfunc)(nlCurrentContext->solver_func);
+		break;
+	case NL_FUNC_MATRIX:
+		*param = (NLfunc)(nlMatrixGetFunction(nlCurrentContext->M));
+		break;
+	case NL_FUNC_PRECONDITIONER:
+		*param = (NLfunc)(nlMatrixGetFunction(nlCurrentContext->P));
+		break;
+	default:
+		nlError("nlGetFunction","Invalid parameter");
+		nl_assert_not_reached;
+	}
 }
 
 
 /* Get/Set Lock/Unlock variables */
 
 void nlSetVariable(NLuint index, NLdouble value) {
-    nlCheckState(NL_STATE_SYSTEM);
-    nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
-    NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[0],index) = value;
+	nlCheckState(NL_STATE_SYSTEM);
+	nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
+	NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[0],index) = value;
 }
 
 void nlMultiSetVariable(NLuint index, NLuint system, NLdouble value) {
-    nlCheckState(NL_STATE_SYSTEM);
-    nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables-1);
-    nl_debug_range_assert(system, 0, nlCurrentContext->nb_systems-1);    
-    NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[system],index) = value;
+	nlCheckState(NL_STATE_SYSTEM);
+	nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables-1);
+	nl_debug_range_assert(system, 0, nlCurrentContext->nb_systems-1);
+	NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[system],index) = value;
 }
 
 NLdouble nlGetVariable(NLuint index) {
-    nl_assert(nlCurrentContext->state != NL_STATE_INITIAL);
-    nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
-    return NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[0],index);
+	nl_assert(nlCurrentContext->state != NL_STATE_INITIAL);
+	nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
+	return NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[0],index);
 }
 
 NLdouble nlMultiGetVariable(NLuint index, NLuint system) {
-    nl_assert(nlCurrentContext->state != NL_STATE_INITIAL);
-    nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables-1);
-    nl_debug_range_assert(system, 0, nlCurrentContext->nb_systems-1);
-    return NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[system],index);    
+	nl_assert(nlCurrentContext->state != NL_STATE_INITIAL);
+	nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables-1);
+	nl_debug_range_assert(system, 0, nlCurrentContext->nb_systems-1);
+	return NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[system],index);
 }
 
 
 void nlLockVariable(NLuint index) {
-    nlCheckState(NL_STATE_SYSTEM);
-    nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
-    nlCurrentContext->variable_is_locked[index] = NL_TRUE;
+	nlCheckState(NL_STATE_SYSTEM);
+	nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
+	nlCurrentContext->variable_is_locked[index] = NL_TRUE;
 }
 
 void nlUnlockVariable(NLuint index) {
-    nlCheckState(NL_STATE_SYSTEM);
-    nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
-    nlCurrentContext->variable_is_locked[index] = NL_FALSE;
+	nlCheckState(NL_STATE_SYSTEM);
+	nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
+	nlCurrentContext->variable_is_locked[index] = NL_FALSE;
 }
 
 NLboolean nlVariableIsLocked(NLuint index) {
-    nl_assert(nlCurrentContext->state != NL_STATE_INITIAL);
-    nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
-    return nlCurrentContext->variable_is_locked[index];
+	nl_assert(nlCurrentContext->state != NL_STATE_INITIAL);
+	nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
+	return nlCurrentContext->variable_is_locked[index];
 }
 
 
 /* System construction */
 
 static void nlVariablesToVector() {
-    NLuint n=nlCurrentContext->n;
-    NLuint k,i,index;
-    NLdouble value;
-    
-    nl_assert(nlCurrentContext->x != NULL);
-    for(k=0; k<nlCurrentContext->nb_systems; ++k) {
+	NLuint n=nlCurrentContext->n;
+	NLuint k,i,index;
+	NLdouble value;
+
+	nl_assert(nlCurrentContext->x != NULL);
+	for(k=0; k<nlCurrentContext->nb_systems; ++k) {
 	for(i=0; i<nlCurrentContext->nb_variables; ++i) {
-	    if(!nlCurrentContext->variable_is_locked[i]) {
+		if(!nlCurrentContext->variable_is_locked[i]) {
 		index = nlCurrentContext->variable_index[i];
-		nl_assert(index < nlCurrentContext->n);		
+		nl_assert(index < nlCurrentContext->n);
 		value = NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[k],i);
 		nlCurrentContext->x[index+k*n] = value;
-	    }
+		}
 	}
-    }
+	}
 }
 
 static void nlVectorToVariables() {
-    NLuint n=nlCurrentContext->n;
-    NLuint k,i,index;
-    NLdouble value;
+	NLuint n=nlCurrentContext->n;
+	NLuint k,i,index;
+	NLdouble value;
 
-    nl_assert(nlCurrentContext->x != NULL);
-    for(k=0; k<nlCurrentContext->nb_systems; ++k) {
+	nl_assert(nlCurrentContext->x != NULL);
+	for(k=0; k<nlCurrentContext->nb_systems; ++k) {
 	for(i=0; i<nlCurrentContext->nb_variables; ++i) {
-	    if(!nlCurrentContext->variable_is_locked[i]) {
+		if(!nlCurrentContext->variable_is_locked[i]) {
 		index = nlCurrentContext->variable_index[i];
 		nl_assert(index < nlCurrentContext->n);
 		value = nlCurrentContext->x[index+k*n];
 		NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[k],i) = value;
-	    }
+		}
 	}
-    }
+	}
 }
 
 
 static void nlBeginSystem() {
-    NLuint k;
-    
-    nlTransition(NL_STATE_INITIAL, NL_STATE_SYSTEM);
-    nl_assert(nlCurrentContext->nb_variables > 0);
+	NLuint k;
 
-    nlCurrentContext->variable_buffer = NL_NEW_ARRAY(
+	nlTransition(NL_STATE_INITIAL, NL_STATE_SYSTEM);
+	nl_assert(nlCurrentContext->nb_variables > 0);
+
+	nlCurrentContext->variable_buffer = NL_NEW_ARRAY(
 	NLBufferBinding, nlCurrentContext->nb_systems
-    );
-    
-    if(nlCurrentContext->user_variable_buffers) {
+	);
+
+	if(nlCurrentContext->user_variable_buffers) {
 	nlCurrentContext->variable_value = NULL;
-    } else {
+	} else {
 	nlCurrentContext->variable_value = NL_NEW_ARRAY(
-	    NLdouble,
-	    nlCurrentContext->nb_variables * nlCurrentContext->nb_systems
+		NLdouble,
+		nlCurrentContext->nb_variables * nlCurrentContext->nb_systems
 	);
 	for(k=0; k<nlCurrentContext->nb_systems; ++k) {
-	    nlCurrentContext->variable_buffer[k].base_address =
+		nlCurrentContext->variable_buffer[k].base_address =
 		nlCurrentContext->variable_value +
 		k * nlCurrentContext->nb_variables;
-	    nlCurrentContext->variable_buffer[k].stride = sizeof(NLdouble);
+		nlCurrentContext->variable_buffer[k].stride = sizeof(NLdouble);
 	}
-    }
-    
-    nlCurrentContext->variable_is_locked = NL_NEW_ARRAY(
+	}
+
+	nlCurrentContext->variable_is_locked = NL_NEW_ARRAY(
 	NLboolean, nlCurrentContext->nb_variables
-    );
-    nlCurrentContext->variable_index = NL_NEW_ARRAY(
+	);
+	nlCurrentContext->variable_index = NL_NEW_ARRAY(
 	NLuint, nlCurrentContext->nb_variables
-    );
+	);
 }
 
 static void nlEndSystem() {
-    nlTransition(NL_STATE_MATRIX_CONSTRUCTED, NL_STATE_SYSTEM_CONSTRUCTED);    
+	nlTransition(NL_STATE_MATRIX_CONSTRUCTED, NL_STATE_SYSTEM_CONSTRUCTED);
 }
 
 static void nlInitializeM() {
-    NLuint i;
-    NLuint n = 0;
-    NLenum storage = NL_MATRIX_STORE_ROWS;
+	NLuint i;
+	NLuint n = 0;
+	NLenum storage = NL_MATRIX_STORE_ROWS;
 
 
-    for(i=0; i<nlCurrentContext->nb_variables; i++) {
-        if(!nlCurrentContext->variable_is_locked[i]) {
-            nlCurrentContext->variable_index[i] = n;
-            n++;
-        } else {
-            nlCurrentContext->variable_index[i] = (NLuint)~0;
-        }
-    }
+	for(i=0; i<nlCurrentContext->nb_variables; i++) {
+		if(!nlCurrentContext->variable_is_locked[i]) {
+			nlCurrentContext->variable_index[i] = n;
+			n++;
+		} else {
+			nlCurrentContext->variable_index[i] = (NLuint)~0;
+		}
+	}
 
-    nlCurrentContext->n = n;
+	nlCurrentContext->n = n;
 
-    /*
-     * If the user trusts OpenNL and has left solver as NL_SOLVER_DEFAULT,
-     * then we setup reasonable parameters for him.
-     */
-    if(nlCurrentContext->solver == NL_SOLVER_DEFAULT) {
-        if(nlCurrentContext->least_squares || nlCurrentContext->symmetric) {
-            nlCurrentContext->solver = NL_CG;
-            if(!nlCurrentContext->preconditioner_defined) {
-                nlCurrentContext->preconditioner = NL_PRECOND_JACOBI;
-            }
-        } else {
-            nlCurrentContext->solver = NL_BICGSTAB;
-        }
-        if(!nlCurrentContext->max_iterations_defined) {
-            nlCurrentContext->max_iterations = n*5;
-        }
-        if(!nlCurrentContext->threshold_defined) {
-            nlCurrentContext->threshold = 1e-6;
-        }
-    }
+	/*
+	 * If the user trusts OpenNL and has left solver as NL_SOLVER_DEFAULT,
+	 * then we setup reasonable parameters for him.
+	 */
+	if(nlCurrentContext->solver == NL_SOLVER_DEFAULT) {
+		if(nlCurrentContext->least_squares || nlCurrentContext->symmetric) {
+			nlCurrentContext->solver = NL_CG;
+			if(!nlCurrentContext->preconditioner_defined) {
+				nlCurrentContext->preconditioner = NL_PRECOND_JACOBI;
+			}
+		} else {
+			nlCurrentContext->solver = NL_BICGSTAB;
+		}
+		if(!nlCurrentContext->max_iterations_defined) {
+			nlCurrentContext->max_iterations = n*5;
+		}
+		if(!nlCurrentContext->threshold_defined) {
+			nlCurrentContext->threshold = 1e-6;
+		}
+	}
 
-    
-    /* SSOR preconditioner requires rows and columns */
-    if(nlCurrentContext->preconditioner == NL_PRECOND_SSOR) {
-        storage = (storage | NL_MATRIX_STORE_COLUMNS);
-    }
 
-    /* a least squares problem results in a symmetric matrix */
-    if(
-        nlCurrentContext->least_squares  &&
-       !nlSolverIsCNC((NLint)(nlCurrentContext->solver))
-    ) {
-        nlCurrentContext->symmetric = NL_TRUE;
-    }
+	/* SSOR preconditioner requires rows and columns */
+	if(nlCurrentContext->preconditioner == NL_PRECOND_SSOR) {
+		storage = (storage | NL_MATRIX_STORE_COLUMNS);
+	}
 
-    if(
+	/* a least squares problem results in a symmetric matrix */
+	if(
+		nlCurrentContext->least_squares  &&
+	   !nlSolverIsCNC((NLint)(nlCurrentContext->solver))
+	) {
+		nlCurrentContext->symmetric = NL_TRUE;
+	}
+
+	if(
 	nlCurrentContext->symmetric &&
 	nlCurrentContext->preconditioner == NL_PRECOND_SSOR
-    ) {
-	/* 
+	) {
+	/*
 	 * For now, only used with SSOR preconditioner, because
 	 * for other modes it is either unsupported (SUPERLU) or
 	 * causes performance loss (non-parallel sparse SpMV)
 	 */
-        storage = (storage | NL_MATRIX_STORE_SYMMETRIC);
-    }
+		storage = (storage | NL_MATRIX_STORE_SYMMETRIC);
+	}
 
-    nlCurrentContext->M = (NLMatrix)(NL_NEW(NLSparseMatrix));
-    nlSparseMatrixConstruct(
-	     (NLSparseMatrix*)(nlCurrentContext->M), n, n, storage
-    );
+	nlCurrentContext->M = (NLMatrix)(NL_NEW(NLSparseMatrix));
+	nlSparseMatrixConstruct(
+		 (NLSparseMatrix*)(nlCurrentContext->M), n, n, storage
+	);
 
-    nlCurrentContext->x = NL_NEW_ARRAY(
+	nlCurrentContext->x = NL_NEW_ARRAY(
 	NLdouble, n*nlCurrentContext->nb_systems
-    );
-    nlCurrentContext->b = NL_NEW_ARRAY(
+	);
+	nlCurrentContext->b = NL_NEW_ARRAY(
 	NLdouble, n*nlCurrentContext->nb_systems
-    );
+	);
 
-    nlVariablesToVector();
+	nlVariablesToVector();
 
-    nlRowColumnConstruct(&nlCurrentContext->af);
-    nlRowColumnConstruct(&nlCurrentContext->al);
+	nlRowColumnConstruct(&nlCurrentContext->af);
+	nlRowColumnConstruct(&nlCurrentContext->al);
 
-    nlCurrentContext->right_hand_side = NL_NEW_ARRAY(
+	nlCurrentContext->right_hand_side = NL_NEW_ARRAY(
 	double, nlCurrentContext->nb_systems
-    );
-    nlCurrentContext->current_row = 0;
+	);
+	nlCurrentContext->current_row = 0;
 }
 
 static void nlEndMatrix() {
-    nlTransition(NL_STATE_MATRIX, NL_STATE_MATRIX_CONSTRUCTED);    
+	nlTransition(NL_STATE_MATRIX, NL_STATE_MATRIX_CONSTRUCTED);
 
-    nlRowColumnClear(&nlCurrentContext->af);
-    nlRowColumnClear(&nlCurrentContext->al);
-    
-    if(!nlCurrentContext->least_squares) {
-        nl_assert(
-            nlCurrentContext->ij_coefficient_called || (
-                nlCurrentContext->current_row == 
-                nlCurrentContext->n
-            )
-        );
-    }
+	nlRowColumnClear(&nlCurrentContext->af);
+	nlRowColumnClear(&nlCurrentContext->al);
+
+	if(!nlCurrentContext->least_squares) {
+		nl_assert(
+			nlCurrentContext->ij_coefficient_called || (
+				nlCurrentContext->current_row ==
+				nlCurrentContext->n
+			)
+		);
+	}
 }
 
 static void nlBeginRow() {
-    nlTransition(NL_STATE_MATRIX, NL_STATE_ROW);
-    nlRowColumnZero(&nlCurrentContext->af);
-    nlRowColumnZero(&nlCurrentContext->al);
+	nlTransition(NL_STATE_MATRIX, NL_STATE_ROW);
+	nlRowColumnZero(&nlCurrentContext->af);
+	nlRowColumnZero(&nlCurrentContext->al);
 }
 
 static void nlScaleRow(NLdouble s) {
-    NLRowColumn*    af = &nlCurrentContext->af;
-    NLRowColumn*    al = &nlCurrentContext->al;
-    NLuint nf            = af->size;
-    NLuint nl            = al->size;
-    NLuint i,k;
-    for(i=0; i<nf; i++) {
-        af->coeff[i].value *= s;
-    }
-    for(i=0; i<nl; i++) {
-        al->coeff[i].value *= s;
-    }
-    for(k=0; k<nlCurrentContext->nb_systems; ++k) {
+	NLRowColumn*    af = &nlCurrentContext->af;
+	NLRowColumn*    al = &nlCurrentContext->al;
+	NLuint nf            = af->size;
+	NLuint nl            = al->size;
+	NLuint i,k;
+	for(i=0; i<nf; i++) {
+		af->coeff[i].value *= s;
+	}
+	for(i=0; i<nl; i++) {
+		al->coeff[i].value *= s;
+	}
+	for(k=0; k<nlCurrentContext->nb_systems; ++k) {
 	nlCurrentContext->right_hand_side[k] *= s;
-    }
+	}
 }
 
 static void nlNormalizeRow(NLdouble weight) {
-    NLRowColumn*    af = &nlCurrentContext->af;
-    NLRowColumn*    al = &nlCurrentContext->al;
-    NLuint nf            = af->size;
-    NLuint nl            = al->size;
-    NLuint i;
-    NLdouble norm = 0.0;
-    for(i=0; i<nf; i++) {
-        norm += af->coeff[i].value * af->coeff[i].value;
-    }
-    for(i=0; i<nl; i++) {
-        norm += al->coeff[i].value * al->coeff[i].value;
-    }
-    norm = sqrt(norm);
-    nlScaleRow(weight / norm);
+	NLRowColumn*    af = &nlCurrentContext->af;
+	NLRowColumn*    al = &nlCurrentContext->al;
+	NLuint nf            = af->size;
+	NLuint nl            = al->size;
+	NLuint i;
+	NLdouble norm = 0.0;
+	for(i=0; i<nf; i++) {
+		norm += af->coeff[i].value * af->coeff[i].value;
+	}
+	for(i=0; i<nl; i++) {
+		norm += al->coeff[i].value * al->coeff[i].value;
+	}
+	norm = sqrt(norm);
+	nlScaleRow(weight / norm);
 }
 
 static void nlEndRow() {
-    NLRowColumn*    af = &nlCurrentContext->af;
-    NLRowColumn*    al = &nlCurrentContext->al;
-    NLSparseMatrix* M  = nlGetCurrentSparseMatrix();
-    NLdouble* b        = nlCurrentContext->b;
-    NLuint nf          = af->size;
-    NLuint nl          = al->size;
-    NLuint n           = nlCurrentContext->n;
-    NLuint current_row = nlCurrentContext->current_row;
-    NLuint i,j,jj;
-    NLdouble S;
-    NLuint k;
-    nlTransition(NL_STATE_ROW, NL_STATE_MATRIX);
+	NLRowColumn*    af = &nlCurrentContext->af;
+	NLRowColumn*    al = &nlCurrentContext->al;
+	NLSparseMatrix* M  = nlGetCurrentSparseMatrix();
+	NLdouble* b        = nlCurrentContext->b;
+	NLuint nf          = af->size;
+	NLuint nl          = al->size;
+	NLuint n           = nlCurrentContext->n;
+	NLuint current_row = nlCurrentContext->current_row;
+	NLuint i,j,jj;
+	NLdouble S;
+	NLuint k;
+	nlTransition(NL_STATE_ROW, NL_STATE_MATRIX);
 
-    if(nlCurrentContext->normalize_rows) {
-        nlNormalizeRow(nlCurrentContext->row_scaling);
-    } else if(nlCurrentContext->row_scaling != 1.0) {
-        nlScaleRow(nlCurrentContext->row_scaling);
-    }
-    /*
-     * if least_squares : we want to solve
-     * A'A x = A'b
-     */
+	if(nlCurrentContext->normalize_rows) {
+		nlNormalizeRow(nlCurrentContext->row_scaling);
+	} else if(nlCurrentContext->row_scaling != 1.0) {
+		nlScaleRow(nlCurrentContext->row_scaling);
+	}
+	/*
+	 * if least_squares : we want to solve
+	 * A'A x = A'b
+	 */
 
-    if(nlCurrentContext->least_squares) {
-        for(i=0; i<nf; i++) {
-            for(j=0; j<nf; j++) {
-                nlSparseMatrixAdd(
-                    M, af->coeff[i].index, af->coeff[j].index,
-                    af->coeff[i].value * af->coeff[j].value
-                );
-            }
-        }
+	if(nlCurrentContext->least_squares) {
+		for(i=0; i<nf; i++) {
+			for(j=0; j<nf; j++) {
+				nlSparseMatrixAdd(
+					M, af->coeff[i].index, af->coeff[j].index,
+					af->coeff[i].value * af->coeff[j].value
+				);
+			}
+		}
 	for(k=0; k<nlCurrentContext->nb_systems; ++k) {
-	    S = -nlCurrentContext->right_hand_side[k];
-	    for(jj=0; jj<nl; ++jj) {
+		S = -nlCurrentContext->right_hand_side[k];
+		for(jj=0; jj<nl; ++jj) {
 		j = al->coeff[jj].index;
 		S += al->coeff[jj].value *
-		    NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[k],j);
-	    }
-	    for(jj=0; jj<nf; jj++) {
+			NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[k],j);
+		}
+		for(jj=0; jj<nf; jj++) {
 		b[ k*n+af->coeff[jj].index ] -= af->coeff[jj].value * S;
-	    }
+		}
 	}
-    } else {
-        for(jj=0; jj<nf; ++jj) {
-            nlSparseMatrixAdd(
-                M, current_row, af->coeff[jj].index, af->coeff[jj].value
-            );
-        }
+	} else {
+		for(jj=0; jj<nf; ++jj) {
+			nlSparseMatrixAdd(
+				M, current_row, af->coeff[jj].index, af->coeff[jj].value
+			);
+		}
 	for(k=0; k<nlCurrentContext->nb_systems; ++k) {
-	    b[k*n+current_row] = nlCurrentContext->right_hand_side[k];
-	    for(jj=0; jj<nl; ++jj) {
+		b[k*n+current_row] = nlCurrentContext->right_hand_side[k];
+		for(jj=0; jj<nl; ++jj) {
 		j = al->coeff[jj].index;
 		b[k*n+current_row] -= al->coeff[jj].value *
-		    NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[k],j);
-	    }
+			NL_BUFFER_ITEM(nlCurrentContext->variable_buffer[k],j);
+		}
 	}
-    }
-    nlCurrentContext->current_row++;
-    for(k=0; k<nlCurrentContext->nb_systems; ++k) {
+	}
+	nlCurrentContext->current_row++;
+	for(k=0; k<nlCurrentContext->nb_systems; ++k) {
 	nlCurrentContext->right_hand_side[k] = 0.0;
-    }
-    nlCurrentContext->row_scaling = 1.0;
+	}
+	nlCurrentContext->row_scaling = 1.0;
 }
 
 void nlCoefficient(NLuint index, NLdouble value) {
-    nlCheckState(NL_STATE_ROW);
-    nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
-    if(nlCurrentContext->variable_is_locked[index]) {
-	/* 
-	 * Note: in al, indices are NLvariable indices, 
+	nlCheckState(NL_STATE_ROW);
+	nl_debug_range_assert(index, 0, nlCurrentContext->nb_variables - 1);
+	if(nlCurrentContext->variable_is_locked[index]) {
+	/*
+	 * Note: in al, indices are NLvariable indices,
 	 * within [0..nb_variables-1]
 	 */
-        nlRowColumnAppend(&(nlCurrentContext->al), index, value);
-    } else {
+		nlRowColumnAppend(&(nlCurrentContext->al), index, value);
+	} else {
 	/*
-	 * Note: in af, indices are system indices, 
+	 * Note: in af, indices are system indices,
 	 * within [0..n-1]
 	 */
-        nlRowColumnAppend(
-	    &(nlCurrentContext->af),
-	    nlCurrentContext->variable_index[index], value
+		nlRowColumnAppend(
+		&(nlCurrentContext->af),
+		nlCurrentContext->variable_index[index], value
 	);
-    }
+	}
 }
 
 void nlAddIJCoefficient(NLuint i, NLuint j, NLdouble value) {
-    NLSparseMatrix* M  = nlGetCurrentSparseMatrix();    
-    nlCheckState(NL_STATE_MATRIX);
-    nl_debug_range_assert(i, 0, nlCurrentContext->nb_variables - 1);
-    nl_debug_range_assert(j, 0, nlCurrentContext->nb_variables - 1);
+	NLSparseMatrix* M  = nlGetCurrentSparseMatrix();
+	nlCheckState(NL_STATE_MATRIX);
+	nl_debug_range_assert(i, 0, nlCurrentContext->nb_variables - 1);
+	nl_debug_range_assert(j, 0, nlCurrentContext->nb_variables - 1);
 #ifdef NL_DEBUG
-    for(NLuint i=0; i<nlCurrentContext->nb_variables; ++i) {
-        nl_debug_assert(!nlCurrentContext->variable_is_locked[i]);
-    }
-#endif    
-    nlSparseMatrixAdd(M, i, j, value);
-    nlCurrentContext->ij_coefficient_called = NL_TRUE;
+	for(NLuint i=0; i<nlCurrentContext->nb_variables; ++i) {
+		nl_debug_assert(!nlCurrentContext->variable_is_locked[i]);
+	}
+#endif
+	nlSparseMatrixAdd(M, i, j, value);
+	nlCurrentContext->ij_coefficient_called = NL_TRUE;
 }
 
 void nlAddIRightHandSide(NLuint i, NLdouble value) {
-    nlCheckState(NL_STATE_MATRIX);
-    nl_debug_range_assert(i, 0, nlCurrentContext->nb_variables - 1);
+	nlCheckState(NL_STATE_MATRIX);
+	nl_debug_range_assert(i, 0, nlCurrentContext->nb_variables - 1);
 #ifdef NL_DEBUG
-    for(NLuint i=0; i<nlCurrentContext->nb_variables; ++i) {
-        nl_debug_assert(!nlCurrentContext->variable_is_locked[i]);
-    }
+	for(NLuint i=0; i<nlCurrentContext->nb_variables; ++i) {
+		nl_debug_assert(!nlCurrentContext->variable_is_locked[i]);
+	}
 #endif
-    nlCurrentContext->b[i] += value;
-    nlCurrentContext->ij_coefficient_called = NL_TRUE;
+	nlCurrentContext->b[i] += value;
+	nlCurrentContext->ij_coefficient_called = NL_TRUE;
 }
 
 void nlMultiAddIRightHandSide(NLuint i, NLuint k, NLdouble value) {
-    NLuint n = nlCurrentContext->n;
-    nlCheckState(NL_STATE_MATRIX);
-    nl_debug_range_assert(i, 0, nlCurrentContext->nb_variables - 1);
-    nl_debug_range_assert(k, 0, nlCurrentContext->nb_systems - 1);
+	NLuint n = nlCurrentContext->n;
+	nlCheckState(NL_STATE_MATRIX);
+	nl_debug_range_assert(i, 0, nlCurrentContext->nb_variables - 1);
+	nl_debug_range_assert(k, 0, nlCurrentContext->nb_systems - 1);
 #ifdef NL_DEBUG
-    for(NLuint i=0; i<nlCurrentContext->nb_variables; ++i) {
-        nl_debug_assert(!nlCurrentContext->variable_is_locked[i]);
-    }
+	for(NLuint i=0; i<nlCurrentContext->nb_variables; ++i) {
+		nl_debug_assert(!nlCurrentContext->variable_is_locked[i]);
+	}
 #endif
-    nlCurrentContext->b[i + k*n] += value;
-    nlCurrentContext->ij_coefficient_called = NL_TRUE;
+	nlCurrentContext->b[i + k*n] += value;
+	nlCurrentContext->ij_coefficient_called = NL_TRUE;
 }
 
 void nlRightHandSide(NLdouble value) {
-    nlCurrentContext->right_hand_side[0] = value;
+	nlCurrentContext->right_hand_side[0] = value;
 }
 
 void nlMultiRightHandSide(NLuint k, NLdouble value) {
-    nl_debug_range_assert(k, 0, nlCurrentContext->nb_systems - 1);
-    nlCurrentContext->right_hand_side[k] = value;
+	nl_debug_range_assert(k, 0, nlCurrentContext->nb_systems - 1);
+	nlCurrentContext->right_hand_side[k] = value;
 }
 
 void nlRowScaling(NLdouble value) {
-    nlCheckState(NL_STATE_MATRIX);
-    nlCurrentContext->row_scaling = value;
+	nlCheckState(NL_STATE_MATRIX);
+	nlCurrentContext->row_scaling = value;
 }
 
 void nlBegin(NLenum prim) {
-    switch(prim) {
-    case NL_SYSTEM: {
-        nlBeginSystem();
-    } break;
-    case NL_MATRIX: {
+	switch(prim) {
+	case NL_SYSTEM: {
+		nlBeginSystem();
+	} break;
+	case NL_MATRIX: {
 	nlTransition(NL_STATE_SYSTEM, NL_STATE_MATRIX);
 	if(
-	    nlCurrentContext->matrix_mode == NL_STIFFNESS_MATRIX &&
-	    nlCurrentContext->M == NULL
+		nlCurrentContext->matrix_mode == NL_STIFFNESS_MATRIX &&
+		nlCurrentContext->M == NULL
 	) {
-	    nlInitializeM();
+		nlInitializeM();
 	}
-    } break;
-    case NL_ROW: {
-        nlBeginRow();
-    } break;
-    default: {
-        nl_assert_not_reached;
-    }
-    }
+	} break;
+	case NL_ROW: {
+		nlBeginRow();
+	} break;
+	default: {
+		nl_assert_not_reached;
+	}
+	}
 }
 
 void nlEnd(NLenum prim) {
-    switch(prim) {
-    case NL_SYSTEM: {
-        nlEndSystem();
-    } break;
-    case NL_MATRIX: {
-        nlEndMatrix();
-    } break;
-    case NL_ROW: {
-        nlEndRow();
-    } break;
-    default: {
-        nl_assert_not_reached;
-    }
-    }
+	switch(prim) {
+	case NL_SYSTEM: {
+		nlEndSystem();
+	} break;
+	case NL_MATRIX: {
+		nlEndMatrix();
+	} break;
+	case NL_ROW: {
+		nlEndRow();
+	} break;
+	default: {
+		nl_assert_not_reached;
+	}
+	}
 }
 
 
 /* nlSolve() driver routine */
 
 NLboolean nlSolve() {
-    NLboolean result;
-    NLdouble start_time = nlCurrentTime(); 
-    nlCheckState(NL_STATE_SYSTEM_CONSTRUCTED);
-    nlCurrentContext->elapsed_time = 0.0;
-    nlCurrentContext->flops = 0;    
-    result = nlCurrentContext->solver_func();
-    nlVectorToVariables();
-    nlCurrentContext->elapsed_time = nlCurrentTime() - start_time;
-    nlTransition(NL_STATE_SYSTEM_CONSTRUCTED, NL_STATE_SOLVED);
-    return result;
+	NLboolean result;
+	NLdouble start_time = nlCurrentTime();
+	nlCheckState(NL_STATE_SYSTEM_CONSTRUCTED);
+	nlCurrentContext->elapsed_time = 0.0;
+	nlCurrentContext->flops = 0;
+	result = nlCurrentContext->solver_func();
+	nlVectorToVariables();
+	nlCurrentContext->elapsed_time = nlCurrentTime() - start_time;
+	nlTransition(NL_STATE_SYSTEM_CONSTRUCTED, NL_STATE_SOLVED);
+	return result;
 }
 
 void nlUpdateRightHandSide(NLdouble* values) {
-    /*
-     * If we are in the solved state, get back to the
-     * constructed state.
-     */
-    nl_assert(nlCurrentContext->nb_systems == 1);
-    if(nlCurrentContext->state == NL_STATE_SOLVED) {
-        nlTransition(NL_STATE_SOLVED, NL_STATE_SYSTEM_CONSTRUCTED);
-    }
-    nlCheckState(NL_STATE_SYSTEM_CONSTRUCTED);
-    memcpy(nlCurrentContext->x, values, nlCurrentContext->n * sizeof(double));
+	/*
+	 * If we are in the solved state, get back to the
+	 * constructed state.
+	 */
+	nl_assert(nlCurrentContext->nb_systems == 1);
+	if(nlCurrentContext->state == NL_STATE_SOLVED) {
+		nlTransition(NL_STATE_SOLVED, NL_STATE_SYSTEM_CONSTRUCTED);
+	}
+	nlCheckState(NL_STATE_SYSTEM_CONSTRUCTED);
+	memcpy(nlCurrentContext->x, values, nlCurrentContext->n * sizeof(double));
 }
 
 
 /* Buffers management */
 
 void nlBindBuffer(
-    NLenum buffer, NLuint k, void* addr, NLuint stride
+	NLenum buffer, NLuint k, void* addr, NLuint stride
 ) {
-    nlCheckState(NL_STATE_SYSTEM);    
-    nl_assert(nlIsEnabled(buffer));
-    nl_assert(buffer == NL_VARIABLES_BUFFER);
-    nl_assert(k<nlCurrentContext->nb_systems);
-    if(stride == 0) {
+	nlCheckState(NL_STATE_SYSTEM);
+	nl_assert(nlIsEnabled(buffer));
+	nl_assert(buffer == NL_VARIABLES_BUFFER);
+	nl_assert(k<nlCurrentContext->nb_systems);
+	if(stride == 0) {
 	stride = sizeof(NLdouble);
-    }
-    nlCurrentContext->variable_buffer[k].base_address = addr;
-    nlCurrentContext->variable_buffer[k].stride = stride;
+	}
+	nlCurrentContext->variable_buffer[k].base_address = addr;
+	nlCurrentContext->variable_buffer[k].stride = stride;
 }
 
 
 /* Eigen solver */
 
 void nlMatrixMode(NLenum matrix) {
-    NLuint n = 0;
-    NLuint i;
-    nl_assert(
+	NLuint n = 0;
+	NLuint i;
+	nl_assert(
 	nlCurrentContext->state == NL_STATE_SYSTEM ||
 	nlCurrentContext->state == NL_STATE_MATRIX_CONSTRUCTED
-    );
-    nlCurrentContext->state = NL_STATE_SYSTEM;
-    nlCurrentContext->matrix_mode = matrix;
-    nlCurrentContext->current_row = 0;
-    nlCurrentContext->ij_coefficient_called = NL_FALSE;
-    switch(matrix) {
+	);
+	nlCurrentContext->state = NL_STATE_SYSTEM;
+	nlCurrentContext->matrix_mode = matrix;
+	nlCurrentContext->current_row = 0;
+	nlCurrentContext->ij_coefficient_called = NL_FALSE;
+	switch(matrix) {
 	case NL_STIFFNESS_MATRIX: {
-	    /* Stiffness matrix is already constructed. */
+		/* Stiffness matrix is already constructed. */
 	} break ;
 	case NL_MASS_MATRIX: {
-	    if(nlCurrentContext->B == NULL) {
+		if(nlCurrentContext->B == NULL) {
 		for(i=0; i<nlCurrentContext->nb_variables; ++i) {
-		    if(!nlCurrentContext->variable_is_locked[i]) {
+			if(!nlCurrentContext->variable_is_locked[i]) {
 			++n;
-		    }
+			}
 		}
 		nlCurrentContext->B = (NLMatrix)(NL_NEW(NLSparseMatrix));
 		nlSparseMatrixConstruct(
-		    (NLSparseMatrix*)(nlCurrentContext->B),
-		    n, n, NL_MATRIX_STORE_ROWS
+			(NLSparseMatrix*)(nlCurrentContext->B),
+			n, n, NL_MATRIX_STORE_ROWS
 		);
-	    }
+		}
 	} break ;
 	default:
-	    nl_assert_not_reached;
-    }
+		nl_assert_not_reached;
+	}
 }
 
 
 void nlEigenSolverParameterd(
-    NLenum pname, NLdouble val
+	NLenum pname, NLdouble val
 ) {
-    switch(pname) {
+	switch(pname) {
 	case NL_EIGEN_SHIFT: {
-	    nlCurrentContext->eigen_shift =  val;
+		nlCurrentContext->eigen_shift =  val;
 	} break;
 	case NL_EIGEN_THRESHOLD: {
-	    nlSolverParameterd(pname, val);
+		nlSolverParameterd(pname, val);
 	} break;
 	default:
-	    nl_assert_not_reached;
-    }
+		nl_assert_not_reached;
+	}
 }
 
 void nlEigenSolverParameteri(
-    NLenum pname, NLint val
+	NLenum pname, NLint val
 ) {
-    switch(pname) {
+	switch(pname) {
 	case NL_EIGEN_SOLVER: {
-	    nlCurrentContext->eigen_solver = (NLenum)val;
+		nlCurrentContext->eigen_solver = (NLenum)val;
 	} break;
 	case NL_SYMMETRIC:
-	case NL_NB_VARIABLES:	    
+	case NL_NB_VARIABLES:
 	case NL_NB_EIGENS:
 	case NL_EIGEN_MAX_ITERATIONS: {
-	    nlSolverParameteri(pname, val);
+		nlSolverParameteri(pname, val);
 	} break;
 	default:
-	    nl_assert_not_reached;
-    }
+		nl_assert_not_reached;
+	}
 }
 
 void nlEigenSolve() {
-    if(nlCurrentContext->eigen_value == NULL) {
+	if(nlCurrentContext->eigen_value == NULL) {
 	nlCurrentContext->eigen_value = NL_NEW_ARRAY(
-	    NLdouble,nlCurrentContext->nb_systems
+		NLdouble,nlCurrentContext->nb_systems
 	);
-    }
-    
-    nlMatrixCompress(&nlCurrentContext->M);
-    if(nlCurrentContext->B != NULL) {
+	}
+
+	nlMatrixCompress(&nlCurrentContext->M);
+	if(nlCurrentContext->B != NULL) {
 	nlMatrixCompress(&nlCurrentContext->B);
-    }
-    
-    switch(nlCurrentContext->eigen_solver) {
+	}
+
+	switch(nlCurrentContext->eigen_solver) {
 	case NL_ARPACK_EXT:
-	    nlEigenSolve_ARPACK();
-	    break;
+		nlEigenSolve_ARPACK();
+		break;
 	default:
-	    nl_assert_not_reached;
-    }
+		nl_assert_not_reached;
+	}
 }
 
 double nlGetEigenValue(NLuint i) {
-    nl_debug_assert(i < nlCurrentContext->nb_variables);
-    return nlCurrentContext->eigen_value[i];
+	nl_debug_assert(i < nlCurrentContext->nb_variables);
+	return nlCurrentContext->eigen_value[i];
 }

--- a/thirdparty/OpenNL/OpenNL_psm.h
+++ b/thirdparty/OpenNL/OpenNL_psm.h
@@ -13,7 +13,7 @@
  *  * Neither the name of the ALICE Project-Team nor the names of its
  *  contributors may be used to endorse or promote products derived from this
  *  software without specific prior written permission.
- * 
+ *
  *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -35,9 +35,9 @@
  *     levy@loria.fr
  *
  *     ALICE Project
- *     LORIA, INRIA Lorraine, 
+ *     LORIA, INRIA Lorraine,
  *     Campus Scientifique, BP 239
- *     54506 VANDOEUVRE LES NANCY CEDEX 
+ *     54506 VANDOEUVRE LES NANCY CEDEX
  *     FRANCE
  *
  */
@@ -70,21 +70,21 @@
 #endif
 
 #ifdef WIN32
-    #ifdef NL_SHARED_LIBS
-        #ifdef NL_EXPORTS
-            #define NLAPIENTRY __declspec( dllexport )
-        #else
-            #define NLAPIENTRY __declspec( dllimport )
-        #endif
-    #else
-        #define NLAPIENTRY
-    #endif
+	#ifdef NL_SHARED_LIBS
+		#ifdef NL_EXPORTS
+			#define NLAPIENTRY __declspec( dllexport )
+		#else
+			#define NLAPIENTRY __declspec( dllimport )
+		#endif
+	#else
+		#define NLAPIENTRY
+	#endif
 #else
-    #ifdef NL_SHARED_LIBS
-        #define NLAPIENTRY __attribute__ ((visibility("default")))
-    #else
-        #define NLAPIENTRY
-    #endif
+	#ifdef NL_SHARED_LIBS
+		#define NLAPIENTRY __attribute__ ((visibility("default")))
+	#else
+		#define NLAPIENTRY
+	#endif
 #endif
 
 #ifdef __GNUC__
@@ -111,7 +111,7 @@ extern "C" {
 
 #define NLAPI
 
-/* 
+/*
  * Deactivate warnings about documentation
  * We do that, because CLANG's doxygen parser does not know
  * some doxygen commands that we use (retval, copydoc) and
@@ -120,11 +120,11 @@ extern "C" {
 
 #if defined(__clang__)
 #pragma clang diagnostic ignored "-Wunknown-pragmas"
-#pragma clang diagnostic ignored "-Wdocumentation"        
+#pragma clang diagnostic ignored "-Wdocumentation"
 #pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
 #endif
-    
-    
+
+
 
 typedef unsigned int    NLenum;
 
@@ -138,15 +138,15 @@ typedef signed char     NLbyte;
 
 typedef short           NLshort;
 
-typedef int             NLint; 
+typedef int             NLint;
 
 typedef unsigned char   NLubyte;
 
 typedef unsigned short  NLushort;
 
-typedef unsigned int    NLuint;  
+typedef unsigned int    NLuint;
 
-typedef unsigned long   NLulong; 
+typedef unsigned long   NLulong;
 
 typedef int             NLsizei;
 
@@ -156,7 +156,7 @@ typedef double          NLdouble;
 
 typedef void(*NLfunc)();
 
-typedef void* NLContext; 
+typedef void* NLContext;
 
 #define NL_FALSE   0x0
 #define NL_TRUE    0x1
@@ -188,11 +188,11 @@ typedef void* NLContext;
 
 #define NL_GFLOPS           0x10c
 
-#define NL_NNZ              0x10d    
+#define NL_NNZ              0x10d
 
 
 #define NL_NB_SYSTEMS       0x10e
-    
+
 
 #define NL_SOLVER_DEFAULT        0x000
 
@@ -217,32 +217,32 @@ typedef void* NLContext;
 #define NL_VERBOSE         0x401
 
 
-    NLAPI NLContext NLAPIENTRY nlNewContext(void);
+	NLAPI NLContext NLAPIENTRY nlNewContext(void);
 
-    NLAPI void NLAPIENTRY nlDeleteContext(NLContext context);
+	NLAPI void NLAPIENTRY nlDeleteContext(NLContext context);
 
-    NLAPI void NLAPIENTRY nlMakeCurrent(NLContext context);
+	NLAPI void NLAPIENTRY nlMakeCurrent(NLContext context);
 
-    NLAPI NLContext NLAPIENTRY nlGetCurrent(void);
+	NLAPI NLContext NLAPIENTRY nlGetCurrent(void);
 
-    NLAPI NLboolean NLAPIENTRY nlInitExtension(const char* extension);
+	NLAPI NLboolean NLAPIENTRY nlInitExtension(const char* extension);
 
 
-    NLAPI void NLAPIENTRY nlSolverParameterd(NLenum pname, NLdouble param);
+	NLAPI void NLAPIENTRY nlSolverParameterd(NLenum pname, NLdouble param);
 
-    NLAPI void NLAPIENTRY nlSolverParameteri(NLenum pname, NLint param);
+	NLAPI void NLAPIENTRY nlSolverParameteri(NLenum pname, NLint param);
 
-    NLAPI void NLAPIENTRY nlGetBooleanv(NLenum pname, NLboolean* params);
+	NLAPI void NLAPIENTRY nlGetBooleanv(NLenum pname, NLboolean* params);
 
-    NLAPI void NLAPIENTRY nlGetDoublev(NLenum pname, NLdouble* params);
+	NLAPI void NLAPIENTRY nlGetDoublev(NLenum pname, NLdouble* params);
 
-    NLAPI void NLAPIENTRY nlGetIntegerv(NLenum pname, NLint* params);
+	NLAPI void NLAPIENTRY nlGetIntegerv(NLenum pname, NLint* params);
 
-    NLAPI void NLAPIENTRY nlEnable(NLenum pname);
+	NLAPI void NLAPIENTRY nlEnable(NLenum pname);
 
-    NLAPI void NLAPIENTRY nlDisable(NLenum pname);
+	NLAPI void NLAPIENTRY nlDisable(NLenum pname);
 
-    NLAPI NLboolean nlIsEnabled(NLenum pname);
+	NLAPI NLboolean nlIsEnabled(NLenum pname);
 
 
 #define NL_FUNC_SOLVER         0x600
@@ -253,27 +253,27 @@ typedef void* NLContext;
 
 #define NL_FUNC_PROGRESS       0x603
 
-    NLAPI void NLAPIENTRY nlSetFunction(NLenum pname, NLfunc param);
+	NLAPI void NLAPIENTRY nlSetFunction(NLenum pname, NLfunc param);
 
-    NLAPI void NLAPIENTRY nlGetFunction(NLenum pname, NLfunc* param);
-
-
-    NLAPI void NLAPIENTRY nlSetVariable(NLuint i, NLdouble value);
+	NLAPI void NLAPIENTRY nlGetFunction(NLenum pname, NLfunc* param);
 
 
-    NLAPI void NLAPIENTRY nlMultiSetVariable(
+	NLAPI void NLAPIENTRY nlSetVariable(NLuint i, NLdouble value);
+
+
+	NLAPI void NLAPIENTRY nlMultiSetVariable(
 	NLuint i, NLuint k, NLdouble value
-    );
-    
-    NLAPI NLdouble NLAPIENTRY nlGetVariable(NLuint i);
+	);
 
-    NLAPI NLdouble NLAPIENTRY nlMultiGetVariable(NLuint i, NLuint k);
-    
-    NLAPI void NLAPIENTRY nlLockVariable(NLuint index);
+	NLAPI NLdouble NLAPIENTRY nlGetVariable(NLuint i);
 
-    NLAPI void NLAPIENTRY nlUnlockVariable(NLuint index);
+	NLAPI NLdouble NLAPIENTRY nlMultiGetVariable(NLuint i, NLuint k);
 
-    NLAPI NLboolean NLAPIENTRY nlVariableIsLocked(NLuint index);
+	NLAPI void NLAPIENTRY nlLockVariable(NLuint index);
+
+	NLAPI void NLAPIENTRY nlUnlockVariable(NLuint index);
+
+	NLAPI NLboolean NLAPIENTRY nlVariableIsLocked(NLuint index);
 
 
 #define NL_SYSTEM  0x0
@@ -282,78 +282,78 @@ typedef void* NLContext;
 
 #define NL_ROW     0x2
 
-    NLAPI void NLAPIENTRY nlBegin(NLenum primitive);
+	NLAPI void NLAPIENTRY nlBegin(NLenum primitive);
 
-    NLAPI void NLAPIENTRY nlEnd(NLenum primitive);
+	NLAPI void NLAPIENTRY nlEnd(NLenum primitive);
 
-    NLAPI void NLAPIENTRY nlCoefficient(NLuint i, NLdouble value);
-
-
-
-    NLAPI void NLAPIENTRY nlAddIJCoefficient(
-        NLuint i, NLuint j, NLdouble value
-    );
+	NLAPI void NLAPIENTRY nlCoefficient(NLuint i, NLdouble value);
 
 
-    NLAPI void NLAPIENTRY nlAddIRightHandSide(NLuint i, NLdouble value);
 
-    NLAPI void NLAPIENTRY nlMultiAddIRightHandSide(
+	NLAPI void NLAPIENTRY nlAddIJCoefficient(
+		NLuint i, NLuint j, NLdouble value
+	);
+
+
+	NLAPI void NLAPIENTRY nlAddIRightHandSide(NLuint i, NLdouble value);
+
+	NLAPI void NLAPIENTRY nlMultiAddIRightHandSide(
 	NLuint i, NLuint k, NLdouble value
-    );
-    
-    NLAPI void NLAPIENTRY nlRightHandSide(NLdouble value);
+	);
+
+	NLAPI void NLAPIENTRY nlRightHandSide(NLdouble value);
 
 
-    NLAPI void NLAPIENTRY nlMultiRightHandSide(NLuint k, NLdouble value);
-    
-    NLAPI void NLAPIENTRY nlRowScaling(NLdouble value);
-    
+	NLAPI void NLAPIENTRY nlMultiRightHandSide(NLuint k, NLdouble value);
 
-    NLAPI NLboolean NLAPIENTRY nlSolve(void);
+	NLAPI void NLAPIENTRY nlRowScaling(NLdouble value);
 
 
-    NLAPI void NLAPIENTRY nlUpdateRightHandSide(NLdouble* values);
+	NLAPI NLboolean NLAPIENTRY nlSolve(void);
+
+
+	NLAPI void NLAPIENTRY nlUpdateRightHandSide(NLdouble* values);
 
 
 #define NL_VARIABLES_BUFFER 0x1000
 
-    NLAPI void NLAPIENTRY nlBindBuffer(
+	NLAPI void NLAPIENTRY nlBindBuffer(
 	NLenum buffer, NLuint k, void* addr, NLuint stride
-    );
+	);
 
-    
+
 
 #define NL_STIFFNESS_MATRIX 0x3001
 
 #define NL_MASS_MATRIX 0x3002
 
 NLAPI void NLAPIENTRY nlMatrixMode(NLenum matrix);
-    
+
 #define NL_NB_EIGENS       NL_NB_SYSTEMS
 
 #define NL_EIGEN_MAX_ITERATIONS NL_MAX_ITERATIONS
-    
+
 #define NL_EIGEN_THRESHOLD NL_THRESHOLD
 
 #define NL_EIGEN_SOLVER 0x2000
-    
+
 #define NL_EIGEN_SHIFT 0x2001
 
 #define NL_EIGEN_SHIFT_INVERT 0x2002
-    
-    NLAPI void NLAPIENTRY nlEigenSolverParameterd(
+
+	NLAPI void NLAPIENTRY nlEigenSolverParameterd(
 	NLenum pname, NLdouble val
-    );
+	);
 
-    NLAPI void NLAPIENTRY nlEigenSolverParameteri(
+	NLAPI void NLAPIENTRY nlEigenSolverParameteri(
 	NLenum pname, NLint val
-    );
+	);
 
-    NLAPI void NLAPIENTRY nlEigenSolve(void);
+	NLAPI void NLAPIENTRY nlEigenSolve(void);
 
 
-    NLAPI double NLAPIENTRY nlGetEigenValue(NLuint i);
-    
+	NLAPI double NLAPIENTRY nlGetEigenValue(NLuint i);
+
 
 #ifdef __cplusplus
 }
@@ -371,14 +371,14 @@ NLAPI void NLAPIENTRY nlMatrixMode(NLenum matrix);
 extern "C" {
 #endif
 
-    
+
 #define NL_SUPERLU_EXT           0x210
 #define NL_PERM_SUPERLU_EXT      0x211
 #define NL_SYMMETRIC_SUPERLU_EXT 0x212
 #define NL_SOLVER_USER           0x213
 #define NL_CHOLMOD_EXT           0x214
 #define NL_ARPACK_EXT            0x215
-    
+
 #define NL_CNC_FLOAT_CRS_EXT     0x220
 #define NL_CNC_DOUBLE_CRS_EXT    0x222
 #define NL_CNC_FLOAT_BCRS2_EXT   0x221
@@ -391,6 +391,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-    
+
 #endif
 


### PR DESCRIPTION
Super dangeureux de lire les normales de l'obj !
Les indices de normales sont indépendants de ceux sommets
Ca peut donc faire peut n'importe quoi, et même planter aléatoirement 
quand il y a plus de normale que de sommet (arêtes franches)
